### PR TITLE
Keep cursor and scroll in same place after lint

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -93,19 +93,25 @@ export default class LinterPlugin extends Plugin {
       }
 
       // Replace changed lines
-      const changes = Diff.diffLines(oldText, newText);
-      let lineNum = 0;
+      const changes = Diff.diffChars(oldText, newText);
+      let curText = '';
       changes.forEach((change) => {
+        function endOfDocument(doc: string) {
+          const lines = doc.split('\n');
+          return {line: lines.length - 1, ch: lines[lines.length - 1].length};
+        }
+
         if (change.added) {
-          const pos = {line: lineNum, ch: 0};
-          editor.replaceRange(change.value, pos);
-          lineNum += change.count;
+          editor.replaceRange(change.value, endOfDocument(curText));
+          curText += change.value;
         } else if (change.removed) {
-          const start = {line: lineNum, ch: 0};
-          const end = {line: lineNum + change.count, ch: 0};
+          const start = endOfDocument(curText);
+          let tempText = curText;
+          tempText += change.value;
+          const end = endOfDocument(tempText);
           editor.replaceRange('', start, end);
         } else {
-          lineNum += change.count;
+          curText += change.value;
         }
       });
     }

--- a/main.ts
+++ b/main.ts
@@ -67,8 +67,6 @@ export default class LinterPlugin extends Plugin {
     runLinter(editor: Editor) {
       console.log('running linter');
 
-      const cursor = editor.getCursor();
-      const scroll = editor.getScrollInfo();
       const oldText = editor.getValue();
       let newText = oldText;
       const enabledRules = this.settings.enabledRules.split('\n');
@@ -110,9 +108,6 @@ export default class LinterPlugin extends Plugin {
           lineNum += change.count;
         }
       });
-
-      editor.setCursor(cursor);
-      editor.scrollTo(scroll.left, scroll.top);
     }
 }
 


### PR DESCRIPTION
Switch to char level diffs for minimum changes.
Removed custom logic for maintaining cursor and scroll, its already handled by codemirror. 