### PR TITLE
Capitalize 1st a - Z Character in a Heading

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1137,7 +1137,7 @@ export const rules: Rule[] = [
               case 'First Letter':
                 lines[i] = lines[i]
                     .toLowerCase()
-                    .replace(/^#*\s([a-z])/, (string) => string.toUpperCase()); // capitalize first letter of heading
+                    .replace(/^#*\s+([^a-z])*([a-z])/, (string) => string.toUpperCase()); // capitalize first letter of heading
                 break;
             }
           }

--- a/src/test.ts
+++ b/src/test.ts
@@ -197,6 +197,17 @@ describe('Rules tests', () => {
         `;
       expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First Letter'})).toBe(after);
     });
+    it('Can capitalize only first letter that is a - Z', () => {
+      const before = dedent`
+        # 1. heading attempt
+        # 1 John
+        `;
+      const after = dedent`
+        # 1. Heading attempt
+        # 1 John
+        `;
+      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First Letter'})).toBe(after);
+    });
     it('Can capitalize to all caps', () => {
       const before = dedent`
         # this Is A Heading


### PR DESCRIPTION
Fixes #171 

There was an issue where if the first letter of a heading was not a letter that is a through z then it would not capitalize the first letter. This PR changes that and adds a test to make sure it handles that scenario.

Changes Made:
- Updated the regex to ignore non a through z characters that start a heading and capitalize the first a through z character in the heading
- Added a UT to make sure this does not break in the future
