### PR TITLE
Remove Spaces from Link Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
 - [line-break-at-document-end](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#line-break-at-document-end)
 - [space-between-chinese-and-english-or-numbers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-between-chinese-and-english-or-numbers)
+- [remove-link-spacing](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-link-spacing)
 
 
 ## Development Instructions

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1416,3 +1416,58 @@ After:
 ```markdown
 中文字符串 `code` 中文字符串。
 ```
+
+### Remove link spacing
+
+Alias: `remove-link-spacing`
+
+Removes spacing around link text.
+
+
+
+Example: Space in regular markdown link text
+
+Before:
+
+```markdown
+[ here is link text1 ](link_here)
+[ here is link text2](link_here)
+[here is link text3 ](link_here)
+[here is link text4](link_here)
+[	here is link text5	](link_here)
+[](link_here)
+```
+
+After:
+
+```markdown
+[here is link text1](link_here)
+[here is link text2](link_here)
+[here is link text3](link_here)
+[here is link text4](link_here)
+[here is link text5](link_here)
+[](link_here)
+```
+Example: Space in wiki link text
+
+Before:
+
+```markdown
+[[link_here| here is link text1 ]]
+[[link_here|here is link text2 ]]
+[[link_here| here is link text3]]
+[[link_here|here is link text4]]
+[[link_here|	here is link text5	]]
+[[link_here]]
+```
+
+After:
+
+```markdown
+[[link_here|here is link text1]]
+[[link_here|here is link text2]]
+[[link_here|here is link text3]]
+[[link_here|here is link text4]]
+[[link_here|here is link text5]]
+[[link_here]]
+```


### PR DESCRIPTION
It helps cover another rule for #32 

Removes spaces in the link text for both wiki links and markdown links.

Changes Made:
- Added test cases showing how the whitespace removal works
- Added a rule to remove the whitespace