### PR TITLE
Fix Frontmatter Parsing with Lines that Start with Tabs

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -581,6 +581,27 @@ describe('Insert yaml attributes', () => {
     `;
     expect(rulesDict['insert-yaml-attributes'].apply(before, {'Text to insert': 'tags:'})).toBe(after);
   });
+  // accounts for https://github.com/platers/obsidian-linter/issues/157
+  it('When a file has tabs at the start of a line in the frontmatter, the yaml insertion still works leaving other tabs as they were', () => {
+    const before = dedent`
+    ---
+    title: this title\thas a tab
+    tags:
+    \t- test1
+    \t- test2
+    ---
+    `;
+    const after = dedent`
+    ---
+    blob:
+    title: this title\thas a tab
+    tags:
+    \t- test1
+    \t- test2
+    ---
+    `;
+    expect(rulesDict['insert-yaml-attributes'].apply(before, {'Text to insert': 'blob:'})).toBe(after);
+  });
 });
 
 describe('Disabled rules parsing', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -198,7 +198,9 @@ export function stripCr(text: string): string {
 }
 
 export function loadYAML(yaml_text: string): any {
-  const parsed_yaml = load(yaml_text) as {};
+  // replacing tabs at the beginning of new lines with 2 spaces fixes loading yaml that has tabs at the start of a line
+  // https://github.com/platers/obsidian-linter/issues/157
+  const parsed_yaml = load(yaml_text.replace(/\n(\t)+/g, '\n  ')) as {};
   if (!parsed_yaml) {
     return {};
   }


### PR DESCRIPTION
Fixes #157 

The issue was the parser expected 2 spaces instead of a tab. To remedy this, I have gone ahead and converted tabs to 2 spaces. I am not sure how nested lists would be affected if those are even allowed in the frontmatter. Nevertheless, this should take care of the issue until it is reported that we are using nested lists if this does cause some kind of issue with that.

Changes Made:
- replaced any number of tabs after a new line character with 2 spaces when parsing the yaml frontmatter
- Added a test to help us know if the issue is accidentally created again in the future