### PR TITLE
make `trailing-spaces` ignore YAML to avoid conflict with `insert-yaml-attributes`

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -156,14 +156,16 @@ export const rules: Rule[] = [
       'Removes extra spaces after every line.',
       RuleType.SPACING,
       (text: string, options = {}) => {
-        if (options['Two Space Linebreak'] === false) {
-          return text.replace(/[ \t]+$/gm, '');
-        } else {
-          text = text.replace(/(\S)[ \t]$/gm, '$1'); // one whitespace
-          text = text.replace(/(\S)[ \t]{3,}$/gm, '$1'); // three or more whitespaces
-          text = text.replace(/(\S)( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
-          return text;
-        }
+        return ignoreCodeBlocksAndYAML(text, (text) => {
+          if (options['Two Space Linebreak'] === false) {
+            return text.replace(/[ \t]+$/gm, '');
+          } else {
+            text = text.replace(/(\S)[ \t]$/gm, '$1'); // one whitespace
+            text = text.replace(/(\S)[ \t]{3,}$/gm, '$1'); // three or more whitespaces
+            text = text.replace(/(\S)( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
+            return text;
+          }
+        });
       },
       [
         new Example(


### PR DESCRIPTION
Right now, the attributes added by `insert-yaml-attributes` are missing trailing spaces, even when they they are set in the settings. so when I have `tags: ` there, then after linting, I only get `tags:` in my document. I assume this is due to the `trailing-spaces` rule not ignoring yaml. 

Having that trailing whitespace there is actually useful, since you need a space after the `:` in yaml to have valid yaml, having the space there saves the time of manually typing it every time.