### PR TITLE
Remove Blank Lines Between List and Checklist Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [heading-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#heading-blank-lines)
 - [paragraph-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#paragraph-blank-lines)
 - [space-after-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-after-list-markers)
+- [remove-empty-lines-between-list-markers-and-checklists](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-empty-lines-between-list-markers-and-checklists)
 - [compact-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#compact-yaml)
 - [consecutive-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#consecutive-blank-lines)
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -844,6 +844,71 @@ After:
 	- [ ] Item 3
 ```
 
+### Remove Empty Lines Between List Markers and Checklists
+
+Alias: `remove-empty-lines-between-list-markers-and-checklists`
+
+There should not be any empty lines between list markers and checklists.
+
+
+
+Example: 
+
+Before:
+
+```markdown
+1. Item 1
+
+2. Item 2
+
+- Item 1
+
+	- Subitem 1
+
+- Item 2
+
+- [x] Item 1
+
+	- [ ] Subitem 1
+
+- [ ] Item 2
+
++ Item 1
+
+	+ Subitem 1
+
++ Item 2
+
+* Item 1
+
+	* Subitem 1
+
+* Item 2
+```
+
+After:
+
+```markdown
+1. Item 1
+2. Item 2
+
+- Item 1
+	- Subitem 1
+- Item 2
+
+- [x] Item 1
+	- [ ] Subitem 1
+- [ ] Item 2
+
++ Item 1
+	+ Subitem 1
++ Item 2
+
+* Item 1
+	* Subitem 1
+* Item 2
+```
+
 ### Compact YAML
 
 Alias: `compact-yaml`

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -358,6 +358,103 @@ export const rules: Rule[] = [
       ],
   ),
   new Rule(
+      `Remove Empty Lines Between List Markers and Checklists`,
+      'There should not be any empty lines between list markers and checklists.',
+      RuleType.SPACING,
+      (text: string) => {
+        return ignoreCodeBlocksYAMLAndLinks(text, (text) => {
+          const replaceEmptyLinesBetweenList = function(text: string, listRegex: RegExp, replaceWith: string): string {
+            let match;
+            let newText = text;
+
+            do {
+              match = newText.match(listRegex);
+              newText = newText.replaceAll(listRegex, replaceWith);
+            } while (match);
+
+            // console.log(newText);
+            return newText;
+          };
+
+          /* eslint-disable no-useless-escape */
+          // account for '- [x]' and  '- [ ]' checkbox markers
+          const checkboxMarker = new RegExp(/^(( |\t)*- \[( |x)\].+)\n\n(( |\t)*- \[( |x)\].+)$/gm);
+          text = replaceEmptyLinesBetweenList(text, checkboxMarker, '$1\n$4');
+
+          // account for ordered list marker
+          const orderedMarker = new RegExp(/^(( |\t)*\d+\..+)\n\n(( |\t)*\d+\..+)$/gm);
+          text = replaceEmptyLinesBetweenList(text, orderedMarker, '$1\n$3');
+
+          // account for '+' list marker
+          const plusMarker = new RegExp(/^(( |\t)*\+.+)\n\n(( |\t)*\+.+)$/gm);
+          text = replaceEmptyLinesBetweenList(text, plusMarker, '$1\n$3');
+
+          // account for '-' list marker
+          const dashMarker = new RegExp(/^(( |\t)*-(?! \[( |x)\]).+)\n\n(( |\t)*-(?! \[( |x)\]).+)$/gm);
+          text = replaceEmptyLinesBetweenList(text, dashMarker, '$1\n$4');
+
+          // account for '*' list marker
+          const splatMarker = new RegExp(/^(( |\t)*\*.+)\n\n(( |\t)*\*.+)$/gm);
+          return replaceEmptyLinesBetweenList(text, splatMarker, '$1\n$3');
+          /* eslint-enable no-useless-escape */
+        });
+      },
+      [
+        new Example(
+            '',
+            dedent`
+      1. Item 1
+
+      2. Item 2
+
+      - Item 1
+
+      \t- Subitem 1
+
+      - Item 2
+
+      - [x] Item 1
+
+      \t- [ ] Subitem 1
+
+      - [ ] Item 2
+
+      + Item 1
+      
+      \t+ Subitem 1
+
+      + Item 2
+
+      * Item 1
+
+      \t* Subitem 1
+
+      * Item 2
+      `,
+            dedent`
+      1. Item 1
+      2. Item 2
+
+      - Item 1
+      \t- Subitem 1
+      - Item 2
+
+      - [x] Item 1
+      \t- [ ] Subitem 1
+      - [ ] Item 2
+
+      + Item 1
+      \t+ Subitem 1
+      + Item 2
+
+      * Item 1
+      \t* Subitem 1
+      * Item 2
+      `,
+        ),
+      ],
+  ),
+  new Rule(
       'Compact YAML',
       'Removes leading and trailing blank lines in the YAML front matter.',
       RuleType.SPACING,

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -378,23 +378,23 @@ export const rules: Rule[] = [
 
           /* eslint-disable no-useless-escape */
           // account for '- [x]' and  '- [ ]' checkbox markers
-          const checkboxMarker = new RegExp(/^(( |\t)*- \[( |x)\].+)\n\n(( |\t)*- \[( |x)\].+)$/gm);
+          const checkboxMarker = new RegExp(/^(( |\t)*- \[( |x)\].+)\n{2,}(( |\t)*- \[( |x)\].+)$/gm);
           text = replaceEmptyLinesBetweenList(text, checkboxMarker, '$1\n$4');
 
           // account for ordered list marker
-          const orderedMarker = new RegExp(/^(( |\t)*\d+\..+)\n\n(( |\t)*\d+\..+)$/gm);
+          const orderedMarker = new RegExp(/^(( |\t)*\d+\..+)\n{2,}(( |\t)*\d+\..+)$/gm);
           text = replaceEmptyLinesBetweenList(text, orderedMarker, '$1\n$3');
 
           // account for '+' list marker
-          const plusMarker = new RegExp(/^(( |\t)*\+.+)\n\n(( |\t)*\+.+)$/gm);
+          const plusMarker = new RegExp(/^(( |\t)*\+.+)\n{2,}(( |\t)*\+.+)$/gm);
           text = replaceEmptyLinesBetweenList(text, plusMarker, '$1\n$3');
 
           // account for '-' list marker
-          const dashMarker = new RegExp(/^(( |\t)*-(?! \[( |x)\]).+)\n\n(( |\t)*-(?! \[( |x)\]).+)$/gm);
+          const dashMarker = new RegExp(/^(( |\t)*-(?! \[( |x)\]).+)\n{2,}(( |\t)*-(?! \[( |x)\]).+)$/gm);
           text = replaceEmptyLinesBetweenList(text, dashMarker, '$1\n$4');
 
           // account for '*' list marker
-          const splatMarker = new RegExp(/^(( |\t)*\*.+)\n\n(( |\t)*\*.+)$/gm);
+          const splatMarker = new RegExp(/^(( |\t)*\*.+)\n{2,}(( |\t)*\*.+)$/gm);
           return replaceEmptyLinesBetweenList(text, splatMarker, '$1\n$3');
           /* eslint-enable no-useless-escape */
         });


### PR DESCRIPTION
Fixes #190 

Make sure to remove blank lines between list items and checklist items. These can be broken out into 2 separate rules if we would like, but for now, I will include them as one rule.

Changes Made:
- Added a new rule to account for the following list indicators: `*`, `+`, `-`, and `- [( |x)]`

It should make sure that all instances of the lists do not have an empty line between them so long as there is no white space or anything of the sort on those lines.