### PR TITLE
Fix Issue with First Letter Capitalization and Header

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -458,3 +458,35 @@ class LintConfirmationModal extends Modal {
     });
   }
 }
+
+class LintFolderConfirmationModal extends Modal {
+  constructor(app: App, plugin: LinterPlugin, folder: TFolder) {
+    super(app);
+    this.modalEl.addClass('confirm-modal');
+
+    this.contentEl.createEl('h3', {text: 'Warning'});
+    const folderName = folder.name;
+
+    const e: HTMLParagraphElement = this.contentEl.createEl('p',
+        {text: 'This will edit all of your files in ' + folderName + ' including files in its subfolders which may introduce errors. Make sure you have backed up your files.'});
+    e.id = 'confirm-dialog';
+
+    this.contentEl.createDiv('modal-button-container', (buttonsEl) => {
+      buttonsEl.createEl('button', {text: 'Cancel'}).addEventListener('click', () => this.close());
+
+      const btnSumbit = buttonsEl.createEl('button', {
+        attr: {type: 'submit'},
+        cls: 'mod-cta',
+        text: 'Lint All Files in ' + folderName,
+      });
+      btnSumbit.addEventListener('click', async (e) => {
+        new Notice('Linting all files in ' + folderName + '...');
+        this.close();
+        await plugin.runLinterAllFileInFolder(folder);
+      });
+      setTimeout(() => {
+        btnSumbit.focus();
+      }, 50);
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,15 @@ export default class LinterPlugin extends Plugin {
         },
       });
 
+      this.addCommand({
+        id: 'lint-all-files-in-folder',
+        name: 'Lint all files in the current folder',
+        editorCallback: (editor) => {
+          const file = this.app.workspace.getActiveFile();
+          new LintFolderConfirmationModal(this.app, this, file.parent).open();
+        },
+      });
+
       // https://github.com/mgmeyers/obsidian-kanban/blob/main/src/main.ts#L239-L251
       this.registerEvent(
           this.app.workspace.on('file-menu', (menu, file: TFile) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,15 +45,6 @@ export default class LinterPlugin extends Plugin {
         },
       });
 
-      this.addCommand({
-        id: 'lint-all-files-in-folder',
-        name: 'Lint all files in the current folder',
-        editorCallback: (editor) => {
-          const file = this.app.workspace.getActiveFile();
-          new LintFolderConfirmationModal(this.app, this, file.parent).open();
-        },
-      });
-
       // https://github.com/mgmeyers/obsidian-kanban/blob/main/src/main.ts#L239-L251
       this.registerEvent(
           this.app.workspace.on('file-menu', (menu, file: TFile) => {
@@ -460,38 +451,6 @@ class LintConfirmationModal extends Modal {
         new Notice(submitBtnNoticeText);
         this.close();
         await btnSubmitAction();
-      });
-      setTimeout(() => {
-        btnSumbit.focus();
-      }, 50);
-    });
-  }
-}
-
-class LintFolderConfirmationModal extends Modal {
-  constructor(app: App, plugin: LinterPlugin, folder: TFolder) {
-    super(app);
-    this.modalEl.addClass('confirm-modal');
-
-    this.contentEl.createEl('h3', {text: 'Warning'});
-    const folderName = folder.name;
-
-    const e: HTMLParagraphElement = this.contentEl.createEl('p',
-        {text: 'This will edit all of your files in ' + folderName + ' including files in its subfolders which may introduce errors. Make sure you have backed up your files.'});
-    e.id = 'confirm-dialog';
-
-    this.contentEl.createDiv('modal-button-container', (buttonsEl) => {
-      buttonsEl.createEl('button', {text: 'Cancel'}).addEventListener('click', () => this.close());
-
-      const btnSumbit = buttonsEl.createEl('button', {
-        attr: {type: 'submit'},
-        cls: 'mod-cta',
-        text: 'Lint All Files in ' + folderName,
-      });
-      btnSumbit.addEventListener('click', async (e) => {
-        new Notice('Linting all files in ' + folderName + '...');
-        this.close();
-        await plugin.runLinterAllFileInFolder(folder);
       });
       setTimeout(() => {
         btnSumbit.focus();

--- a/src/test.ts
+++ b/src/test.ts
@@ -721,4 +721,19 @@ describe('Links', () => {
 
     expect(rulesDict['trailing-spaces'].apply(before)).toBe(after);
   });
+  it('Link in heading is still present with first letter capitalization rules on', () => {
+    const before = dedent`
+    # Heading [[docker]]
+    # Heading [docker](docker)
+    # Heading ![docker](docker)
+    `;
+
+    const after = dedent`
+    # Heading [[docker]]
+    # Heading [docker](docker)
+    # Heading ![docker](docker)
+    `;
+
+    expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First Letter'})).toBe(after);
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,7 +123,9 @@ export function ignoreCodeBlocksYAMLAndLinks(text: string, func: (text: string) 
 
   if (linkMatches) {
     for (const link of linkMatches) {
-      text = text.replace(linkPlaceHolder, link);
+      // Regex was added to fix capitalization issue  where another rule made the text not match the original place holder's case
+      // see https://github.com/platers/obsidian-linter/issues/201
+      text = text.replace(new RegExp(linkPlaceHolder, 'i'), link);
     }
   }
 


### PR DESCRIPTION
@platers 

Fixes #201 

It seems that when the placeholder is added to the title and capitalization is set to first letter capitalization, the header changes the placeholder to no longer be all caps which meant that the replace would not work. In order to fix this, I made the replace case insensitive.

Changes Made:
- Updated the replace to be case insensitive for the links
- Added a test to verify that links stay as they were in the headings

Please let me know if we want the test placed elsewhere or a different kind of test or fix to be used.