### PR TITLE
new rule `remove-empty-list-markers` & minor fix for `format-tags-in-yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [remove-multiple-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-spaces)
 - [remove-hyphenated-line-breaks](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-hyphenated-line-breaks)
 - [remove-consecutive-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-consecutive-list-markers)
+- [remove-empty-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-empty-list-markers)
 - [proper-ellipsis](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#proper-ellipsis)
 
 ### Spacing rules

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -549,6 +549,31 @@ After:
   - copypasted item B
 ```
 
+### Remove Empty List Markers
+
+Alias: `remove-empty-list-markers`
+
+Removes empty list markers, i.e. list items without content.
+
+
+
+Example: Removes empty list markers.
+
+Before:
+
+```markdown
+- item 1
+-
+- item 2
+```
+
+After:
+
+```markdown
+- item 1
+- item 2
+```
+
 ### Proper Ellipsis
 
 Alias: `proper-ellipsis`

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -529,6 +529,30 @@ export const rules: Rule[] = [
       ],
   ),
   new Rule(
+      'Remove Empty List Markers',
+      'Removes empty list markers, i.e. list items without content.',
+      RuleType.CONTENT,
+      (text: string) => {
+        return ignoreCodeBlocksAndYAML(text, (text) => {
+          return text.replace(/^\s*-\s*\n/gm, '');
+        });
+      },
+      [
+        new Example(
+            'Removes empty list markers.',
+            dedent`
+            - item 1
+            -
+            - item 2
+            `,
+            dedent`
+            - item 1
+            - item 2
+            `,
+        ),
+      ],
+  ),
+  new Rule(
       'Proper Ellipsis',
       'Replaces three consecutive dots with an ellipsis.',
       RuleType.CONTENT,
@@ -558,7 +582,7 @@ export const rules: Rule[] = [
       RuleType.YAML,
       (text: string) => {
         return formatYAML(text, (text) => {
-          return text.replace(/\ntags:(.*?)(?=\n(?:[A-Za-z\-]+?:|---))/s, function(tagsYAML) {
+          return text.replace(/\ntags:(.*?)(?=\n(?:[A-Za-z-]+?:|---))/s, function(tagsYAML) {
             return tagsYAML.replaceAll('#', '');
           });
         });

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -558,7 +558,7 @@ export const rules: Rule[] = [
       RuleType.YAML,
       (text: string) => {
         return formatYAML(text, (text) => {
-          return text.replace(/\ntags:(.*?)(?=\n(?:---|\w+:))/s, function(tagsYAML) {
+          return text.replace(/\ntags:(.*?)(?=\n(?:[A-Za-z\-]+?:|---))/s, function(tagsYAML) {
             return tagsYAML.replaceAll('#', '');
           });
         });


### PR DESCRIPTION
`remove-empty-list-markers` will simply remove bullet points you have left empty.

---

The minor fix for `format-tags-in-yaml` is related to the fact, that yaml-keys with `-` were not matched with the current regex using `\w+`. This is most notable when using the breadcrumbs plugin, where you have a a yaml line like `BC-tag-note: '#coding'` where you explicitly *need* the `#`. By changing `\w+` to `[A-Za-z-]+`, I fixed that. You can see the difference here:
- with `\w+`: https://regex101.com/r/reyLZq/1
- with `[A-Za-z-]+`: https://regex101.com/r/0L4vd5/2