### PR TITLE
Add an option to add space between Chinese and English

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ To lint the all files, run `Lint all files in the vault`.
 
 When `Lint on save` is toggled on, the plugin will lint the current file on manual save (when you press `Ctrl+S`).
 
-
-![Demo](images/demo.gif)
-
 ### Disable rules
 
 ```markdown
@@ -70,6 +67,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [consecutive-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#consecutive-blank-lines)
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
 - [line-break-at-document-end](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#line-break-at-document-end)
+- [space-between-chinese-and-english-or-numbers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-between-chinese-and-english-or-numbers)
 
 
 ## Development Instructions

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -927,3 +927,51 @@ After:
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
 ```
+
+### Space between Chinese and English or numbers
+
+Alias: `space-between-chinese-and-english-or-numbers`
+
+Ensures that Chinese and English or numbers are separated by a single space. Follow this [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)
+
+
+
+Example: Space between Chinese and English
+
+Before:
+
+```markdown
+中文字符串english中文字符串。
+```
+
+After:
+
+```markdown
+中文字符串 english 中文字符串。
+```
+Example: Space between Chinese and link
+
+Before:
+
+```markdown
+中文字符串[english](http://example.com)中文字符串。
+```
+
+After:
+
+```markdown
+中文字符串 [english](http://example.com) 中文字符串。
+```
+Example: Space between Chinese and inline code block
+
+Before:
+
+```markdown
+中文字符串`code`中文字符串。
+```
+
+After:
+
+```markdown
+中文字符串 `code` 中文字符串。
+```

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "remark": "^14.0.1",
     "remark-gfm": "^3.0.0",
     "ts-dedent": "^2.2.0",
-    "unified-lint-rule": "^2.1.0"
+    "unified-lint-rule": "^2.1.0",
+    "unist-util-visit": "^4.1.0"
   }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1221,8 +1221,8 @@ export const rules: Rule[] = [
       RuleType.SPACING,
       (text: string) => {
         return ignoreCodeBlocksAndYAML(text, (text) => {
-          return text.replace(/(\[[^[]*\]\(.*\)|\w+|°|%|`.*`)( *)([\u4e00-\u9fa5])/gm, '$1 $3')
-              .replace(/([\u4e00-\u9fa5])( *)(\[[^[]*\]\(.*\)|\w+|`.*`)/gm, '$1 $3');
+          return text.replace(/(\[[^[]*\]\(.*\)|\w+|°|%|`[^`]*`)( *)([\u4e00-\u9fa5])/gm, '$1 $3')
+              .replace(/([\u4e00-\u9fa5])( *)(\[[^[]*\]\(.*\)|\w+|`[^`]*`)/gm, '$1 $3');
         });
       },
       [

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1221,8 +1221,8 @@ export const rules: Rule[] = [
       RuleType.SPACING,
       (text: string) => {
         return ignoreCodeBlocksAndYAML(text, (text) => {
-          return text.replace(/([\w]+)([\s]*)([\u4e00-\u9fa5])/gm, '$1 $3')
-              .replace(/([\u4e00-\u9fa5])([\s]*)([\w]+)/gm, '$1 $3');
+          return text.replace(/(\w+)( *)([\u4e00-\u9fa5])/gm, '$1 $3')
+              .replace(/([\u4e00-\u9fa5])( *)(\w+)/gm, '$1 $3');
         });
       },
       [

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1221,8 +1221,9 @@ export const rules: Rule[] = [
       RuleType.SPACING,
       (text: string) => {
         return ignoreCodeBlocksAndYAML(text, (text) => {
-          return text.replace(/(\[[^[]*\]\(.*\)|\w+|°|%|`[^`]*`)( *)([\u4e00-\u9fa5])/gm, '$1 $3')
-              .replace(/([\u4e00-\u9fa5])( *)(\[[^[]*\]\(.*\)|\w+|`[^`]*`)/gm, '$1 $3');
+          const head = /([\u4e00-\u9fa5])( *)(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+'"([{¥$]|\*[^*])/gm;
+          const tail = /(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+;:'"°%)\]}]|[^*]\*)( *)([\u4e00-\u9fa5])/gm;
+          return text.replace(head, '$1 $3').replace(tail, '$1 $3');
         });
       },
       [

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1215,6 +1215,28 @@ export const rules: Rule[] = [
         ),
       ],
   ),
+  new Rule(
+      'Space between Chinese and English or numbers',
+      'Ensures that Chinese and English or numbers are separated by a single space. Follow this [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)',
+      RuleType.SPACING,
+      (text: string) => {
+        return ignoreCodeBlocksAndYAML(text, (text) => {
+          return text.replace(/([\w]+)([\s]*)([\u4e00-\u9fa5])/gm, '$1 $3')
+              .replace(/([\u4e00-\u9fa5])([\s]*)([\w]+)/gm, '$1 $3');
+        });
+      },
+      [
+        new Example(
+            'Space between Chinese and English',
+            dedent`
+        中文字符串english中文字符串。
+        `,
+            dedent`
+        中文字符串 english 中文字符串。
+        `,
+        ),
+      ],
+  ),
 ].sort((a, b) => RuleTypeOrder.indexOf(a.type) - RuleTypeOrder.indexOf(b.type));
 
 export const rulesDict = rules.reduce((dict, rule) => (dict[rule.alias()] = rule, dict), {} as Record<string, Rule>);

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1221,8 +1221,8 @@ export const rules: Rule[] = [
       RuleType.SPACING,
       (text: string) => {
         return ignoreCodeBlocksAndYAML(text, (text) => {
-          return text.replace(/(\w+)( *)([\u4e00-\u9fa5])/gm, '$1 $3')
-              .replace(/([\u4e00-\u9fa5])( *)(\w+)/gm, '$1 $3');
+          return text.replace(/(\[[^[]*\]\(.*\)|\w+|°|%|`.*`)( *)([\u4e00-\u9fa5])/gm, '$1 $3')
+              .replace(/([\u4e00-\u9fa5])( *)(\[[^[]*\]\(.*\)|\w+|`.*`)/gm, '$1 $3');
         });
       },
       [
@@ -1233,6 +1233,24 @@ export const rules: Rule[] = [
         `,
             dedent`
         中文字符串 english 中文字符串。
+        `,
+        ),
+        new Example(
+            'Space between Chinese and link',
+            dedent`
+        中文字符串[english](http://example.com)中文字符串。
+        `,
+            dedent`
+        中文字符串 [english](http://example.com) 中文字符串。
+        `,
+        ),
+        new Example(
+            'Space between Chinese and inline code block',
+            dedent`
+        中文字符串\`code\`中文字符串。
+        `,
+            dedent`
+        中文字符串 \`code\` 中文字符串。
         `,
         ),
       ],


### PR DESCRIPTION
The behavior is following [the spacing section of guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.en.md#spacing).

## Some Examples 
"零分sjkldfsdj赛姐" to "零分 sjkldfsdj 赛姐".

"赛琳方式[docs](https://getanalytics.io/)囧带领防晒临登机" to "赛琳方式 [docs](https://getanalytics.io/) 囧带领防晒临登机".

"疯狂懂`jskldjflk`将带领" to "疯狂懂 `jskldjflk` 将带领".
