### PR TITLE
Format tags in yaml just removes #s

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -27,16 +27,16 @@ After:
 
 ```markdown
 ---
-tags: one, two, three, nested/four/five
+tags: one two three nested/four/five
 ---
 ```
-Example: Format Tags in YAML frontmatter
+Example: Format tags in array
 
 Before:
 
 ```markdown
 ---
-tags: #one, #two, #three
+tags: [#one #two #three]
 ---
 ```
 
@@ -44,7 +44,28 @@ After:
 
 ```markdown
 ---
-tags: one, two, three
+tags: [one two three]
+---
+```
+Example: Format tags in list
+
+Before:
+
+```markdown
+---
+tags:
+- #tag1
+- #tag2
+---
+```
+
+After:
+
+```markdown
+---
+tags:
+- tag1
+- tag2
 ---
 ```
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -897,7 +897,8 @@ export const rules: Rule[] = [
                 lines[i] = lines[i].toUpperCase(); // convert full heading to uppercase
                 break;
               case 'First Letter':
-                lines[i] = lines[i].replace(/^#*\s([a-z])/, (string) => string.toUpperCase()); // capitalize first letter of heading
+                lines[i] = lines[i].toLowerCase()
+                    .replace(/^#*\s([a-z])/, (string) => string.toUpperCase()); // capitalize first letter of heading
                 break;
             }
           }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -558,8 +558,8 @@ export const rules: Rule[] = [
       RuleType.YAML,
       (text: string) => {
         return formatYAML(text, (text) => {
-          return text.replace(/\ntags: [\w\u2E80-\u9FFF#/ ,-]+(?=.*\n---)/is, function(tagsYAML) {
-            return tagsYAML.replaceAll('#', '').replaceAll(' ', ', ').replaceAll(',,', ',').replace('tags:,', 'tags:');
+          return text.replace(/\ntags:(.*?)(?=\n(?:---|\w+:))/s, function(tagsYAML) {
+            return tagsYAML.replaceAll('#', '');
           });
         });
       },
@@ -573,21 +573,38 @@ export const rules: Rule[] = [
         `,
             dedent`
          ---
-         tags: one, two, three, nested/four/five
+         tags: one two three nested/four/five
          ---
         `,
         ),
         new Example(
-            'Format Tags in YAML frontmatter',
+            'Format tags in array',
             dedent`
          ---
-         tags: #one, #two, #three
+         tags: [#one #two #three]
          ---
         `,
             dedent`
          ---
-         tags: one, two, three
+         tags: [one two three]
          ---
+        `,
+        ),
+        new Example(
+            'Format tags in list',
+            dedent`
+          ---
+          tags:
+          - #tag1
+          - #tag2
+          ---
+        `,
+            dedent`
+          ---
+          tags:
+          - tag1
+          - tag2
+          ---
         `,
         ),
       ],

--- a/src/test.ts
+++ b/src/test.ts
@@ -188,6 +188,24 @@ describe('Rules tests', () => {
         `;
       expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'Title Case'})).toBe(after);
     });
+    it('Can capitalize only first letter', () => {
+      const before = dedent`
+        # this Is A Heading
+        `;
+      const after = dedent`
+        # This is a heading
+        `;
+      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First Letter'})).toBe(after);
+    });
+    it('Can capitalize to all caps', () => {
+      const before = dedent`
+        # this Is A Heading
+        `;
+      const after = dedent`
+        # THIS IS A HEADING
+        `;
+      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'All Caps'})).toBe(after);
+    });
   });
   describe('File Name Heading', () => {
     it('Handles stray dashes', () => {


### PR DESCRIPTION
Fixes #63.
It just removes the #'s after `tags: ` until the next attribute or end of yaml.