### PR TITLE
Compact YAML Remove Inner Empty Lines

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -916,7 +916,7 @@ Alias: `compact-yaml`
 Removes leading and trailing blank lines in the YAML front matter.
 
 Options:
-- Inner Spaces: Remove spaces that are not at the start or the end of the YAML
+- Inner New Lines: Remove new lines that are not at the start or the end of the YAML
 	- Default: `false`
 
 Example: Remove blank lines at the start and end of the YAML
@@ -928,7 +928,7 @@ Before:
 
 date: today
 
-title: unchanged without inner spaces turned on
+title: unchanged without inner new lines turned on
 
 ---
 ```
@@ -939,10 +939,10 @@ After:
 ---
 date: today
 
-title: unchanged without inner spaces turned on
+title: unchanged without inner new lines turned on
 ---
 ```
-Example: Remove blank lines anywhere in YAML with inner spaces set.
+Example: Remove blank lines anywhere in YAML with inner new lines set to true
 
 Before:
 
@@ -952,7 +952,7 @@ Before:
 date: today
 
 
-title: remove inner spaces
+title: remove inner new lines
 
 ---
 
@@ -967,7 +967,7 @@ After:
 ```markdown
 ---
 date: today
-title: remove inner spaces
+title: remove inner new lines
 ---
 
 # Header 1

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -915,9 +915,11 @@ Alias: `compact-yaml`
 
 Removes leading and trailing blank lines in the YAML front matter.
 
+Options:
+- Inner Spaces: Remove spaces that are not at the start or the end of the YAML
+	- Default: `false`
 
-
-Example: 
+Example: Remove blank lines at the start and end of the YAML
 
 Before:
 
@@ -925,6 +927,8 @@ Before:
 ---
 
 date: today
+
+title: unchanged without inner spaces turned on
 
 ---
 ```
@@ -934,7 +938,42 @@ After:
 ```markdown
 ---
 date: today
+
+title: unchanged without inner spaces turned on
 ---
+```
+Example: Remove blank lines anywhere in YAML with inner spaces set.
+
+Before:
+
+```markdown
+---
+
+date: today
+
+
+title: remove inner spaces
+
+---
+
+# Header 1
+
+
+Body content here.
+```
+
+After:
+
+```markdown
+---
+date: today
+title: remove inner spaces
+---
+
+# Header 1
+
+
+Body content here.
 ```
 
 ### Consecutive blank lines

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -458,28 +458,73 @@ export const rules: Rule[] = [
       'Compact YAML',
       'Removes leading and trailing blank lines in the YAML front matter.',
       RuleType.SPACING,
-      (text: string) => {
+      (text: string, options = {}) => {
         return formatYAML(text, (text) => {
           text = text.replace(/^---\n+/, '---\n');
           text = text.replace(/\n+---/, '\n---');
+          if (options['Inner Spaces']) {
+            text = text.replaceAll(/\n{2,}/g, '\n');
+          }
+
           return text;
         });
       },
       [
         new Example(
-            '',
+            'Remove blank lines at the start and end of the YAML',
             dedent`
         ---
 
         date: today
+
+        title: unchanged without inner spaces turned on
 
         ---
         `,
             dedent`
         ---
         date: today
+
+        title: unchanged without inner spaces turned on
         ---
         `,
+        ),
+        new Example(
+            'Remove blank lines anywhere in YAML with inner spaces set.',
+            dedent`
+      ---
+
+      date: today
+
+
+      title: remove inner spaces
+
+      ---
+
+      # Header 1
+
+
+      Body content here.
+      `,
+            dedent`
+      ---
+      date: today
+      title: remove inner spaces
+      ---
+
+      # Header 1
+
+
+      Body content here.
+      `,
+            {'Inner Spaces': true},
+        ),
+      ],
+      [
+        new BooleanOption(
+            'Inner Spaces',
+            'Remove spaces that are not at the start or the end of the YAML',
+            false,
         ),
       ],
   ),

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -462,7 +462,7 @@ export const rules: Rule[] = [
         return formatYAML(text, (text) => {
           text = text.replace(/^---\n+/, '---\n');
           text = text.replace(/\n+---/, '\n---');
-          if (options['Inner Spaces']) {
+          if (options['Inner New Lines']) {
             text = text.replaceAll(/\n{2,}/g, '\n');
           }
 
@@ -477,7 +477,7 @@ export const rules: Rule[] = [
 
         date: today
 
-        title: unchanged without inner spaces turned on
+        title: unchanged without inner new lines turned on
 
         ---
         `,
@@ -485,19 +485,19 @@ export const rules: Rule[] = [
         ---
         date: today
 
-        title: unchanged without inner spaces turned on
+        title: unchanged without inner new lines turned on
         ---
         `,
         ),
         new Example(
-            'Remove blank lines anywhere in YAML with inner spaces set.',
+            'Remove blank lines anywhere in YAML with inner new lines set to true',
             dedent`
       ---
 
       date: today
 
 
-      title: remove inner spaces
+      title: remove inner new lines
 
       ---
 
@@ -509,7 +509,7 @@ export const rules: Rule[] = [
             dedent`
       ---
       date: today
-      title: remove inner spaces
+      title: remove inner new lines
       ---
 
       # Header 1
@@ -517,13 +517,13 @@ export const rules: Rule[] = [
 
       Body content here.
       `,
-            {'Inner Spaces': true},
+            {'Inner New Lines': true},
         ),
       ],
       [
         new BooleanOption(
-            'Inner Spaces',
-            'Remove spaces that are not at the start or the end of the YAML',
+            'Inner New Lines',
+            'Remove new lines that are not at the start or the end of the YAML',
             false,
         ),
       ],


### PR DESCRIPTION
Fixes #191 

Remove inner empty lines if the compact yaml option is turned on.

Changes Made:
- Updated the existing example to show that inner new lines are not removed by default
- Added another example to show that inner new lines are removed when the option is turned on, but that other new lines outside the yaml are not necessarily updated