### PR TITLE
Fix a Couple of Issues Around Header Increment

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -995,6 +995,7 @@ backticks around url should stay the same: `https://github.com`
 Links mid-sentence should be updated like https://google.com will be.
 'https://github.com'
 "https://github.com"
+<https://github.com>
 links should stay the same: [](https://github.com)
 https://gitlab.com
 ```
@@ -1008,6 +1009,7 @@ backticks around url should stay the same: `https://github.com`
 Links mid-sentence should be updated like <https://google.com> will be.
 'https://github.com'
 "https://github.com"
+<https://github.com>
 links should stay the same: [](https://github.com)
 <https://gitlab.com>
 ```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -263,6 +263,53 @@ After:
 
 We skipped a 2nd level heading
 ```
+Example: Skipped headings in sections that would be decremented will result in those headings not having the same meaning
+
+Before:
+
+```markdown
+# H1
+### H3
+
+We skip from 1 to 3
+
+####### H7
+
+We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+###### H6
+
+We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+## H2
+
+This resets the decrement section so the H6 below is decremented to an H3
+
+###### H6
+```
+
+After:
+
+```markdown
+# H1
+## H3
+
+We skip from 1 to 3
+
+### H7
+
+We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+## H6
+
+We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+## H2
+
+This resets the decrement section so the H6 below is decremented to an H3
+
+### H6
+```
 
 ### File Name Heading
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1109,7 +1109,7 @@ export const rules: Rule[] = [
       RuleType.CONTENT,
       (text: string) => {
         return ignoreCodeBlocksYAMLAndLinks(text, (text) => {
-          const URLMatches = text.match(/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'"]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'"]{2,})/gi);
+          const URLMatches = text.match(/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'">]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'">]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'">]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'">]{2,})/gi);
 
           if (!URLMatches) {
             return text;
@@ -1125,8 +1125,8 @@ export const rules: Rule[] = [
 
             const previousChar = urlStart === 0 ? undefined : text.charAt(urlStart - 1);
             const nextChar = urlEnd >= text.length ? undefined : text.charAt(urlEnd);
-            if (previousChar != undefined && (previousChar === '`' || previousChar === '"' || previousChar === '\'' || previousChar === '[') &&
-              nextChar != undefined && (nextChar === '`' || nextChar === '"' || nextChar === '\'' || nextChar === ']')) {
+            if (previousChar != undefined && (previousChar === '`' || previousChar === '"' || previousChar === '\'' || previousChar === '[' || previousChar === '<') &&
+              nextChar != undefined && (nextChar === '`' || nextChar === '"' || nextChar === '\'' || nextChar === ']' || nextChar === '>')) {
               startSearch = urlStart + urlMatch.length;
               continue;
             }
@@ -1148,6 +1148,7 @@ export const rules: Rule[] = [
           Links mid-sentence should be updated like https://google.com will be.
           'https://github.com'
           "https://github.com"
+          <https://github.com>
           links should stay the same: [](https://github.com)
           https://gitlab.com
           `,
@@ -1158,6 +1159,7 @@ export const rules: Rule[] = [
           Links mid-sentence should be updated like <https://google.com> will be.
           'https://github.com'
           "https://github.com"
+          <https://github.com>
           links should stay the same: [](https://github.com)
           <https://gitlab.com>
           `,

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1554,6 +1554,13 @@ export const rules: Rule[] = [
             if (level > lastLevel + 1) {
               decrement += level - (lastLevel + 1);
               level = lastLevel + 1;
+            } else if (level < lastLevel) {
+              decrement -= lastLevel + decrement - match[2].length;
+
+              if (decrement <= 0) {
+                level = match[2].length;
+                decrement = 0;
+              }
             }
 
             lines[i] = lines[i].replace(
@@ -1586,6 +1593,49 @@ export const rules: Rule[] = [
 
         We skipped a 2nd level heading
         `,
+        ),
+        new Example(
+            'Skipped headings in sections that would be decremented will result in those headings not having the same meaning',
+            dedent`
+          # H1
+          ### H3
+
+          We skip from 1 to 3
+
+          ####### H7
+
+          We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+          ###### H6
+
+          We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+          ## H2
+
+          This resets the decrement section so the H6 below is decremented to an H3
+
+          ###### H6
+      `,
+            dedent`
+          # H1
+          ## H3
+
+          We skip from 1 to 3
+
+          ### H7
+
+          We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+          ## H6
+
+          We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+          ## H2
+
+          This resets the decrement section so the H6 below is decremented to an H3
+
+          ### H6
+      `,
         ),
       ],
   ),

--- a/src/test.ts
+++ b/src/test.ts
@@ -157,6 +157,54 @@ describe('Rules tests', () => {
         `;
       expect(rulesDict['header-increment'].apply(before)).toBe(after);
     });
+    it('Handles change from decrement to regular increment', () => {
+      const before = dedent`
+        # H1
+        ##### H5
+        ####### H7
+        ###### H6
+        ## H2
+        `;
+      const after = dedent`
+        # H1
+        ## H5
+        ### H7
+        ## H6
+        ## H2
+        `;
+      expect(rulesDict['header-increment'].apply(before)).toBe(after);
+    });
+    it('Handles a variety of changes in header size', () => {
+      const before = dedent`
+        # H1
+        ### H3
+        #### H4
+        ###### H6
+        ## H2
+        # H1
+        ## H2
+        ### H3
+        #### H4
+        ###### H6
+        ##### H5
+        ### H3
+        `;
+      const after = dedent`
+        # H1
+        ## H3
+        ### H4
+        #### H6
+        ## H2
+        # H1
+        ## H2
+        ### H3
+        #### H4
+        ##### H6
+        ##### H5
+        ### H3
+        `;
+      expect(rulesDict['header-increment'].apply(before)).toBe(after);
+    });
   });
   describe('Capitalize Headings', () => {
     it('Ignores not words', () => {


### PR DESCRIPTION
Fixes #142 

There was an issue where when we incremented our headers there would be an issue where the next header could be 0 or less. This was because we were not handling the case of what to do when we had a heading less than or equal to the value of decrement. For example:
``` text
# H1
##### H5
## H2
```

In order to fix this, we should keep track of the proper decrement when we go up levels. This allows for us to also address the issue where decreasing the heading level inside of a decrement section would not affect the decrement value. For example:
``` text
# H1
### H3
##### H5
#### H4
```
H4 would be treated the same as H5 even though it is my understanding that it should be treated like H3.

Changes Made:
- Included missed documentation for No Base URL change
- Updated increment header to keep track of increases and decreases in the decrement of headers that should happen
- Added UTs to help make sure that the header changes are working as intended
- Added another example for Header Increment to help make it clearer what will happen when headings are skipped inside of decrement sections

_Note: this logic may contain other issues in it since this is a little tricky to think through how it should work, but this should resolve the one bug and we can address any other issues down the road_