### PR TITLE
New Rule: Remove Multiple Spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [consecutive-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#consecutive-blank-lines)
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
 - [line-break-at-document-end](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#line-break-at-document-end)
+- [remove-multiple-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-spaces)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -636,7 +636,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
 Alias: `remove-multiple-spaces`
 
-Removes or multiple consecutive spaces. Ignores Spaces at the beginning and ending of the line. 
+Removes two or more consecutive spaces. Ignores spaces at the beginning and ending of the line. 
 
 
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -631,3 +631,25 @@ After:
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
 ```
+
+### Remove Multiple Spaces
+
+Alias: `remove-multiple-spaces`
+
+Removes or multiple consecutive spaces. Ignores Spaces at the beginning and ending of the line. 
+
+
+
+Example: Removing double and triple space.
+
+Before:
+
+```markdown
+Lorem ipsum   dolor  sit amet.
+```
+
+After:
+
+```markdown
+Lorem ipsum dolor sit amet.
+```

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -400,7 +400,7 @@ export const rules: Rule[] = [
   ),
   new Rule(
       'Remove Multiple Spaces',
-      'Removes or multiple consecutive spaces. Ignores Spaces at the beginning and ending of the line. ',
+      'Removes two or more consecutive spaces. Ignores spaces at the beginning and ending of the line. ',
       RuleType.SPACING,
       (text: string) => {
         return ignoreCodeBlocksAndYAML(text, (text) => {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -397,6 +397,27 @@ export const rules: Rule[] = [
         ),
       ],
   ),
+  new Rule(
+      'Remove Multiple Spaces',
+      'Removes or multiple consecutive spaces. Ignores Spaces at the beginning and ending of the line. ',
+      RuleType.SPACING,
+      (text: string) => {
+        return ignoreCodeBlocksAndYAML(text, (text) => {
+          return text.replace(/\b {2,}\b/g, ' ');
+        });
+      },
+      [
+        new Example(
+            'Removing double and triple space.',
+            dedent`
+          Lorem ipsum   dolor  sit amet.
+      `,
+            dedent`
+          Lorem ipsum dolor sit amet.
+      `,
+        ),
+      ],
+  ),
 
   // YAML rules
 


### PR DESCRIPTION
- only effects spaces between words
- spaces next to `-` (ul) are ignored (are covered by `space-after-list-markers`)
- spaces at the end are ignored (covered by `trailing-spaces`)
- spaces at the beginning (indention) are ignored as well
- see https://regex101.com/r/6heqdq/1