### PR TITLE
Fix Placeholders' First Character Matching "\b" for Regex

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -1033,3 +1033,24 @@ describe('Remove Multiple Spaces', () => {
     expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
   });
 });
+
+describe('Remove Hyphenated Line Breaks', () => {
+  // accounts for https://github.com/platers/obsidian-linter/issues/241
+  it('Make sure text ending in a hyphen followed by a link does not trigger the hyphenated line break rule', () => {
+    const before = dedent`
+    # Hello world
+
+    Paragraph contents are here- [link text](pathToFile/file.md)
+    Paragraph contents are here- [[file]]
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    Paragraph contents are here- [link text](pathToFile/file.md)
+    Paragraph contents are here- [[file]]
+    `;
+
+    expect(rulesDict['remove-hyphenated-line-breaks'].apply(before)).toBe(after);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,7 +193,7 @@ export function moveFootnotesToEnd(text: string) {
  * @return {string} The processed text
  */
 export function ignoreCodeBlocksYAMLTagsAndLinks(text: string, func: (text: string) => string): string {
-  const codePlaceholder = 'PLACEHOLDER 321417';
+  const codePlaceholder = '{PLACEHOLDER 321417}';
   const ret = replaceCodeblocks(text, codePlaceholder);
   text = ret.text;
   const replacedCodeBlocks = ret.replacedCodeBlocks;
@@ -203,7 +203,7 @@ export function ignoreCodeBlocksYAMLTagsAndLinks(text: string, func: (text: stri
     text = text.replace(yamlMatches[0], escapeDollarSigns(yamlPlaceholder));
   }
 
-  const linkPlaceHolder = 'PLACEHOLDER_LINK 57849';
+  const linkPlaceHolder = '{PLACEHOLDER_LINK 57849}';
   const linkMatches = text.match(linkRegex);
   text = text.replaceAll(linkRegex, linkPlaceHolder);
 


### PR DESCRIPTION
Fixes #241 

There was an issue where placeholders could match on `\b` for regex which would have unintended issues. The one in this case was that if you had the rule on to remove hyphenated line breaks, when a link was escaped and it was right after the hyphenated text with a single space in it, it would meet the requirements for the removal of the hyphenated line break. For example `text- [[File Name]]` would become `textPlaceholder ...`. This was not the intended result. So the placeholders have been updated so they will not match `\b` on their first character which prevents the above issue.

Changes Made:
- Updated placeholders that started out with a letter or number to start with `{` and end with `}`
- Added a test to account for the above issue and help us to catch if we accidentally create the above scenario again