### PR TITLE
Fix Title Case Style Not Capitalizing the First Word

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1103,6 +1103,7 @@ export const rules: Rule[] = [
                 const ignoreShortWords = (
                 options['Lowercase Words'] as string
                 ).split(/[,\s]+/);
+                let firstWord = true;
                 for (let j = 1; j < headerWords.length; j++) {
                   const isWord = headerWords[j].match(/^[A-Za-z'-]+[.?!,:;]?$/);
                   if (!isWord) {
@@ -1117,12 +1118,14 @@ export const rules: Rule[] = [
                   if (!keepWordCasing) {
                     headerWords[j] = headerWords[j].toLowerCase();
                     const ignoreWord = ignoreShortWords.includes(headerWords[j]);
-                    if (!ignoreWord || j == 1) {
+                    if (!ignoreWord || firstWord === true) {
                     // ignore words that are not capitalized in titles except if they are the first word
                       headerWords[j] =
                       headerWords[j][0].toUpperCase() + headerWords[j].slice(1);
                     }
                   }
+
+                  firstWord = false;
                 }
 
                 lines[i] = lines[i].replace(

--- a/src/test.ts
+++ b/src/test.ts
@@ -166,6 +166,7 @@ describe('Rules tests', () => {
         ## this is a sentence.
         ## I can't do this
         ## comma, comma, comma
+        ## 1.1 the Header
         `;
       const after = dedent`
         # h1
@@ -173,6 +174,7 @@ describe('Rules tests', () => {
         ## This is a Sentence.
         ## I Can't Do This
         ## Comma, Comma, Comma
+        ## 1.1 The Header
         `;
       const options = Object.assign({
         'Style': 'Title Case',


### PR DESCRIPTION
Fixes #171 

Takes care of title case first word capitalization when the first set of characters is not a word.

Changes Made:
- Made sure to not assume the first set of characters would be a word
- Added another header to the title case test case string