### PR TITLE
Display Currently Active Dropdown Option as Selected

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -353,10 +353,14 @@ class SettingTab extends PluginSettingTab {
             .setName(this.name)
             .setDesc(this.description)
             .addDropdown((dropdown) => {
-              dropdown.setValue(settings.ruleConfigs[this.ruleName][this.name]);
+              // First, add all the available options
               for (const option of this.options) {
                 dropdown.addOption(option.value, option.value);
               }
+
+              // Set currently selected value from existing settings
+              dropdown.setValue(settings.ruleConfigs[this.ruleName][this.name]);
+
               dropdown.onChange((value) => {
                 this.setOption(value, settings);
                 plugin.settings = settings;


### PR DESCRIPTION
For dropdown settings, show the currently active (user-chosen) one as the selected one on the UI.

Fixes #216

---

### Issue Description
When dropdown options load in settings, the user-selected options are not shown as the currently selected item.

#### Steps to Reproduce
We can use the "Capitalize Headings > Style" option to demonstrate.

1. Open Obsidian Linter settings, and scroll down to the "Capitalize Headings" section
2. For the "Style" dropdown, choose a setting that's different from what's currently enabled. For example, if "Title Case" is currently your preferred setting, choose "All Caps".
3. Close the settings page. (Optional: test that the linter is now changing headings to "ALL CAPS").
4. Re-open the settings page, and scroll down to "Capitalize Headings"

*Expected:* that the newly selected option "ALL CAPS" is chosen as the Style (i.e. with a checkmark), and is currently shown

*Actual:* "Title Case" is still chosen as the Style, and it has the checkmark.

(see full details in #216)

---

### Testing
- Manual testing was done to verify this change
- Any guidance on how / where we can add unit tests for this would be appreciated

#### Before Fix

The value shown in the drop-down always defaults to "Title Case", despite the currently selected user setting

https://user-images.githubusercontent.com/1861055/172000985-85e229c9-f027-42dd-a622-ff57572dfa85.mp4


#### After Fix

The currently selected user setting is now displayed as the active option in the dropdown

https://user-images.githubusercontent.com/1861055/172001033-8627ee0f-0b54-434c-95f4-7d54854e8ac7.mp4


