### PR TITLE
2 new rules, 2 bugfixes (re-submit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [space-after-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-after-list-markers)
 - [compact-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#compact-yaml)
 - [consecutive-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#consecutive-blank-lines)
+- [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
+- [line-break-at-document-end](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#line-break-at-document-end)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -29,6 +29,23 @@ After:
 tags: one, two, three
 ---
 ```
+Example: Format Tags in YAML frontmatter
+
+Before:
+
+```markdown
+---
+tags: #one, #two, #three
+---
+```
+
+After:
+
+```markdown
+---
+tags: one, two, three
+---
+```
 
 ### YAML Timestamp
 
@@ -518,4 +535,57 @@ After:
 Some text
 
 Some more text
+```
+
+### Convert Spaces to Tabs
+
+Alias: `convert-spaces-to-tabs`
+
+Converts 4 spaces to 1 tab.
+
+Options:
+- Tabsize: Number of Spaces that will be converted to a Tab (default: 4)
+  - Default: `4`
+
+Example: Converting spaces to tabs with `tabsize = 3`
+
+Before:
+
+```markdown
+- text with no indention
+   - text indented with 3 spaces
+- text with no indention
+      - text indented with 6 spaces
+```
+
+After:
+
+```markdown
+- text with no indention
+	- text indented with 3 spaces
+- text with no indention
+		- text indented with 6 spaces
+```
+
+### Line Break at Document End
+
+Alias: `line-break-at-document-end`
+
+Appends a line break at the end of the document, if there is none.
+
+
+
+Example: Appending a line break to the end of the document.
+
+Before:
+
+```markdown
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+```
+
+After:
+
+```markdown
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
 ```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -544,7 +544,7 @@ Alias: `convert-spaces-to-tabs`
 Converts 4 spaces to 1 tab.
 
 Options:
-- Tabsize: Number of Spaces that will be converted to a Tab (default: 4)
+- Tabsize: Number of Spaces that will be converted to a Tab
   - Default: `4`
 
 Example: Converting spaces to tabs with `tabsize = 3`

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import {LinterSettings, Options, rules} from './rules';
 import {getDisabledRules} from './utils';
 import Diff from 'diff';
 import moment from 'moment';
-import {BooleanOption, MomentFormatOption} from './option';
+import {BooleanOption, MomentFormatOption, TextOption} from './option';
 import dedent from 'ts-dedent';
 
 export default class LinterPlugin extends Plugin {
@@ -163,6 +163,20 @@ class SettingTab extends PluginSettingTab {
             .addToggle((toggle) => {
               toggle.setValue(settings.ruleConfigs[this.ruleName][this.name]);
               toggle.onChange((value) => {
+                this.setOption(value, settings);
+                plugin.settings = settings;
+                plugin.saveData(plugin.settings);
+              });
+            });
+      };
+
+      TextOption.prototype.display = function(containerEl: HTMLElement, settings: LinterSettings, plugin: LinterPlugin): void {
+        new Setting(containerEl)
+            .setName(this.name)
+            .setDesc(this.description)
+            .addText((textbox) => {
+              textbox.setValue(settings.ruleConfigs[this.ruleName][this.name]);
+              textbox.onChange((value) => {
                 this.setOption(value, settings);
                 plugin.settings = settings;
                 plugin.saveData(plugin.settings);

--- a/src/option.ts
+++ b/src/option.ts
@@ -39,6 +39,9 @@ export class BooleanOption extends Option {
   public defaultValue: boolean;
 }
 
+export class TextOption extends Option {
+  public defaultValue: string;
+}
 
 export class MomentFormatOption extends Option {
   public defaultValue: boolean;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,7 +1,7 @@
 import dedent from 'ts-dedent';
 import moment from 'moment';
 import {headerRegex, ignoreCodeBlocksAndYAML, initYAML, insert} from './utils';
-import {Option, BooleanOption, MomentFormatOption} from './option';
+import {Option, BooleanOption, MomentFormatOption, TextOption} from './option';
 
 export type Options = { [optionName: string]: any };
 type ApplyFunction = (text: string, options?: Options) => string;
@@ -314,6 +314,69 @@ export const rules: Rule[] = [
       ],
   ),
   new Rule(
+      'Convert Spaces to Tabs',
+      'Converts 4 spaces to 1 tab.',
+      RuleType.SPACING,
+      (text: string, options = {}) => {
+        return ignoreCodeBlocksAndYAML(text, (text) => {
+          const tabsize = String(options['Tabsize']);
+          const tabsize_regex = new RegExp('^(\t*) {' + String(tabsize) + '}', 'gm');
+
+          while (text.match(tabsize_regex) != null) {
+            text = text.replace(tabsize_regex, '$1\t');
+          }
+          return text;
+        });
+      },
+      /* eslint-disable no-mixed-spaces-and-tabs, no-tabs */
+      [
+        new Example(
+            'Converting spaces to tabs with `tabsize = 3`',
+            dedent`
+          - text with no indention
+             - text indented with 3 spaces
+          - text with no indention
+                - text indented with 6 spaces
+      `,
+            dedent`
+          - text with no indention
+          \t- text indented with 3 spaces
+          - text with no indention
+          \t\t- text indented with 6 spaces
+      `,
+            {Tabsize: '3'},
+        ),
+      ],
+      /* eslint-enable no-mixed-spaces-and-tabs, no-tabs */
+      [
+        new TextOption('Tabsize', 'Number of Spaces that will be converted to a Tab', '4'),
+      ],
+  ),
+  new Rule(
+      'Line Break at Document End',
+      'Appends a line break at the end of the document, if there is none.',
+      RuleType.SPACING,
+      (text: string) => {
+        if (text.slice(-1) != '\n') text += '\n';
+        return text;
+      },
+      [
+        new Example(
+            'Appending a line break to the end of the document.',
+            dedent`
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      `,
+            dedent`
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+      `,
+        ),
+      ],
+  ),
+
+  // YAML rules
+
+  new Rule(
       'Format Tags in YAML',
       'Remove Hashtags from tags in the YAML frontmatter, as they make the tags there invalid.',
       RuleType.YAML,
@@ -351,9 +414,6 @@ export const rules: Rule[] = [
         ),
       ],
   ),
-
-  // YAML rules
-
   new Rule(
       'YAML Timestamp',
       'Keep track of the date the file was last edited in the YAML front matter. Gets dates from file metadata.',
@@ -729,64 +789,6 @@ export const rules: Rule[] = [
 
         [^1]: first footnote
         [^2]: second footnote
-        `,
-        ),
-      ],
-  ),
-  new Rule(
-      'Convert Spaces to Tabs',
-      'Converts 4 spaces to 1 tab.',
-      RuleType.SPACING,
-      (text: string, options = {}) => {
-        const tabsize = String(options['tabsize']);
-        const tabsize_regex = new RegExp('^(\t*) {' + String(tabsize) + '}', 'gm');
-
-        while (text.match(tabsize_regex) != null) {
-          text = text.replace(tabsize_regex, '$1\t');
-        }
-        return text;
-      },
-      /* eslint-disable no-mixed-spaces-and-tabs, no-tabs */
-      [
-        new Example(
-            'Converting spaces to tabs with `tabsize = 3`',
-            dedent`
-            - text with no indention
-               - text indented with 3 spaces
-            - text with no indention
-                  - text indented with 6 spaces
-        `,
-            dedent`
-            - text with no indention
-            	- text indented with 3 spaces
-            - text with no indention
-            		- text indented with 6 spaces
-        `,
-            /* eslint-enable no-mixed-spaces-and-tabs, no-tabs */
-            {tabsize: '3'},
-        ),
-      ],
-      [
-        new Option('Tabsize', 'Number of Spaces that will be converted to a Tab (default: 4)', '4'),
-      ],
-  ),
-  new Rule(
-      'Line Break at Document End',
-      'Appends a line break at the end of the document, if there is none.',
-      RuleType.SPACING,
-      (text: string) => {
-        if (text.slice(-1) != '\n') text += '\n';
-        return text;
-      },
-      [
-        new Example(
-            'Appending a line break to the end of the document.',
-            dedent`
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        `,
-            dedent`
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-
         `,
         ),
       ],

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -318,7 +318,7 @@ export const rules: Rule[] = [
       'Remove Hashtags from tags in the YAML frontmatter, as they make the tags there invalid.',
       RuleType.YAML,
       (text: string) => {
-        return text.replace(/^tags: ((?:#\w+(?: |$))+)$/im, function(tagsYAML) {
+        return text.replace(/^tags: (?:#\w+(?:,? |$))+/im, function(tagsYAML) {
           return tagsYAML.replaceAll('#', '').replaceAll(' ', ', ').replaceAll(',,', ',').replace('tags:,', 'tags:');
         });
       },
@@ -328,6 +328,19 @@ export const rules: Rule[] = [
             dedent`
          ---
          tags: #one #two #three
+         ---
+        `,
+            dedent`
+         ---
+         tags: one, two, three
+         ---
+        `,
+        ),
+        new Example(
+            'Format Tags in YAML frontmatter',
+            dedent`
+         ---
+         tags: #one, #two, #three
          ---
         `,
             dedent`
@@ -525,18 +538,21 @@ export const rules: Rule[] = [
               const headerWords = lines[i].match(/\S+/g);
               const ignoreNames = ['macOS', 'iOS', 'iPhone', 'iPad', 'JavaScript', 'TypeScript', 'AppleScript'];
               const ignoreAbbreviations = ['CSS', 'HTML', 'YAML', 'PDF', 'USA', 'EU', 'NATO', 'ASCII'];
+              const keepCasing = [...ignoreNames, ...ignoreAbbreviations];
               const ignoreShortWords = ['via', 'a', 'an', 'the', 'and', 'or', 'but', 'for', 'nor', 'so', 'yet', 'at', 'by', 'in', 'of', 'on', 'to', 'up', 'as', 'is', 'if', 'it', 'for', 'to', 'with', 'without', 'into', 'onto', 'per'];
-              const ignore = [...ignoreAbbreviations, ...ignoreShortWords, ...ignoreNames];
               for (let j = 1; j < headerWords.length; j++) {
                 const isWord = headerWords[j].match(/^[A-Za-z'-]+[\.\?!,:;]?$/);
                 if (!isWord) {
                   continue;
                 }
 
-                headerWords[j] = headerWords[j].toLowerCase();
-                const ignoreWord = ignore.includes(headerWords[j]);
-                if (!ignoreWord || j == 1) { // ignore words that are not capitalized in titles except if they are the first word
-                  headerWords[j] = headerWords[j][0].toUpperCase() + headerWords[j].slice(1);
+                const keepWordcasing = keepCasing.includes(headerWords[j]);
+                if (!keepWordcasing) {
+                  headerWords[j] = headerWords[j].toLowerCase();
+                  const ignoreWord = ignoreShortWords.includes(headerWords[j]);
+                  if (!ignoreWord || j == 1) { // ignore words that are not capitalized in titles except if they are the first word
+                    headerWords[j] = headerWords[j][0].toUpperCase() + headerWords[j].slice(1);
+                  }
                 }
               }
 
@@ -713,6 +729,64 @@ export const rules: Rule[] = [
 
         [^1]: first footnote
         [^2]: second footnote
+        `,
+        ),
+      ],
+  ),
+  new Rule(
+      'Convert Spaces to Tabs',
+      'Converts 4 spaces to 1 tab.',
+      RuleType.SPACING,
+      (text: string, options = {}) => {
+        const tabsize = String(options['tabsize']);
+        const tabsize_regex = new RegExp('^(\t*) {' + String(tabsize) + '}', 'gm');
+
+        while (text.match(tabsize_regex) != null) {
+          text = text.replace(tabsize_regex, '$1\t');
+        }
+        return text;
+      },
+      /* eslint-disable no-mixed-spaces-and-tabs, no-tabs */
+      [
+        new Example(
+            'Converting spaces to tabs with `tabsize = 3`',
+            dedent`
+            - text with no indention
+               - text indented with 3 spaces
+            - text with no indention
+                  - text indented with 6 spaces
+        `,
+            dedent`
+            - text with no indention
+            	- text indented with 3 spaces
+            - text with no indention
+            		- text indented with 6 spaces
+        `,
+            /* eslint-enable no-mixed-spaces-and-tabs, no-tabs */
+            {tabsize: '3'},
+        ),
+      ],
+      [
+        new Option('Tabsize', 'Number of Spaces that will be converted to a Tab (default: 4)', '4'),
+      ],
+  ),
+  new Rule(
+      'Line Break at Document End',
+      'Appends a line break at the end of the document, if there is none.',
+      RuleType.SPACING,
+      (text: string) => {
+        if (text.slice(-1) != '\n') text += '\n';
+        return text;
+      },
+      [
+        new Example(
+            'Appending a line break to the end of the document.',
+            dedent`
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        `,
+            dedent`
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
         `,
         ),
       ],

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -315,7 +315,7 @@ export const rules: Rule[] = [
   ),
   new Rule(
       'Convert Spaces to Tabs',
-      'Converts 4 spaces to 1 tab.',
+      'Converts leading spaces to tabs.',
       RuleType.SPACING,
       (text: string, options = {}) => {
         return ignoreCodeBlocksAndYAML(text, (text) => {
@@ -349,7 +349,7 @@ export const rules: Rule[] = [
       ],
       /* eslint-enable no-mixed-spaces-and-tabs, no-tabs */
       [
-        new TextOption('Tabsize', 'Number of Spaces that will be converted to a Tab', '4'),
+        new TextOption('Tabsize', 'Number of spaces that will be converted to a tab', '4'),
       ],
   ),
   new Rule(


### PR DESCRIPTION
okay, next try. Like the last time:
- new rule for converting spaces to tabs (#36)
- new rule for ensuring there is a line break at the end of the document
- bugfix for titlecasing
- bugfix for YAML header tags with commata