### PR TITLE
Capitalize headings rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [compact-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#compact-yaml)
 - [header-increment](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#header-increment)
 - [consecutive-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#consecutive-blank-lines)
+- [capitalize-headings](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#capitalize-headings)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -238,7 +238,7 @@ Options:
 - titleCase: Format headings with title case capitalization, default=`false`
 - allCaps: Format headings with all capitals, default= `false`
 
-Example: Headings should be surrounded by blank lines
+Example: The first letter of a heading should be capitalized
 
 Before:
 
@@ -260,6 +260,7 @@ Before:
 ```markdown
 # this is a heading 1
 ## this is a heading 2
+### a heading 3
 ```
 
 After:
@@ -267,6 +268,7 @@ After:
 ```markdown
 # This is a Heading 1
 ## This is a Heading 2
+### A Heading 3
 ```
 Example: With `allCaps=true`
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -227,3 +227,59 @@ Some text
 
 Some more text
 ```
+
+## Capitalize Headings
+
+Alias: `capitalize-headings`
+
+Headings should be formatted with capitalization
+
+Options:
+- titleCase: Format headings with title case capitalization, default=`false`
+- allCaps: Format headings with all capitals, default= `false`
+
+Example: Headings should be surrounded by blank lines
+
+Before:
+
+```markdown
+# this is a heading 1
+## this is a heading 2
+```
+
+After:
+
+```markdown
+# This is a heading 1
+## This is a heading 2
+```
+Example: With `titleCase=true`
+
+Before:
+
+```markdown
+# this is a heading 1
+## this is a heading 2
+```
+
+After:
+
+```markdown
+# This is a Heading 1
+## This is a Heading 2
+```
+Example: With `allCaps=true`
+
+Before:
+
+```markdown
+# this is a heading 1
+## this is a heading 2
+```
+
+After:
+
+```markdown
+# THIS IS A HEADING 1
+## THIS IS A HEADING 2
+```

--- a/rules.ts
+++ b/rules.ts
@@ -402,7 +402,6 @@ function ignoreCodeBlocks(text: string, func: (text: string) => string) {
 function initYAML(text: string) {
 	if (text.match(/^---\s*\n.*\n---/s) === null) {
 		text = "---\n---\n" + text;
-		console.log("inserted yaml");
 	}
 	return text;
 }

--- a/rules.ts
+++ b/rules.ts
@@ -282,8 +282,24 @@ export const rules: Rule[] = [
 	new Rule(
 		"Capitalize Headings",
 		"Headings should be formatted with capitalization",
-		(text: string, options = { "titleCase": "false", "allCaps":"false"}) => {
-			return text.replace("", "");
+		(text: string, options = { "titleCase": "false", "allCaps": "false" }) => {
+			
+			const lines = text.split("\n");
+			for (let i = 0; i < lines.length; i++) {
+				const headerRegex = /^#*\s\w.*/;
+				const match = lines[i].match(headerRegex); // match only headings
+				if (!match) {
+					continue;
+				}
+				if (options["titleCase"] == "true") {
+					return match
+				} else if (options["allCaps"] == "true") {
+					lines[i] = lines[i].replace(/^#*\s\w.*/, string => string.toUpperCase()) // convert full heading to uppercase
+				} else {
+					return text
+				}
+			}
+			return lines.join("\n");
 		},
 		[
 			new Example(

--- a/rules.ts
+++ b/rules.ts
@@ -295,7 +295,7 @@ export const rules: Rule[] = [
 					const headerWords = lines[i].match(/\w+/g);
 					const ignore = ["a", "an", "the", "and", "or", "but", "for", "nor", "so", "yet", "at", "by", "in", "of", "on", "to", "up", "as", "is", "if", "it", "for", "to", "with"];
 					for (let j = 0; j < headerWords.length; j++) {
-						if (ignore.includes(headerWords[j])) {
+						if (ignore.includes(headerWords[j]) && j != 0) {
 							continue;
 						}
 						headerWords[j] = headerWords[j].replace(/^\w/, c => c.toUpperCase());
@@ -328,10 +328,12 @@ export const rules: Rule[] = [
 				dedent`
 				# this is a heading 1
 				## this is a heading 2
+				### a heading 3
 				`,
 				dedent`
 				# This is a Heading 1
 				## This is a Heading 2
+				### A Heading 3
 				`,
 				{titleCase: "true"}
 			),

--- a/rules.ts
+++ b/rules.ts
@@ -279,6 +279,53 @@ export const rules: Rule[] = [
 			),
 		]
 	),
+	new Rule(
+		"Capitalize Headings",
+		"Headings should be formatted with capitalization",
+		(text: string, options = { "titleCase": "false", "allCaps":"false"}) => {
+			return text.replace("", "");
+		},
+		[
+			new Example(
+				"Headings should be surrounded by blank lines",
+				dedent`
+				# this is a heading 1
+				## this is a heading 2
+				`,
+				dedent`
+				# This is a heading 1
+				## This is a heading 2
+				`
+			),
+			new Example(
+				"With `titleCase=true`",
+				dedent`
+				# this is a heading 1
+				## this is a heading 2
+				`,
+				dedent`
+				# This is a Heading 1
+				## This is a Heading 2
+				`,
+				{titleCase: "true"}
+			),
+			new Example(
+				"With `allCaps=true`",
+				dedent`
+				# this is a heading 1
+				## this is a heading 2
+				`,
+				dedent`
+				# THIS IS A HEADING 1
+				## THIS IS A HEADING 2
+				`,
+				{allCaps: "true"}
+			),
+		],
+		[
+			"titleCase: Format headings with title case capitalization, default=`false`", "allCaps: Format headings with all capitals, default= `false`"
+		]
+	),
 ]; 
 
 export const rulesDict = rules.reduce((dict, rule) => (dict[rule.alias()] = rule, dict), {} as Record<string, Rule>);

--- a/rules.ts
+++ b/rules.ts
@@ -286,13 +286,23 @@ export const rules: Rule[] = [
 			
 			const lines = text.split("\n");
 			for (let i = 0; i < lines.length; i++) {
-				const headerRegex = /^#*\s\w.*/;
+				const headerRegex = /^(#*\s)\w.*/;
 				const match = lines[i].match(headerRegex); // match only headings
 				if (!match) {
 					continue;
 				}
 				if (options["titleCase"] == "true") {
-					return text
+					const headerWords = lines[i].match(/\w+/g);
+					const ignore = ["a", "an", "the", "and", "or", "but", "for", "nor", "so", "yet", "at", "by", "in", "of", "on", "to", "up", "as", "is", "if", "it", "for", "to", "with"];
+					for (let j = 0; j < headerWords.length; j++) {
+						if (ignore.includes(headerWords[j])) {
+							continue;
+						}
+						headerWords[j] = headerWords[j].replace(/^\w/, c => c.toUpperCase());
+					}
+
+					lines[i] = lines[i].replace(headerRegex, `$1${headerWords.join(" ")}`);
+
 				} else if (options["allCaps"] == "true") {
 					lines[i] = lines[i].replace(/^#*\s\w.*/, string => string.toUpperCase()) // convert full heading to uppercase
 				} else {

--- a/rules.ts
+++ b/rules.ts
@@ -292,11 +292,11 @@ export const rules: Rule[] = [
 					continue;
 				}
 				if (options["titleCase"] == "true") {
-					return match
+					return text
 				} else if (options["allCaps"] == "true") {
 					lines[i] = lines[i].replace(/^#*\s\w.*/, string => string.toUpperCase()) // convert full heading to uppercase
 				} else {
-					return text
+					lines[i] = lines[i].replace(/^#*\s([a-z])/, string => string.toUpperCase()) // capitalize first letter of heading
 				}
 			}
 			return lines.join("\n");

--- a/rules.ts
+++ b/rules.ts
@@ -295,7 +295,7 @@ export const rules: Rule[] = [
 					const headerWords = lines[i].match(/\w+/g);
 					const ignore = ["a", "an", "the", "and", "or", "but", "for", "nor", "so", "yet", "at", "by", "in", "of", "on", "to", "up", "as", "is", "if", "it", "for", "to", "with"];
 					for (let j = 0; j < headerWords.length; j++) {
-						if (ignore.includes(headerWords[j]) && j != 0) {
+						if (ignore.includes(headerWords[j]) && j != 0) { // ignore words that are not capitalized in titles except if they are the first word
 							continue;
 						}
 						headerWords[j] = headerWords[j].replace(/^\w/, c => c.toUpperCase());
@@ -313,7 +313,7 @@ export const rules: Rule[] = [
 		},
 		[
 			new Example(
-				"Headings should be surrounded by blank lines",
+				"The first letter of a heading should be capitalized",
 				dedent`
 				# this is a heading 1
 				## this is a heading 2
@@ -351,7 +351,8 @@ export const rules: Rule[] = [
 			),
 		],
 		[
-			"titleCase: Format headings with title case capitalization, default=`false`", "allCaps: Format headings with all capitals, default= `false`"
+			"titleCase: Format headings with title case capitalization, default=`false`",
+			"allCaps: Format headings with all capitals, default= `false`"
 		]
 	),
 ]; 


### PR DESCRIPTION
Closes #8 

This PR adds the `Capitalize headings` rule with options to format headings where the `First word is capitalized`, in `Proper Title Capitalization`, or in `ALL CAPS`.  