### PR TITLE
Make Remove Multiple Whitespace Remove Multiple Spaces Around Non-Letters

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -646,7 +646,7 @@ export const rules: Rule[] = [
       RuleType.CONTENT,
       (text: string) => {
         return ignoreCodeBlocksYAMLAndLinks(text, (text) => {
-          return text.replace(/\b {2,}\b/g, ' ');
+          return text.replace(/([^\s])( ){2,}([^\s])/g, '$1 $3');
         });
       },
       [

--- a/src/test.ts
+++ b/src/test.ts
@@ -929,3 +929,45 @@ describe('Links', () => {
     expect(rulesDict['capitalize-headings'].apply(before, {'Style': 'First letter'})).toBe(after);
   });
 });
+
+describe('Remove Multiple Spaces', () => {
+  it('Make sure spaces at the end of the line are ignored', () => {
+    const before = dedent`
+    # Hello world
+
+    Paragraph contents are here  
+    Second paragraph contents here  
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    Paragraph contents are here  
+    Second paragraph contents here  
+    `;
+
+    expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
+  });
+  it('Make sure spaces at the start of the line are ignored', () => {
+    const before = '  Paragraph contents are here\n  Second paragraph here...';
+
+    const after = '  Paragraph contents are here\n  Second paragraph here...';
+
+    expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
+  });
+  it('Make sure non-letter followed or preceeded by 2 spaces has them cut down to 1 space', () => {
+    const before = dedent`
+    # Hello world
+
+    Paragraph contents  (something). Something else  .
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    Paragraph contents (something). Something else .
+    `;
+
+    expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
+  });
+});


### PR DESCRIPTION
Fixes #226 

There was an issue reported where sometimes multiple whitespace values were not getting removed. After looking at the logic, it was determined that the issue was the use of `\b` instead of more generic value of `[^\s]` which matches on any character that is not a new line character as opposed to just word endings (punctuation and others did not seem to match all of the time).

Changes Made:
- Updated remove multiple whitespace regex
- Added UTs around the issue