### PR TITLE
Match Header Capitalization Style Title to Formatting Result

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1587,10 +1587,10 @@ export const rules: Rule[] = [
                 );
                 break;
               }
-              case 'All Caps':
+              case 'ALL CAPS':
                 lines[i] = lines[i].toUpperCase(); // convert full heading to uppercase
                 break;
-              case 'First Letter':
+              case 'First letter':
                 lines[i] = lines[i]
                     .toLowerCase()
                     .replace(/^#*\s+([^a-z])*([a-z])/, (string) => string.toUpperCase()); // capitalize first letter of heading
@@ -1630,7 +1630,7 @@ export const rules: Rule[] = [
             {'Style': 'Title Case', 'Ignore Cased Words': true},
         ),
         new Example(
-            'With `First Letter=true`',
+            'With `First letter=true`',
             dedent`
         # this is a heading 1
         ## this is a heading 2
@@ -1639,10 +1639,10 @@ export const rules: Rule[] = [
         # This is a heading 1
         ## This is a heading 2
         `,
-            {Style: 'First Letter'},
+            {Style: 'First letter'},
         ),
         new Example(
-            'With `All Caps=true`',
+            'With `ALL CAPS=true`',
             dedent`
         # this is a heading 1
         ## this is a heading 2
@@ -1651,7 +1651,7 @@ export const rules: Rule[] = [
         # THIS IS A HEADING 1
         ## THIS IS A HEADING 2
         `,
-            {Style: 'All Caps'},
+            {Style: 'ALL CAPS'},
         ),
       ],
       [
@@ -1660,13 +1660,13 @@ export const rules: Rule[] = [
             'The style of capitalization to use',
             'Title Case',
             [
-              new DropdownRecord('Title Case', 'Capitalize using title case rules'),
+              new DropdownRecord('Title Case', 'Capitalize Using Title Case Rules'),
               new DropdownRecord(
-                  'All Caps',
-                  'Capitalize the first letter of each word',
+                  'ALL CAPS',
+                  'CAPITALIZE THE WHOLE TITLE',
               ),
               new DropdownRecord(
-                  'First Letter',
+                  'First letter',
                   'Only capitalize the first letter',
               ),
             ],

--- a/src/test.ts
+++ b/src/test.ts
@@ -197,7 +197,7 @@ describe('Rules tests', () => {
       const after = dedent`
         # This is a heading
         `;
-      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First Letter'})).toBe(after);
+      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First letter'})).toBe(after);
     });
     it('Can capitalize only first letter that is a - Z', () => {
       const before = dedent`
@@ -208,7 +208,7 @@ describe('Rules tests', () => {
         # 1. Heading attempt
         # 1 John
         `;
-      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First Letter'})).toBe(after);
+      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First letter'})).toBe(after);
     });
     it('Can capitalize to all caps', () => {
       const before = dedent`
@@ -217,7 +217,7 @@ describe('Rules tests', () => {
       const after = dedent`
         # THIS IS A HEADING
         `;
-      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'All Caps'})).toBe(after);
+      expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'ALL CAPS'})).toBe(after);
     });
   });
   describe('File Name Heading', () => {
@@ -806,6 +806,6 @@ describe('Links', () => {
     # Heading ![docker](docker)
     `;
 
-    expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First Letter'})).toBe(after);
+    expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First letter'})).toBe(after);
   });
 });


### PR DESCRIPTION
- Update the Heading Capitalization Style Options to match what they do
- Fix documentation for ALL CAPS dropdown option

### Before:
![obsidian-linter-style-formatting-before](https://user-images.githubusercontent.com/1861055/172003922-c80ddb29-dd62-4a29-b608-6863e37f7d2f.png)


### After:
![obsidian-linter-style-formatting-after](https://user-images.githubusercontent.com/1861055/172003931-ed96820a-bb30-4748-ba42-a7c38202a985.png)
