### PR TITLE
New Rule: Remove Consecutive List markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [footnote-after-punctuation](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#footnote-after-punctuation)
 - [remove-multiple-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-spaces)
 - [remove-hyphenated-line-breaks](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-hyphenated-line-breaks)
+- [remove-consecutive-list-markers.](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-consecutive-list-markers.)
 - [trailing-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#trailing-spaces)
 - [heading-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#heading-blank-lines)
 - [paragraph-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#paragraph-blank-lines)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [footnote-after-punctuation](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#footnote-after-punctuation)
 - [remove-multiple-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-spaces)
 - [remove-hyphenated-line-breaks](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-hyphenated-line-breaks)
-- [remove-consecutive-list-markers.](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-consecutive-list-markers.)
+- [remove-consecutive-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-consecutive-list-markers)
 - [trailing-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#trailing-spaces)
 - [heading-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#heading-blank-lines)
 - [paragraph-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#paragraph-blank-lines)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -495,9 +495,9 @@ After:
 This text has a linebreak.
 ```
 
-### Remove Consecutive List Markers.
+### Remove Consecutive List Markers
 
-Alias: `remove-consecutive-list-markers.`
+Alias: `remove-consecutive-list-markers`
 
 Removes consecutive list markers. Useful when copy-pasting list items.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -495,6 +495,36 @@ After:
 This text has a linebreak.
 ```
 
+### Remove Consecutive List Markers.
+
+Alias: `remove-consecutive-list-markers.`
+
+Removes consecutive list markers. Useful when copy-pasting list items.
+
+
+
+Example: Removing consecutive list markers.
+
+Before:
+
+```markdown
+- item 1
+- - copypasted item A
+- item 2
+  - indented item
+  - - copypasted item B
+```
+
+After:
+
+```markdown
+- item 1
+- copypasted item A
+- item 2
+  - indented item
+  - copypasted item B
+```
+
 ## Spacing
 ### Trailing spaces
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -484,6 +484,35 @@ export const rules: Rule[] = [
         ),
       ],
   ),
+  new Rule(
+      'Remove Consecutive List Markers.',
+      'Removes consecutive list markers. Useful when copy-pasting list items.',
+      RuleType.CONTENT,
+      (text: string) => {
+        return ignoreCodeBlocksAndYAML(text, (text) => {
+          return text.replace(/^([ |\t]*)- - \b/gm, '$1- ');
+        });
+      },
+      [
+        new Example(
+            'Removing consecutive list markers.',
+            dedent`
+            - item 1
+            - - copypasted item A
+            - item 2
+              - indented item
+              - - copypasted item B
+            `,
+            dedent`
+            - item 1
+            - copypasted item A
+            - item 2
+              - indented item
+              - copypasted item B
+            `,
+        ),
+      ],
+  ),
 
 
   // YAML rules

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -485,7 +485,7 @@ export const rules: Rule[] = [
       ],
   ),
   new Rule(
-      'Remove Consecutive List Markers.',
+      'Remove Consecutive List Markers',
       'Removes consecutive list markers. Useful when copy-pasting list items.',
       RuleType.CONTENT,
       (text: string) => {


### PR DESCRIPTION
Simple rule that removes consecutive list markers that can occur when copypasting list items, e.g. through moving them inside a document.