### PR TITLE
Add Two Spaces at the End of Lines with Content Continued on the Next Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [emphasis-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#emphasis-style)
 - [strong-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#strong-style)
 - [no-bare-urls](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#no-bare-urls)
+- [two-spaces-between-lines-with-content](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#two-spaces-between-lines-with-content)
 
 ### Spacing rules
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1080,6 +1080,102 @@ single quotes around a url should stay the same, but only if the contents of the
 double quotes around a url should stay the same, but only if the contents of the double quotes is the url: "<https://github.com> some text here"
 ```
 
+### Two Spaces Between Lines with Content
+
+Alias: `two-spaces-between-lines-with-content`
+
+Makes sure that two spaces are added to the ends of lines that have content next to each other
+
+
+
+Example: Make sure two spaces are added to the ends of lines that have content on it and the next line for lists, blockquotes, and paragraphs
+
+Before:
+
+```markdown
+# Heading 1
+First paragraph stays as the first paragraph
+
+- list item 1
+- list item 2
+Continuation of list item 2
+- list item 3
+
+1. Item 1
+2. Item 2
+Continuation of item 3
+3. Item 3
+
+Paragraph for with link [[other file name]].
+Continuation *of* the paragraph has `inline code block` __in it__.
+Even more continuation
+
+Paragraph lines that end in <br/>
+Or lines that end in <br>
+Are left alone
+Since they mean the same thing
+
+``` text
+Code blocks are ignored
+Even with multiple lines
+```
+Another paragraph here
+
+> Blockquotes are affected
+> More content here
+Content here
+
+<div>
+html content
+should be ignored
+</div>
+Even more content here
+
+```
+
+After:
+
+```markdown
+# Heading 1
+First paragraph stays as the first paragraph
+
+- list item 1
+- list item 2  
+Continuation of list item 2
+- list item 3
+
+1. Item 1
+2. Item 2  
+Continuation of item 3
+3. Item 3
+
+Paragraph for with link [[other file name]].  
+Continuation *of* the paragraph has `inline code block` __in it__.  
+Even more continuation
+
+Paragraph lines that end in <br/>
+Or lines that end in <br>
+Are left alone  
+Since they mean the same thing
+
+``` text
+Code blocks are ignored
+Even with multiple lines
+```
+Another paragraph here
+
+> Blockquotes are affected  
+> More content here  
+Content here
+
+<div>
+html content
+should be ignored
+</div>
+Even more content here
+
+```
+
 ## Spacing
 ### Trailing spaces
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1084,7 +1084,7 @@ double quotes around a url should stay the same, but only if the contents of the
 
 Alias: `two-spaces-between-lines-with-content`
 
-Makes sure that two spaces are added to the ends of lines that have content next to each other
+Makes sure that two spaces are added to the ends of lines with content continued on the next line for paragraphs, blockquotes, and list items
 
 
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -995,6 +995,7 @@ backticks around url should stay the same: `https://github.com`
 Links mid-sentence should be updated like https://google.com will be.
 'https://github.com'
 "https://github.com"
+<https://github.com>
 links should stay the same: [](https://github.com)
 https://gitlab.com
 ```
@@ -1008,6 +1009,7 @@ backticks around url should stay the same: `https://github.com`
 Links mid-sentence should be updated like <https://google.com> will be.
 'https://github.com'
 "https://github.com"
+<https://github.com>
 links should stay the same: [](https://github.com)
 <https://gitlab.com>
 ```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -263,6 +263,53 @@ After:
 
 We skipped a 2nd level heading
 ```
+Example: Skipped headings in sections that would be decremented will result in those headings not having the same meaning
+
+Before:
+
+```markdown
+# H1
+### H3
+
+We skip from 1 to 3
+
+####### H7
+
+We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+###### H6
+
+We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+## H2
+
+This resets the decrement section so the H6 below is decremented to an H3
+
+###### H6
+```
+
+After:
+
+```markdown
+# H1
+## H3
+
+We skip from 1 to 3
+
+### H7
+
+We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+## H6
+
+We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+## H2
+
+This resets the decrement section so the H6 below is decremented to an H3
+
+### H6
+```
 
 ### File Name Heading
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1109,7 +1109,7 @@ export const rules: Rule[] = [
       RuleType.CONTENT,
       (text: string) => {
         return ignoreCodeBlocksYAMLAndLinks(text, (text) => {
-          const URLMatches = text.match(/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'"]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'"]{2,})/gi);
+          const URLMatches = text.match(/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'">]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'">]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'">]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'">]{2,})/gi);
 
           if (!URLMatches) {
             return text;
@@ -1125,8 +1125,8 @@ export const rules: Rule[] = [
 
             const previousChar = urlStart === 0 ? undefined : text.charAt(urlStart - 1);
             const nextChar = urlEnd >= text.length ? undefined : text.charAt(urlEnd);
-            if (previousChar != undefined && (previousChar === '`' || previousChar === '"' || previousChar === '\'' || previousChar === '[') &&
-              nextChar != undefined && (nextChar === '`' || nextChar === '"' || nextChar === '\'' || nextChar === ']')) {
+            if (previousChar != undefined && (previousChar === '`' || previousChar === '"' || previousChar === '\'' || previousChar === '[' || previousChar === '<') &&
+              nextChar != undefined && (nextChar === '`' || nextChar === '"' || nextChar === '\'' || nextChar === ']' || nextChar === '>')) {
               startSearch = urlStart + urlMatch.length;
               continue;
             }
@@ -1148,6 +1148,7 @@ export const rules: Rule[] = [
           Links mid-sentence should be updated like https://google.com will be.
           'https://github.com'
           "https://github.com"
+          <https://github.com>
           links should stay the same: [](https://github.com)
           https://gitlab.com
           `,
@@ -1158,6 +1159,7 @@ export const rules: Rule[] = [
           Links mid-sentence should be updated like <https://google.com> will be.
           'https://github.com'
           "https://github.com"
+          <https://github.com>
           links should stay the same: [](https://github.com)
           <https://gitlab.com>
           `,

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -12,6 +12,7 @@ import {
   yamlRegex,
   escapeYamlString,
   makeEmphasisOrBoldConsistent,
+  addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent,
   linkRegex,
 } from './utils';
 import {
@@ -1177,6 +1178,99 @@ export const rules: Rule[] = [
           backticks around a url should stay the same, but only if the only contents of the backticks: \`<https://github.com> some text here\`
           single quotes around a url should stay the same, but only if the contents of the single quotes is the url: '<https://github.com> some text here'
           double quotes around a url should stay the same, but only if the contents of the double quotes is the url: "<https://github.com> some text here"
+        `,
+        ),
+      ],
+  ),
+  new Rule(
+      'Two Spaces Between Lines with Content',
+      'Makes sure that two spaces are added to the ends of lines with content continued on the next line for paragraphs, blockquotes, and list items',
+      RuleType.CONTENT,
+      (text: string) => {
+        return addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent(text);
+      },
+      [
+        new Example(
+            'Make sure two spaces are added to the ends of lines that have content on it and the next line for lists, blockquotes, and paragraphs',
+            dedent`
+            # Heading 1
+            First paragraph stays as the first paragraph
+
+            - list item 1
+            - list item 2
+            Continuation of list item 2
+            - list item 3
+
+            1. Item 1
+            2. Item 2
+            Continuation of item 3
+            3. Item 3
+
+            Paragraph for with link [[other file name]].
+            Continuation *of* the paragraph has \`inline code block\` __in it__.
+            Even more continuation
+
+            Paragraph lines that end in <br/>
+            Or lines that end in <br>
+            Are left alone
+            Since they mean the same thing
+
+            \`\`\` text
+            Code blocks are ignored
+            Even with multiple lines
+            \`\`\`
+            Another paragraph here
+
+            > Blockquotes are affected
+            > More content here
+            Content here
+
+            <div>
+            html content
+            should be ignored
+            </div>
+            Even more content here
+
+        `,
+            dedent`
+            # Heading 1
+            First paragraph stays as the first paragraph
+
+            - list item 1
+            - list item 2  
+            Continuation of list item 2
+            - list item 3
+
+            1. Item 1
+            2. Item 2  
+            Continuation of item 3
+            3. Item 3
+
+            Paragraph for with link [[other file name]].  
+            Continuation *of* the paragraph has \`inline code block\` __in it__.  
+            Even more continuation
+
+            Paragraph lines that end in <br/>
+            Or lines that end in <br>
+            Are left alone  
+            Since they mean the same thing
+
+            \`\`\` text
+            Code blocks are ignored
+            Even with multiple lines
+            \`\`\`
+            Another paragraph here
+
+            > Blockquotes are affected  
+            > More content here  
+            Content here
+
+            <div>
+            html content
+            should be ignored
+            </div>
+            Even more content here
+
         `,
         ),
       ],

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1554,6 +1554,13 @@ export const rules: Rule[] = [
             if (level > lastLevel + 1) {
               decrement += level - (lastLevel + 1);
               level = lastLevel + 1;
+            } else if (level < lastLevel) {
+              decrement -= lastLevel + decrement - match[2].length;
+
+              if (decrement <= 0) {
+                level = match[2].length;
+                decrement = 0;
+              }
             }
 
             lines[i] = lines[i].replace(
@@ -1586,6 +1593,49 @@ export const rules: Rule[] = [
 
         We skipped a 2nd level heading
         `,
+        ),
+        new Example(
+            'Skipped headings in sections that would be decremented will result in those headings not having the same meaning',
+            dedent`
+          # H1
+          ### H3
+
+          We skip from 1 to 3
+
+          ####### H7
+
+          We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+          ###### H6
+
+          We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+          ## H2
+
+          This resets the decrement section so the H6 below is decremented to an H3
+
+          ###### H6
+      `,
+            dedent`
+          # H1
+          ## H3
+
+          We skip from 1 to 3
+
+          ### H7
+
+          We skip from 3 to 7 leaving out 4, 5, and 6. Thus headings level 4, 5, and 6 will be treated like H3 above until another H2 or H1 is encountered
+
+          ## H6
+
+          We skipped 6 previously so it will be treated the same as the H3 above since it was the next lowest header that was to be decremented
+
+          ## H2
+
+          This resets the decrement section so the H6 below is decremented to an H3
+
+          ### H6
+      `,
         ),
       ],
   ),

--- a/src/test.ts
+++ b/src/test.ts
@@ -157,6 +157,54 @@ describe('Rules tests', () => {
         `;
       expect(rulesDict['header-increment'].apply(before)).toBe(after);
     });
+    it('Handles change from decrement to regular increment', () => {
+      const before = dedent`
+        # H1
+        ##### H5
+        ####### H7
+        ###### H6
+        ## H2
+        `;
+      const after = dedent`
+        # H1
+        ## H5
+        ### H7
+        ## H6
+        ## H2
+        `;
+      expect(rulesDict['header-increment'].apply(before)).toBe(after);
+    });
+    it('Handles a variety of changes in header size', () => {
+      const before = dedent`
+        # H1
+        ### H3
+        #### H4
+        ###### H6
+        ## H2
+        # H1
+        ## H2
+        ### H3
+        #### H4
+        ###### H6
+        ##### H5
+        ### H3
+        `;
+      const after = dedent`
+        # H1
+        ## H3
+        ### H4
+        #### H6
+        ## H2
+        # H1
+        ## H2
+        ### H3
+        #### H4
+        ##### H6
+        ##### H5
+        ### H3
+        `;
+      expect(rulesDict['header-increment'].apply(before)).toBe(after);
+    });
   });
   describe('Capitalize Headings', () => {
     it('Ignores not words', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,6 +94,41 @@ export function makeEmphasisOrBoldConsistent(text: string, style: string, type: 
 }
 
 /**
+ * Makes sure that blockquotes, paragraphs, and list items have two spaces at the end of them if the following line continues its content.
+ * @param {string} text The text to make sure that the two spaces are added to if there are consecutive lines of content
+ * @return {string} The text with two spaces at the end of lines of paragraphs, list items, and blockquotes where there were consecutive lines of content.
+ */
+export function addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent(text: string): string {
+  const positions: Position[] = getPositions('paragraph', text);
+  if (positions.length === 0) {
+    return text;
+  }
+
+  for (const position of positions) {
+    const paragraphLines = text.substring(position.start.offset, position.end.offset).split('\n');
+    const lastLineIndex = paragraphLines.length - 1;
+    // only update paragraph if there is more than 1 line present
+    if (lastLineIndex < 1) {
+      continue;
+    }
+
+    for (let i = 0; i < lastLineIndex; i++) {
+      const paragraphLine = paragraphLines[i].trimEnd();
+
+      // skip lines that end in <br> or <br/> as it is the same as two spaces in Markdown
+      if (paragraphLine.endsWith('<br>') || paragraphLine.endsWith('<br/>')) {
+        continue;
+      }
+      paragraphLines[i] = paragraphLine + '  ';
+    }
+
+    text = text.substring(0, position.start.offset) + paragraphLines.join('\n') + text.substring(position.end.offset);
+  }
+
+  return text;
+}
+
+/**
  * Moves footnote declarations to the end of the document.
  * @param {string} text The text to move footnotes in
  * @return {string} The text with footnote declarations moved to the end


### PR DESCRIPTION
Fixes #195 

There was a request to add two spaces at the end of lines that continue content. In looking into doing so, I encountered that the parser we use would allow for it to happen to blockquotes, paragraphs, and list items. There may be more, but I did not see them with what I was testing. If there are more, we can address them by either excluding them or add them to the documentation.

Changes Made:
- Added a helper that goes over "paragraphs" (i.e. blockquotes, paragraphs, and list items) and makes sure lines end in two spaces if they have their content continued on the next line
- Added the rule for the helper method
- Added an example that show cases how it works including ignoring lines that would otherwise end in html line breaks