### PR TITLE
Add Consistency Rules for Emphasis and Strong

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [remove-empty-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-empty-list-markers)
 - [convert-bullet-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-bullet-list-markers)
 - [proper-ellipsis](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#proper-ellipsis)
+- [emphasis-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#emphasis-style)
+- [strong-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#strong-style)
 
 ### Spacing rules
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -732,7 +732,7 @@ This is **_nested emphasis_ and ending bold**
 * List Item1 with _emphasized text_
 * List Item2
 ```
-Example: Emphasis indicators should use asterisks when style is set to 'asterisks'
+Example: Emphasis indicators should use asterisks when style is set to 'asterisk'
 
 Before:
 
@@ -913,7 +913,7 @@ This is **_nested emphasis_ and ending bold**
 
 _Test emphasis_
 ```
-Example: Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to 'consistent'
+Example: Strong indicators should use consistent style based on first strong indicator in a file when style is set to 'consistent'
 
 Before:
 
@@ -944,7 +944,7 @@ This is **_nested emphasis_ and ending bold**
 
 **Test bold**
 ```
-Example: Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to 'consistent'
+Example: Strong indicators should use consistent style based on first strong indicator in a file when style is set to 'consistent'
 
 Before:
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -680,6 +680,302 @@ After:
 Lorem (…) Impsum.
 ```
 
+### Emphasis Style
+
+Alias: `emphasis-style`
+
+Makes sure the emphasis style is consistent.
+
+Options:
+- Style: The style used to denote emphasized content
+	- Default: `consistent`
+	- `consistent`: Makes sure the first instance of emphasis is the style that will be used throughout the document
+	- `asterisk`: Makes sure * is the emphasis indicator
+	- `underscore`: Makes sure _ is the emphasis indicator
+
+Example: Emphasis indicators should use underscores when style is set to 'underscore'
+
+Before:
+
+```markdown
+# Emphasis Cases
+
+*Test emphasis*
+* Test not emphasized *
+This is *emphasized* mid sentence
+This is *emphasized* mid sentence with a second *emphasis* on the same line
+This is ***bold and emphasized***
+This is ***nested bold** and ending emphasized*
+This is ***nested emphasis* and ending bold**
+
+**Test bold**
+
+* List Item1 with *emphasized text*
+* List Item2
+```
+
+After:
+
+```markdown
+# Emphasis Cases
+
+_Test emphasis_
+* Test not emphasized *
+This is _emphasized_ mid sentence
+This is _emphasized_ mid sentence with a second _emphasis_ on the same line
+This is _**bold and emphasized**_
+This is _**nested bold** and ending emphasized_
+This is **_nested emphasis_ and ending bold**
+
+**Test bold**
+
+* List Item1 with _emphasized text_
+* List Item2
+```
+Example: Emphasis indicators should use asterisks when style is set to 'asterisks'
+
+Before:
+
+```markdown
+# Emphasis Cases
+
+_Test emphasis_
+_ Test not emphasized _
+This is _emphasized_ mid sentence
+This is _emphasized_ mid sentence with a second _emphasis_ on the same line
+This is ___bold and emphasized___
+This is ___nested bold__ and ending emphasized_
+This is ___nested emphasis_ and ending bold__
+
+__Test bold__
+```
+
+After:
+
+```markdown
+# Emphasis Cases
+
+*Test emphasis*
+_ Test not emphasized _
+This is *emphasized* mid sentence
+This is *emphasized* mid sentence with a second *emphasis* on the same line
+This is *__bold and emphasized__*
+This is *__nested bold__ and ending emphasized*
+This is __*nested emphasis* and ending bold__
+
+__Test bold__
+```
+Example: Emphasis indicators should use consistent style based on first emphasis indicator in a file when style is set to 'consistent'
+
+Before:
+
+```markdown
+# Emphasis First Emphasis Is an Asterisk
+
+*First emphasis*
+This is _emphasized_ mid sentence
+This is *emphasized* mid sentence with a second _emphasis_ on the same line
+This is *__bold and emphasized__*
+This is *__nested bold__ and ending emphasized*
+This is **_nested emphasis_ and ending bold**
+
+__Test bold__
+```
+
+After:
+
+```markdown
+# Emphasis First Emphasis Is an Asterisk
+
+*First emphasis*
+This is *emphasized* mid sentence
+This is *emphasized* mid sentence with a second *emphasis* on the same line
+This is *__bold and emphasized__*
+This is *__nested bold__ and ending emphasized*
+This is ***nested emphasis* and ending bold**
+
+__Test bold__
+```
+Example: Emphasis indicators should use consistent style based on first emphasis indicator in a file when style is set to 'consistent'
+
+Before:
+
+```markdown
+# Emphasis First Emphasis Is an Underscore
+
+**_First emphasis_**
+This is _emphasized_ mid sentence
+This is *emphasized* mid sentence with a second _emphasis_ on the same line
+This is *__bold and emphasized__*
+This is _**nested bold** and ending emphasized_
+This is __*nested emphasis* and ending bold__
+
+__Test bold__
+```
+
+After:
+
+```markdown
+# Emphasis First Emphasis Is an Underscore
+
+**_First emphasis_**
+This is _emphasized_ mid sentence
+This is _emphasized_ mid sentence with a second _emphasis_ on the same line
+This is ___bold and emphasized___
+This is _**nested bold** and ending emphasized_
+This is ___nested emphasis_ and ending bold__
+
+__Test bold__
+```
+
+### Strong Style
+
+Alias: `strong-style`
+
+Makes sure the strong style is consistent.
+
+Options:
+- Style: The style used to denote strong/bolded content
+	- Default: `consistent`
+	- `consistent`: Makes sure the first instance of strong is the style that will be used throughout the document
+	- `asterisk`: Makes sure ** is the strong indicator
+	- `underscore`: Makes sure __ is the strong indicator
+
+Example: Strong indicators should use underscores when style is set to 'underscore'
+
+Before:
+
+```markdown
+# Strong/Bold Cases
+
+**Test bold**
+** Test not bold **
+This is **bold** mid sentence
+This is **bold** mid sentence with a second **bold** on the same line
+This is ***bold and emphasized***
+This is ***nested bold** and ending emphasized*
+This is ***nested emphasis* and ending bold**
+
+*Test emphasis*
+
+* List Item1 with **bold text**
+* List Item2
+```
+
+After:
+
+```markdown
+# Strong/Bold Cases
+
+__Test bold__
+** Test not bold **
+This is __bold__ mid sentence
+This is __bold__ mid sentence with a second __bold__ on the same line
+This is *__bold and emphasized__*
+This is *__nested bold__ and ending emphasized*
+This is __*nested emphasis* and ending bold__
+
+*Test emphasis*
+
+* List Item1 with __bold text__
+* List Item2
+```
+Example: Strong indicators should use asterisks when style is set to 'asterisk'
+
+Before:
+
+```markdown
+# Strong/Bold Cases
+
+__Test bold__
+__ Test not bold __
+This is __bold__ mid sentence
+This is __bold__ mid sentence with a second __bold__ on the same line
+This is ___bold and emphasized___
+This is ___nested bold__ and ending emphasized_
+This is ___nested emphasis_ and ending bold__
+
+_Test emphasis_
+```
+
+After:
+
+```markdown
+# Strong/Bold Cases
+
+**Test bold**
+__ Test not bold __
+This is **bold** mid sentence
+This is **bold** mid sentence with a second **bold** on the same line
+This is _**bold and emphasized**_
+This is _**nested bold** and ending emphasized_
+This is **_nested emphasis_ and ending bold**
+
+_Test emphasis_
+```
+Example: Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to 'consistent'
+
+Before:
+
+```markdown
+# Strong First Strong Is an Asterisk
+
+**First bold**
+This is __bold__ mid sentence
+This is __bold__ mid sentence with a second **bold** on the same line
+This is ___bold and emphasized___
+This is *__nested bold__ and ending emphasized*
+This is **_nested emphasis_ and ending bold**
+
+__Test bold__
+```
+
+After:
+
+```markdown
+# Strong First Strong Is an Asterisk
+
+**First bold**
+This is **bold** mid sentence
+This is **bold** mid sentence with a second **bold** on the same line
+This is _**bold and emphasized**_
+This is ***nested bold** and ending emphasized*
+This is **_nested emphasis_ and ending bold**
+
+**Test bold**
+```
+Example: Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to 'consistent'
+
+Before:
+
+```markdown
+# Strong First Strong Is an Underscore
+
+__First bold__
+This is **bold** mid sentence
+This is **bold** mid sentence with a second __bold__ on the same line
+This is **_bold and emphasized_**
+This is ***nested bold** and ending emphasized*
+This is ___nested emphasis_ and ending bold__
+
+**Test bold**
+```
+
+After:
+
+```markdown
+# Strong First Strong Is an Underscore
+
+__First bold__
+This is __bold__ mid sentence
+This is __bold__ mid sentence with a second __bold__ on the same line
+This is ___bold and emphasized___
+This is *__nested bold__ and ending emphasized*
+This is ___nested emphasis_ and ending bold__
+
+__Test bold__
+```
+
 ## Spacing
 ### Trailing spaces
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -11,6 +11,7 @@ import {
   moveFootnotesToEnd,
   yamlRegex,
   escapeYamlString,
+  makeEmphasisOrBoldConsistent,
 } from './utils';
 import {
   Option,
@@ -788,6 +789,316 @@ export const rules: Rule[] = [
             dedent`
             Lorem (…) Impsum.
             `,
+        ),
+      ],
+  ),
+  new Rule(
+      'Emphasis Style',
+      'Makes sure the emphasis style is consistent.',
+      RuleType.CONTENT,
+      (text: string, options = {}) => {
+        return ignoreCodeBlocksYAMLAndLinks(text, (text) => {
+          return makeEmphasisOrBoldConsistent(text, options['Style'], 'emphasis');
+        });
+      },
+      [
+        new Example(
+            'Emphasis indicators should use underscores when style is set to \'underscore\'',
+            dedent`
+          # Emphasis Cases
+          
+          *Test emphasis*
+          * Test not emphasized *
+          This is *emphasized* mid sentence
+          This is *emphasized* mid sentence with a second *emphasis* on the same line
+          This is ***bold and emphasized***
+          This is ***nested bold** and ending emphasized*
+          This is ***nested emphasis* and ending bold**
+          
+          **Test bold**
+
+          * List Item1 with *emphasized text*
+          * List Item2
+    `,
+            dedent`
+          # Emphasis Cases
+          
+          _Test emphasis_
+          * Test not emphasized *
+          This is _emphasized_ mid sentence
+          This is _emphasized_ mid sentence with a second _emphasis_ on the same line
+          This is _**bold and emphasized**_
+          This is _**nested bold** and ending emphasized_
+          This is **_nested emphasis_ and ending bold**
+          
+          **Test bold**
+
+          * List Item1 with _emphasized text_
+          * List Item2
+    `,
+            {'Style': 'underscore'},
+        ),
+        new Example(
+            'Emphasis indicators should use asterisks when style is set to \'asterisks\'',
+            dedent`
+          # Emphasis Cases
+          
+          _Test emphasis_
+          _ Test not emphasized _
+          This is _emphasized_ mid sentence
+          This is _emphasized_ mid sentence with a second _emphasis_ on the same line
+          This is ___bold and emphasized___
+          This is ___nested bold__ and ending emphasized_
+          This is ___nested emphasis_ and ending bold__
+          
+          __Test bold__
+  `,
+            dedent`
+          # Emphasis Cases
+
+          *Test emphasis*
+          _ Test not emphasized _
+          This is *emphasized* mid sentence
+          This is *emphasized* mid sentence with a second *emphasis* on the same line
+          This is *__bold and emphasized__*
+          This is *__nested bold__ and ending emphasized*
+          This is __*nested emphasis* and ending bold__
+          
+          __Test bold__
+  `,
+            {'Style': 'asterisk'},
+        ),
+        new Example(
+            'Emphasis indicators should use consistent style based on first emphasis indicator in a file when style is set to \'consistent\'',
+            dedent`
+        # Emphasis First Emphasis Is an Asterisk
+
+        *First emphasis*
+        This is _emphasized_ mid sentence
+        This is *emphasized* mid sentence with a second _emphasis_ on the same line
+        This is *__bold and emphasized__*
+        This is *__nested bold__ and ending emphasized*
+        This is **_nested emphasis_ and ending bold**
+        
+        __Test bold__
+`,
+            dedent`
+        # Emphasis First Emphasis Is an Asterisk
+
+        *First emphasis*
+        This is *emphasized* mid sentence
+        This is *emphasized* mid sentence with a second *emphasis* on the same line
+        This is *__bold and emphasized__*
+        This is *__nested bold__ and ending emphasized*
+        This is ***nested emphasis* and ending bold**
+        
+        __Test bold__
+`,
+            {'Style': 'consistent'},
+        ),
+        new Example(
+            'Emphasis indicators should use consistent style based on first emphasis indicator in a file when style is set to \'consistent\'',
+            dedent`
+      # Emphasis First Emphasis Is an Underscore
+
+      **_First emphasis_**
+      This is _emphasized_ mid sentence
+      This is *emphasized* mid sentence with a second _emphasis_ on the same line
+      This is *__bold and emphasized__*
+      This is _**nested bold** and ending emphasized_
+      This is __*nested emphasis* and ending bold__
+      
+      __Test bold__
+`,
+            dedent`
+      # Emphasis First Emphasis Is an Underscore
+
+      **_First emphasis_**
+      This is _emphasized_ mid sentence
+      This is _emphasized_ mid sentence with a second _emphasis_ on the same line
+      This is ___bold and emphasized___
+      This is _**nested bold** and ending emphasized_
+      This is ___nested emphasis_ and ending bold__
+      
+      __Test bold__
+`,
+            {'Style': 'consistent'},
+        ),
+      ],
+      [
+        new DropdownOption(
+            'Style',
+            'The style used to denote emphasized content',
+            'consistent',
+            [
+              new DropdownRecord(
+                  'consistent',
+                  'Makes sure the first instance of emphasis is the style that will be used throughout the document',
+              ),
+              new DropdownRecord(
+                  'asterisk',
+                  'Makes sure * is the emphasis indicator',
+              ),
+              new DropdownRecord(
+                  'underscore',
+                  'Makes sure _ is the emphasis indicator',
+              ),
+            ],
+        ),
+      ],
+  ),
+  new Rule(
+      'Strong Style',
+      'Makes sure the strong style is consistent.',
+      RuleType.CONTENT,
+      (text: string, options = {}) => {
+        return ignoreCodeBlocksYAMLAndLinks(text, (text) => {
+          return makeEmphasisOrBoldConsistent(text, options['Style'], 'strong');
+        });
+      },
+      [
+        new Example(
+            'Strong indicators should use underscores when style is set to \'underscore\'',
+            dedent`
+          # Strong/Bold Cases
+          
+          **Test bold**
+          ** Test not bold **
+          This is **bold** mid sentence
+          This is **bold** mid sentence with a second **bold** on the same line
+          This is ***bold and emphasized***
+          This is ***nested bold** and ending emphasized*
+          This is ***nested emphasis* and ending bold**
+          
+          *Test emphasis*
+
+          * List Item1 with **bold text**
+          * List Item2
+          `,
+            dedent`
+          # Strong/Bold Cases
+          
+          __Test bold__
+          ** Test not bold **
+          This is __bold__ mid sentence
+          This is __bold__ mid sentence with a second __bold__ on the same line
+          This is *__bold and emphasized__*
+          This is *__nested bold__ and ending emphasized*
+          This is __*nested emphasis* and ending bold__
+          
+          *Test emphasis*
+
+          * List Item1 with __bold text__
+          * List Item2
+          `,
+            {'Style': 'underscore'},
+        ),
+        new Example(
+            'Strong indicators should use asterisks when style is set to \'asterisk\'',
+            dedent`
+          # Strong/Bold Cases
+          
+          __Test bold__
+          __ Test not bold __
+          This is __bold__ mid sentence
+          This is __bold__ mid sentence with a second __bold__ on the same line
+          This is ___bold and emphasized___
+          This is ___nested bold__ and ending emphasized_
+          This is ___nested emphasis_ and ending bold__
+          
+          _Test emphasis_
+          `,
+            dedent`
+          # Strong/Bold Cases
+          
+          **Test bold**
+          __ Test not bold __
+          This is **bold** mid sentence
+          This is **bold** mid sentence with a second **bold** on the same line
+          This is _**bold and emphasized**_
+          This is _**nested bold** and ending emphasized_
+          This is **_nested emphasis_ and ending bold**
+
+          _Test emphasis_
+          `,
+            {'Style': 'asterisk'},
+        ),
+        new Example(
+            'Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to \'consistent\'',
+            dedent`
+          # Strong First Strong Is an Asterisk
+
+          **First bold**
+          This is __bold__ mid sentence
+          This is __bold__ mid sentence with a second **bold** on the same line
+          This is ___bold and emphasized___
+          This is *__nested bold__ and ending emphasized*
+          This is **_nested emphasis_ and ending bold**
+
+          __Test bold__
+          `,
+            dedent`
+          # Strong First Strong Is an Asterisk
+
+          **First bold**
+          This is **bold** mid sentence
+          This is **bold** mid sentence with a second **bold** on the same line
+          This is _**bold and emphasized**_
+          This is ***nested bold** and ending emphasized*
+          This is **_nested emphasis_ and ending bold**
+
+          **Test bold**
+          `,
+            {'Style': 'consistent'},
+        ),
+        new Example(
+            'Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to \'consistent\'',
+            dedent`
+          # Strong First Strong Is an Underscore
+
+          __First bold__
+          This is **bold** mid sentence
+          This is **bold** mid sentence with a second __bold__ on the same line
+          This is **_bold and emphasized_**
+          This is ***nested bold** and ending emphasized*
+          This is ___nested emphasis_ and ending bold__
+
+          **Test bold**
+          `,
+            dedent`
+          # Strong First Strong Is an Underscore
+
+          __First bold__
+          This is __bold__ mid sentence
+          This is __bold__ mid sentence with a second __bold__ on the same line
+          This is ___bold and emphasized___
+          This is *__nested bold__ and ending emphasized*
+          This is ___nested emphasis_ and ending bold__
+
+          __Test bold__
+            `,
+            {'Style': 'consistent'},
+        ),
+      ],
+      [
+        new DropdownOption(
+            'Style',
+            'The style used to denote strong/bolded content',
+            'consistent',
+            [
+              new DropdownRecord(
+                  'consistent',
+                  'Makes sure the first instance of strong is the style that will be used throughout the document',
+              ),
+              new DropdownRecord(
+                  'asterisk',
+                  'Makes sure ** is the strong indicator',
+              ),
+              new DropdownRecord(
+                  'underscore',
+                  'Makes sure __ is the strong indicator',
+              ),
+            ],
         ),
       ],
   ),

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -839,7 +839,7 @@ export const rules: Rule[] = [
             {'Style': 'underscore'},
         ),
         new Example(
-            'Emphasis indicators should use asterisks when style is set to \'asterisks\'',
+            'Emphasis indicators should use asterisks when style is set to \'asterisk\'',
             dedent`
           # Emphasis Cases
           
@@ -1024,7 +1024,7 @@ export const rules: Rule[] = [
             {'Style': 'asterisk'},
         ),
         new Example(
-            'Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to \'consistent\'',
+            'Strong indicators should use consistent style based on first strong indicator in a file when style is set to \'consistent\'',
             dedent`
           # Strong First Strong Is an Asterisk
 
@@ -1052,7 +1052,7 @@ export const rules: Rule[] = [
             {'Style': 'consistent'},
         ),
         new Example(
-            'Strong indicators should use consistent style based on first emphasis indicator in a file when style is set to \'consistent\'',
+            'Strong indicators should use consistent style based on first strong indicator in a file when style is set to \'consistent\'',
             dedent`
           # Strong First Strong Is an Underscore
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,10 +60,10 @@ function replaceCodeblocks(text: string, placeholder: string): {text: string, re
 
 /**
  * Makes sure that the style of either strong or emphasis is consistent.
- * @param {string} text The text to move footnotes in
+ * @param {string} text The text to style either the strong or emphasis in a consistent manner
  * @param {string} style The style to use for the emphasis indicator (i.e. underscore, asterisk, or consistent)
  * @param {string} type The type of element to make consistent and the value should be either strong or emphasis
- * @return {string} The text with footnote declarations moved to the end
+ * @return {string} The text with either strong or emphasis styles made consistent
  */
 export function makeEmphasisOrBoldConsistent(text: string, style: string, type: string): string {
   const positions: Position[] = getPositions(type, text);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,6 +59,41 @@ function replaceCodeblocks(text: string, placeholder: string): {text: string, re
 }
 
 /**
+ * Makes sure that the style of either strong or emphasis is consistent.
+ * @param {string} text The text to move footnotes in
+ * @param {string} style The style to use for the emphasis indicator (i.e. underscore, asterisk, or consistent)
+ * @param {string} type The type of element to make consistent and the value should be either strong or emphasis
+ * @return {string} The text with footnote declarations moved to the end
+ */
+export function makeEmphasisOrBoldConsistent(text: string, style: string, type: string): string {
+  const positions: Position[] = getPositions(type, text);
+  if (positions.length === 0) {
+    return text;
+  }
+
+  let indicator = '';
+  if (style === 'underscore') {
+    indicator = '_';
+  } else if (style === 'asterisk') {
+    indicator = '*';
+  } else {
+    const firstPosition = positions[positions.length-1];
+    indicator = text.substring(firstPosition.start.offset, firstPosition.start.offset+1);
+  }
+
+  // make the size two for the indicator when the type is strong
+  if (type === 'strong') {
+    indicator += indicator;
+  }
+
+  for (const position of positions) {
+    text = text.substring(0, position.start.offset) + indicator + text.substring(position.start.offset + indicator.length, position.end.offset - indicator.length) + indicator + text.substring(position.end.offset);
+  }
+
+  return text;
+}
+
+/**
  * Moves footnote declarations to the end of the document.
  * @param {string} text The text to move footnotes in
  * @return {string} The text with footnote declarations moved to the end


### PR DESCRIPTION
Added rules to make strong and emphasis consistent. It took a little longer than I would like to get the tests to pass because of some issue with dedent not removing all spaces (probably an error on my part).

Relates to #32 (adds MD49 and MD50)

[MD049](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md049) emphasis-style - Emphasis style should be consistent
[MD050](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md050) strong-style - Strong style should be consistent

Changes Made:
- Added `makeEmphasisOrBoldConsistent` to handle the consistency rules for emphasis and strong. It allows for `consistent`, `asterisk`, and `underscore`
- Added rules `Emphasis Style` and `Strong Style` to account for those 2 styles