### PR TITLE
Update Link Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Pull requests are welcome, especially for new rules.
    1. Insert a new rule in the corresponding rule type(spacing, headings, etc)
    2. Follow the format of the existing rules
    3. Add tests for edge cases in `test.ts`
-   4. You should probably use some helper functions from `utils.ts`, such as `ignoreCodeBlocksYAMLAndLinks`.
+   4. You should probably use some helper functions from `utils.ts`, such as `ignoreCodeBlocksYAMLTagsAndLinks`.
 5. Run `npm run compile` to build, generate documentation, and test the plugin.
 6. Run `npm run lint` to lint the plugin.
 

--- a/docs/readme_template.md
+++ b/docs/readme_template.md
@@ -48,7 +48,7 @@ Pull requests are welcome, especially for new rules.
    1. Insert a new rule in the corresponding rule type(spacing, headings, etc)
    2. Follow the format of the existing rules
    3. Add tests for edge cases in `test.ts`
-   4. You should probably use some helper functions from `utils.ts`, such as `ignoreCodeBlocksYAMLAndLinks`.
+   4. You should probably use some helper functions from `utils.ts`, such as `ignoreCodeBlocksYAMLTagsAndLinks`.
 5. Run `npm run compile` to build, generate documentation, and test the plugin.
 6. Run `npm run lint` to lint the plugin.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1766,6 +1766,8 @@ Before:
 [here is link text4](link_here)
 [	here is link text5	](link_here)
 [](link_here)
+**Note that image markdown syntax does not get affected even if it is transclusion:**
+![	here is link text6 ](link_here)
 ```
 
 After:
@@ -1777,6 +1779,8 @@ After:
 [here is link text4](link_here)
 [here is link text5](link_here)
 [](link_here)
+**Note that image markdown syntax does not get affected even if it is transclusion:**
+![	here is link text6 ](link_here)
 ```
 Example: Space in wiki link text
 
@@ -1788,6 +1792,7 @@ Before:
 [[link_here| here is link text3]]
 [[link_here|here is link text4]]
 [[link_here|	here is link text5	]]
+![[link_here|	here is link text6	]]
 [[link_here]]
 ```
 
@@ -1799,5 +1804,6 @@ After:
 [[link_here|here is link text3]]
 [[link_here|here is link text4]]
 [[link_here|here is link text5]]
+![[link_here|here is link text6]]
 [[link_here]]
 ```

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -13,7 +13,7 @@ import {
   escapeYamlString,
   makeEmphasisOrBoldConsistent,
   addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent,
-  linkRegex,
+  removeSpacesInLinkText,
 } from './utils';
 import {
   Option,
@@ -2341,26 +2341,7 @@ export const rules: Rule[] = [
       'Removes spacing around link text.',
       RuleType.SPACING,
       (text: string) => {
-        const linkMatches = text.match(linkRegex);
-
-        if (!linkMatches) {
-          return text;
-        }
-
-        for (const link of linkMatches) {
-          // regular markdown link
-          if (!link.startsWith('[[')) {
-            const endLinkTextPosition = link.lastIndexOf(']');
-            const newLink = link.substring(0, 1) + link.substring(1, endLinkTextPosition).trim() + link.substring(endLinkTextPosition);
-            text = text.replace(link, newLink);
-          } else if (link.includes('|')) { // wiki link with link text
-            const startLinkTextPosition = link.indexOf('|');
-            const newLink = link.substring(0, startLinkTextPosition+1) + link.substring(startLinkTextPosition+1, link.length - 2).trim() + ']]';
-            text = text.replace(link, newLink);
-          }
-        }
-
-        return text;
+        return removeSpacesInLinkText(text);
       },
       [
         new Example(
@@ -2372,6 +2353,8 @@ export const rules: Rule[] = [
       [here is link text4](link_here)
       [\there is link text5\t](link_here)
       [](link_here)
+      **Note that image markdown syntax does not get affected even if it is transclusion:**
+      ![\there is link text6 ](link_here)
       `,
             dedent`
       [here is link text1](link_here)
@@ -2380,25 +2363,29 @@ export const rules: Rule[] = [
       [here is link text4](link_here)
       [here is link text5](link_here)
       [](link_here)
+      **Note that image markdown syntax does not get affected even if it is transclusion:**
+      ![\there is link text6 ](link_here)
       `,
         ),
         new Example(
             'Space in wiki link text',
             dedent`
-    [[link_here| here is link text1 ]]
-    [[link_here|here is link text2 ]]
-    [[link_here| here is link text3]]
-    [[link_here|here is link text4]]
-    [[link_here|\there is link text5\t]]
-    [[link_here]]
+      [[link_here| here is link text1 ]]
+      [[link_here|here is link text2 ]]
+      [[link_here| here is link text3]]
+      [[link_here|here is link text4]]
+      [[link_here|\there is link text5\t]]
+      ![[link_here|\there is link text6\t]]
+      [[link_here]]
     `,
             dedent`
-    [[link_here|here is link text1]]
-    [[link_here|here is link text2]]
-    [[link_here|here is link text3]]
-    [[link_here|here is link text4]]
-    [[link_here|here is link text5]]
-    [[link_here]]
+      [[link_here|here is link text1]]
+      [[link_here|here is link text2]]
+      [[link_here|here is link text3]]
+      [[link_here|here is link text4]]
+      [[link_here|here is link text5]]
+      ![[link_here|here is link text6]]
+      [[link_here]]
     `,
         ),
       ],

--- a/src/test.ts
+++ b/src/test.ts
@@ -1032,6 +1032,17 @@ describe('Remove Multiple Spaces', () => {
 
     expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
   });
+  it('Links followed by parentheses do not prevent other removal of multiple spaces in a row', () => {
+    const before = dedent`
+    [Link text](path/fileName.md) (2 spaces in between  text)
+    `;
+
+    const after = dedent`
+    [Link text](path/fileName.md) (2 spaces in between text)
+    `;
+
+    expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
+  });
 });
 
 describe('Remove Hyphenated Line Breaks', () => {


### PR DESCRIPTION
Updated the link parsing to be more robust than before. Before it would often include characters outside the link if the link was followed by a parentheses after the end of the link. To fix this, I let remark handle finding the regular links and just identified wiki links. The downside of this is that images/transclusion of regular makdown links is ignored for the sake of removing spaces in link text. We can add that by including images in the types to pull back from remark.

Changes Made:
- Updated regular markdown link identification to go through `remark-js`
- Added a UT for a scenario I noticed was not working around cleaning up whitespace
- Updated example to show translusion is not affected by removing spaces around links
- Updated documentation to include updated name for a method that was previously updated