### PR TITLE
Update YAML Timestamp and Add Locale

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -119,9 +119,6 @@ Options:
 	- Default: `date modified`
 - Format: Date format
 	- Default: `dddd, MMMM Do YYYY, h:mm:ss a`
-- Always Update Date Modified: Insert the date the file was last modified even if no changes have been made.
- Note: almost always updates the file when seconds are in the date format since we use the last time the file was modified which is not the same after we update the file with the previous date modified metadata.
-	- Default: `false`
 
 Example: Adds a header with the date.
 
@@ -136,7 +133,7 @@ After:
 ```markdown
 ---
 date created: Wednesday, January 1st 2020, 12:00:00 am
-date modified: Thursday, January 2nd 2020, 12:00:00 am
+date modified: Thursday, January 2nd 2020, 12:00:05 am
 ---
 # H1
 ```
@@ -152,7 +149,7 @@ After:
 
 ```markdown
 ---
-date modified: Wednesday, January 1st 2020, 12:00:00 am
+date modified: Thursday, January 2nd 2020, 12:00:05 am
 ---
 # H1
 ```
@@ -184,7 +181,7 @@ After:
 
 ```markdown
 ---
-modified: Wednesday, January 1st 2020, 12:00:00 am
+modified: Wednesday, January 1st 2020, 4:00:00 pm
 ---
 # H1
 ```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -120,7 +120,7 @@ Options:
 - Format: Date format
 	- Default: `dddd, MMMM Do YYYY, h:mm:ss a`
 - Always Update Date Modified: Insert the date the file was last modified even if no changes have been made.
- Note: almost always updates the file when seconds are in the date format since there is a slight delay between the insertion of the metadata and saving of the file.
+ Note: almost always updates the file when seconds are in the date format since we use the last time the file was modified which is not the same after we update the file with the previous date modified metadata.
 	- Default: `false`
 
 Example: Adds a header with the date.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -119,6 +119,9 @@ Options:
 	- Default: `date modified`
 - Format: Date format
 	- Default: `dddd, MMMM Do YYYY, h:mm:ss a`
+- Always Update Date Modified: Insert the date the file was last modified even if no changes have been made.
+ Note: almost always updates the file when seconds are in the date format since there is a slight delay between the insertion of the metadata and saving of the file.
+	- Default: `false`
 
 Example: Adds a header with the date.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -226,6 +226,7 @@ export default class LinterPlugin extends Plugin {
         'metadata: file created time': this.momentInstance(file.stat.ctime).format(),
         'metadata: file modified time': this.momentInstance(file.stat.mtime).format(),
         'metadata: file name': file.basename,
+        'Current Time': this.momentInstance(),
         'Already Modified': oldText != newText,
         'moment': this.momentInstance,
       }, yaml_timestamp_rule.getOptions(this.settings));

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1402,12 +1402,14 @@ export const rules: Rule[] = [
           const created_key_match = new RegExp(created_key_match_str);
           const created_match = new RegExp(created_match_str);
 
-          moment.locale(options['locale']);
+          const moment = options['moment'];
 
           if (options['Date Created'] === true) {
-            const formatted_date = moment(
+            const created_date = moment(
                 options['metadata: file created time'],
-            ).format(options['Format']);
+            );
+
+            const formatted_date = created_date.format(options['Format']);
             const created_date_line = `\n${options['Date Created Key']}: ${formatted_date}`;
 
             const keyWithValueFound = created_match.test(text);
@@ -1455,7 +1457,10 @@ export const rules: Rule[] = [
             const keyWithValueFound = modified_match.test(text);
             if (keyWithValueFound) {
               const modifiedDateTime = moment(text.match(modified_match)[0].replace(options['Date Modified Key'] + ':', '').trim(), options['Format'], true);
-              if (textModified || modifiedDateTime == undefined || !modifiedDateTime.isValid() || Math.abs(modifiedDateTime.diff(modified_date, 'seconds')) > 5) {
+              if (options['Always Update Date Modified'] || textModified ||
+                  modifiedDateTime == undefined || !modifiedDateTime.isValid() ||
+                  Math.abs(modifiedDateTime.diff(modified_date, 'seconds')) > 5
+              ) {
                 text = text.replace(
                     modified_match,
                     escapeDollarSigns(modified_date_line) + '\n',
@@ -1492,6 +1497,7 @@ export const rules: Rule[] = [
               'metadata: file created time': '2020-01-01T00:00:00-00:00',
               'metadata: file modified time': '2020-01-02T00:00:00-00:00',
               'Already Modified': false,
+              'moment': moment,
             },
         ),
         new Example(
@@ -1510,6 +1516,7 @@ export const rules: Rule[] = [
               'metadata: file created time': '2020-01-01T00:00:00-00:00',
               'metadata: file modified time': '2020-01-01T00:00:00-00:00',
               'Already Modified': false,
+              'moment': moment,
             },
         ),
         new Example(
@@ -1529,6 +1536,7 @@ export const rules: Rule[] = [
               'Date Created Key': 'created',
               'metadata: file created time': '2020-01-01T00:00:00-00:00',
               'Already Modified': false,
+              'moment': moment,
             },
         ),
         new Example(
@@ -1548,11 +1556,16 @@ export const rules: Rule[] = [
               'Date Modified Key': 'modified',
               'metadata: file modified time': '2020-01-01T00:00:00-00:00',
               'Already Modified': false,
+              'moment': moment,
             },
         ),
       ],
       [
-        new BooleanOption('Date Created', 'Insert the file creation date', true),
+        new BooleanOption(
+            'Date Created',
+            'Insert the file creation date',
+            true,
+        ),
         new TextOption(
             'Date Created Key',
             'Which YAML key to use for creation date',
@@ -1572,6 +1585,11 @@ export const rules: Rule[] = [
             'Format',
             'Date format',
             'dddd, MMMM Do YYYY, h:mm:ss a',
+        ),
+        new BooleanOption(
+            'Always Update Date Modified',
+            'Insert the date the file was last modified even if no changes have been made.\n Note: almost always updates the file when seconds are in the date format since there is a slight delay between the insertion of the metadata and saving of the file.',
+            false,
         ),
       ],
   ),

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1588,7 +1588,7 @@ export const rules: Rule[] = [
         ),
         new BooleanOption(
             'Always Update Date Modified',
-            'Insert the date the file was last modified even if no changes have been made.\n Note: almost always updates the file when seconds are in the date format since there is a slight delay between the insertion of the metadata and saving of the file.',
+            'Insert the date the file was last modified even if no changes have been made.\n Note: almost always updates the file when seconds are in the date format since we use the last time the file was modified which is not the same after we update the file with the previous date modified metadata.',
             false,
         ),
       ],

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1451,14 +1451,15 @@ export const rules: Rule[] = [
             const modified_date = moment(
                 options['metadata: file modified time'],
             );
-            const formatted_modified_date = modified_date.format(options['Format']);
+            // using the current time helps prevent issues where the previous modified time was greater
+            // than 5 seconds prior to the time the linter will finish with the file (i.e. helps prevent accidental infinite loops on updating the date modified value)
+            const formatted_modified_date = options['Current Time'].format(options['Format']);
             const modified_date_line = `\n${options['Date Modified Key']}: ${formatted_modified_date}`;
 
             const keyWithValueFound = modified_match.test(text);
             if (keyWithValueFound) {
               const modifiedDateTime = moment(text.match(modified_match)[0].replace(options['Date Modified Key'] + ':', '').trim(), options['Format'], true);
-              if (options['Always Update Date Modified'] || textModified ||
-                  modifiedDateTime == undefined || !modifiedDateTime.isValid() ||
+              if (textModified || modifiedDateTime == undefined || !modifiedDateTime.isValid() ||
                   Math.abs(modifiedDateTime.diff(modified_date, 'seconds')) > 5
               ) {
                 text = text.replace(
@@ -1489,13 +1490,14 @@ export const rules: Rule[] = [
             dedent`
         ---
         date created: Wednesday, January 1st 2020, 12:00:00 am
-        date modified: Thursday, January 2nd 2020, 12:00:00 am
+        date modified: Thursday, January 2nd 2020, 12:00:05 am
         ---
         # H1
         `,
             {
               'metadata: file created time': '2020-01-01T00:00:00-00:00',
               'metadata: file modified time': '2020-01-02T00:00:00-00:00',
+              'Current Time': moment('Thursday, January 2nd 2020, 12:00:05 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
               'Already Modified': false,
               'moment': moment,
             },
@@ -1507,7 +1509,7 @@ export const rules: Rule[] = [
         `,
             dedent`
         ---
-        date modified: Wednesday, January 1st 2020, 12:00:00 am
+        date modified: Thursday, January 2nd 2020, 12:00:05 am
         ---
         # H1
         `,
@@ -1515,6 +1517,7 @@ export const rules: Rule[] = [
               'Date Created': false,
               'metadata: file created time': '2020-01-01T00:00:00-00:00',
               'metadata: file modified time': '2020-01-01T00:00:00-00:00',
+              'Current Time': moment('Thursday, January 2nd 2020, 12:00:05 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
               'Already Modified': false,
               'moment': moment,
             },
@@ -1535,6 +1538,7 @@ export const rules: Rule[] = [
               'Date Modified': false,
               'Date Created Key': 'created',
               'metadata: file created time': '2020-01-01T00:00:00-00:00',
+              'Current Time': moment('Thursday, January 2nd 2020, 12:00:03 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
               'Already Modified': false,
               'moment': moment,
             },
@@ -1546,7 +1550,7 @@ export const rules: Rule[] = [
             `,
             dedent`
         ---
-        modified: Wednesday, January 1st 2020, 12:00:00 am
+        modified: Wednesday, January 1st 2020, 4:00:00 pm
         ---
         # H1
         `,
@@ -1555,6 +1559,7 @@ export const rules: Rule[] = [
               'Date Modified': true,
               'Date Modified Key': 'modified',
               'metadata: file modified time': '2020-01-01T00:00:00-00:00',
+              'Current Time': moment('Wednesday, January 1st 2020, 4:00:00 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
               'Already Modified': false,
               'moment': moment,
             },
@@ -1585,11 +1590,6 @@ export const rules: Rule[] = [
             'Format',
             'Date format',
             'dddd, MMMM Do YYYY, h:mm:ss a',
-        ),
-        new BooleanOption(
-            'Always Update Date Modified',
-            'Insert the date the file was last modified even if no changes have been made.\n Note: almost always updates the file when seconds are in the date format since we use the last time the file was modified which is not the same after we update the file with the previous date modified metadata.',
-            false,
         ),
       ],
   ),

--- a/src/test.ts
+++ b/src/test.ts
@@ -609,6 +609,7 @@ describe('yaml timestamp', () => {
       'Date Modified': true,
       'Date Modified Key': 'modified',
       'metadata: file modified time': '2020-01-01T00:00:00-00:00',
+      'Current Time': moment('Thursday, January 2nd 2020, 12:00:00 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'moment': moment,
@@ -631,7 +632,8 @@ describe('yaml timestamp', () => {
       'Date Created': false,
       'Date Modified': true,
       'Date Modified Key': 'modified',
-      'metadata: file modified time': '2020-01-02T00:00:00-00:00',
+      'metadata: file modified time': '2020-01-02T00:00:03-00:00',
+      'Current Time': moment('Thursday, January 2nd 2020, 12:00:00 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'Already Modified': false,
       'moment': moment,
@@ -655,6 +657,7 @@ describe('yaml timestamp', () => {
       'Date Modified': true,
       'Date Modified Key': 'modified',
       'metadata: file modified time': '2020-01-01T00:00:00-00:00',
+      'Current Time': moment('Wednesday, January 1st 2020, 12:00:00 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Format': 'dddd, MMMM Do YYYY',
       'Already Modified': false,
       'moment': moment,
@@ -677,7 +680,8 @@ describe('yaml timestamp', () => {
       'Date Created': false,
       'Date Modified': true,
       'Date Modified Key': 'modified',
-      'metadata: file modified time': '2020-02-01T00:00:00-00:00',
+      'metadata: file modified time': '2020-01-30T00:00:00-00:00',
+      'Current Time': moment('Saturday, February 1st 2020, 12:00:00 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Already Modified': true,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'moment': moment,
@@ -692,7 +696,7 @@ describe('yaml timestamp', () => {
     `;
     const after = dedent`
     ---
-    modified: samedi, février 1er 2020, 12:00:00 am
+    modified: samedi, février 1er 2020, 12:00:05 am
     ---
     `;
 
@@ -702,6 +706,7 @@ describe('yaml timestamp', () => {
       'Date Modified': true,
       'Date Modified Key': 'modified',
       'metadata: file modified time': '2020-02-01T00:00:00-00:00',
+      'Current Time': moment('samedi, février 1er 2020, 12:00:05 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'moment': moment,
@@ -717,7 +722,7 @@ describe('yaml timestamp', () => {
     `;
     const after = dedent`
     ---
-    modified: Thursday, January 2nd 2020, 12:00:00 am
+    modified: Thursday, January 2nd 2020, 12:00:05 am
     created: Wednesday, January 1st 2020, 12:00:00 am
     ---
     `;
@@ -729,6 +734,7 @@ describe('yaml timestamp', () => {
       'Date Modified Key': 'modified',
       'metadata: file created time': '2020-01-01T00:00:00-00:00',
       'metadata: file modified time': '2020-01-02T00:00:00-00:00',
+      'Current Time': moment('Thursday, January 2nd 2020, 12:00:05 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'moment': moment,
@@ -755,8 +761,9 @@ describe('yaml timestamp', () => {
       'Date Created': false,
       'Date Modified': true,
       'Date Modified Key': 'modified',
-      'metadata: file modified time': '2020-02-01T00:00:00-00:00',
+      'metadata: file modified time': '2020-01-30T00:00:00-00:00',
       'Already Modified': false,
+      'Current Time': moment('Saturday, February 1st 2020, 12:00:00 am', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'moment': moment,
     };
@@ -857,7 +864,7 @@ describe('yaml timestamp', () => {
     const after = dedent`
     ---
     tag: tag1
-    modified: Sunday, February 2nd 2020, 12:00:00 am
+    modified: Tuesday, February 4th 2020, 6:00:00 pm
     created: Wednesday, January 1st 2020, 12:00:00 am
     location: "path"
     ---
@@ -870,41 +877,9 @@ describe('yaml timestamp', () => {
       'Date Created Key': 'created',
       'metadata: file created time': '2020-01-01T00:00:00-00:00',
       'metadata: file modified time': '2020-02-02T00:00:00-00:00',
+      'Current Time': moment('Tuesday, February 4th 2020, 6:00:00 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'Already Modified': false,
-      'moment': moment,
-    };
-    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
-  });
-
-  it('Updates modified value when nothing has changed if always update date modified setting is on', () => {
-    const before = dedent`
-    ---
-    tag: tag1
-    modified: Saturday, February 1st 2020, 12:00:00 am
-    created: Wednesday, January 1st 2020, 12:00:00 am
-    location: "path"
-    ---
-    `;
-    const after = dedent`
-    ---
-    tag: tag1
-    modified: Sunday, February 2nd 2020, 12:00:00 am
-    created: Wednesday, January 1st 2020, 12:00:00 am
-    location: "path"
-    ---
-    `;
-
-    const options = {
-      'Date Created': true,
-      'Date Modified': true,
-      'Date Modified Key': 'modified',
-      'Date Created Key': 'created',
-      'metadata: file created time': '2020-01-01T00:00:00-00:00',
-      'metadata: file modified time': '2020-02-02T00:00:00-00:00',
-      'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
-      'Already Modified': false,
-      'Always Update Date Modified': true,
       'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);

--- a/src/test.ts
+++ b/src/test.ts
@@ -576,7 +576,7 @@ describe('yaml timestamp', () => {
     date created: 2019-01-01
     ---
     `;
-    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'date created'})).toBe(after);
+    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'date created', 'locale': 'en'})).toBe(after);
   });
   it('Respects created key', () => {
     const before = dedent`
@@ -589,7 +589,7 @@ describe('yaml timestamp', () => {
     created: 2019-01-01
     ---
     `;
-    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'created'})).toBe(after);
+    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'created', 'locale': 'en'})).toBe(after);
   });
   it('Respects modified key when nothing has changed', () => {
     const before = dedent`
@@ -607,8 +607,56 @@ describe('yaml timestamp', () => {
       'Date Created': false,
       'Date Modified': true,
       'Date Modified Key': 'modified',
-      'metadata: file modified time': '2020-02-01T00:00:00-00:00',
+      'metadata: file modified time': '2020-01-01T00:00:00-00:00',
       'Already Modified': false,
+      'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'locale': 'en',
+    };
+    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+  });
+  it('Updates modified value when nothing has changed, but date modified is more than 5 seconds different than the file metadata', () => {
+    const before = dedent`
+    ---
+    modified: Wednesday, January 1st 2020, 12:00:00 am
+    ---
+    `;
+    const after = dedent`
+    ---
+    modified: Thursday, January 2nd 2020, 12:00:00 am
+    ---
+    `;
+
+    const options = {
+      'Date Created': false,
+      'Date Modified': true,
+      'Date Modified Key': 'modified',
+      'metadata: file modified time': '2020-01-02T00:00:00-00:00',
+      'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'Already Modified': false,
+      'locale': 'en',
+    };
+    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+  });
+  it('Updates modified value when format has changed', () => {
+    const before = dedent`
+    ---
+    modified: Wednesday, January 1st 2020, 12:00:00 am
+    ---
+    `;
+    const after = dedent`
+    ---
+    modified: Wednesday, January 1st 2020
+    ---
+    `;
+
+    const options = {
+      'Date Created': false,
+      'Date Modified': true,
+      'Date Modified Key': 'modified',
+      'metadata: file modified time': '2020-01-01T00:00:00-00:00',
+      'Format': 'dddd, MMMM Do YYYY',
+      'Already Modified': false,
+      'locale': 'en',
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -631,6 +679,30 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-02-01T00:00:00-00:00',
       'Already Modified': true,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'locale': 'en',
+    };
+    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+  });
+  it('Updates modified key when locale has changed', () => {
+    const before = dedent`
+    ---
+    modified: Wednesday, January 1st 2020, 12:00:00 am
+    ---
+    `;
+    const after = dedent`
+    ---
+    modified: samedi, février 1er 2020, 12:00:00 am
+    ---
+    `;
+
+    const options = {
+      'Date Created': false,
+      'Date Modified': true,
+      'Date Modified Key': 'modified',
+      'metadata: file modified time': '2020-02-01T00:00:00-00:00',
+      'Already Modified': false,
+      'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'locale': 'fr',
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -656,6 +728,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-01-02T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'locale': 'en',
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -682,6 +755,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-02-01T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'locale': 'en',
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -708,6 +782,92 @@ describe('yaml timestamp', () => {
       'metadata: file created time': '2020-02-01T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'locale': 'en',
+    };
+    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+  });
+  it('Updates created value when format has changed', () => {
+    const before = dedent`
+    ---
+    tag: tag1
+    created: Saturday, February 1st 2020, 12:00:00 am
+    location: "path"
+    ---
+    `;
+    const after = dedent`
+    ---
+    tag: tag1
+    created: Saturday, February 1st 2020
+    location: "path"
+    ---
+    `;
+
+    const options = {
+      'Date Created': true,
+      'Date Modified': false,
+      'Date Created Key': 'created',
+      'metadata: file created time': '2020-02-01T00:00:00-00:00',
+      'Format': 'dddd, MMMM Do YYYY',
+      'Already Modified': false,
+      'locale': 'en',
+    };
+    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+  });
+  it('Updates created value when locale has changed', () => {
+    const before = dedent`
+    ---
+    tag: tag1
+    created: Saturday, February 1st 2020, 12:00:00 am
+    location: "path"
+    ---
+    `;
+    const after = dedent`
+    ---
+    tag: tag1
+    created: samedi, février 1er 2020, 12:00:00 am
+    location: "path"
+    ---
+    `;
+
+    const options = {
+      'Date Created': true,
+      'Date Modified': false,
+      'Date Created Key': 'created',
+      'metadata: file created time': '2020-02-01T00:00:00-00:00',
+      'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'Already Modified': false,
+      'locale': 'fr',
+    };
+    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+  });
+  it('Updates modified value when format has changed causing created value updated', () => {
+    const before = dedent`
+    ---
+    tag: tag1
+    modified: Saturday, February 1st 2020, 12:00:00 am
+    created: Wednesday, January 1st 2020
+    location: "path"
+    ---
+    `;
+    const after = dedent`
+    ---
+    tag: tag1
+    modified: Sunday, February 2nd 2020, 12:00:00 am
+    created: Wednesday, January 1st 2020, 12:00:00 am
+    location: "path"
+    ---
+    `;
+
+    const options = {
+      'Date Created': true,
+      'Date Modified': true,
+      'Date Modified Key': 'modified',
+      'Date Created Key': 'created',
+      'metadata: file created time': '2020-01-01T00:00:00-00:00',
+      'metadata: file modified time': '2020-02-02T00:00:00-00:00',
+      'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'Already Modified': false,
+      'locale': 'en',
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,5 @@
 import dedent from 'ts-dedent';
+import moment from 'moment';
 import {rules, Rule, rulesDict, Example, getDisabledRules} from './rules';
 import {escapeRegExp, yamlRegex} from './utils';
 
@@ -576,7 +577,7 @@ describe('yaml timestamp', () => {
     date created: 2019-01-01
     ---
     `;
-    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'date created', 'locale': 'en'})).toBe(after);
+    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'date created', 'moment': moment})).toBe(after);
   });
   it('Respects created key', () => {
     const before = dedent`
@@ -589,7 +590,7 @@ describe('yaml timestamp', () => {
     created: 2019-01-01
     ---
     `;
-    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'created', 'locale': 'en'})).toBe(after);
+    expect(rulesDict['yaml-timestamp'].apply(before, {'Date Created': true, 'Date Created Key': 'created', 'moment': moment})).toBe(after);
   });
   it('Respects modified key when nothing has changed', () => {
     const before = dedent`
@@ -610,7 +611,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-01-01T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -633,7 +634,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-01-02T00:00:00-00:00',
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'Already Modified': false,
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -656,7 +657,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-01-01T00:00:00-00:00',
       'Format': 'dddd, MMMM Do YYYY',
       'Already Modified': false,
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -679,7 +680,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-02-01T00:00:00-00:00',
       'Already Modified': true,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -695,6 +696,7 @@ describe('yaml timestamp', () => {
     ---
     `;
 
+    moment.locale('fr');
     const options = {
       'Date Created': false,
       'Date Modified': true,
@@ -702,9 +704,10 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-02-01T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
-      'locale': 'fr',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+    moment.locale('en');
   });
   it('Updates modified key when something has changed inside of the YAML timestamp rule', () => {
     const before = dedent`
@@ -728,7 +731,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-01-02T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -755,7 +758,7 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-02-01T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -782,7 +785,7 @@ describe('yaml timestamp', () => {
       'metadata: file created time': '2020-02-01T00:00:00-00:00',
       'Already Modified': false,
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -809,7 +812,7 @@ describe('yaml timestamp', () => {
       'metadata: file created time': '2020-02-01T00:00:00-00:00',
       'Format': 'dddd, MMMM Do YYYY',
       'Already Modified': false,
-      'locale': 'en',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });
@@ -829,6 +832,7 @@ describe('yaml timestamp', () => {
     ---
     `;
 
+    moment.locale('fr');
     const options = {
       'Date Created': true,
       'Date Modified': false,
@@ -836,9 +840,10 @@ describe('yaml timestamp', () => {
       'metadata: file created time': '2020-02-01T00:00:00-00:00',
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'Already Modified': false,
-      'locale': 'fr',
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+    moment.locale('en');
   });
   it('Updates modified value when format has changed causing created value updated', () => {
     const before = dedent`
@@ -867,7 +872,40 @@ describe('yaml timestamp', () => {
       'metadata: file modified time': '2020-02-02T00:00:00-00:00',
       'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
       'Already Modified': false,
-      'locale': 'en',
+      'moment': moment,
+    };
+    expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
+  });
+
+  it('Updates modified value when nothing has changed if always update date modified setting is on', () => {
+    const before = dedent`
+    ---
+    tag: tag1
+    modified: Saturday, February 1st 2020, 12:00:00 am
+    created: Wednesday, January 1st 2020, 12:00:00 am
+    location: "path"
+    ---
+    `;
+    const after = dedent`
+    ---
+    tag: tag1
+    modified: Sunday, February 2nd 2020, 12:00:00 am
+    created: Wednesday, January 1st 2020, 12:00:00 am
+    location: "path"
+    ---
+    `;
+
+    const options = {
+      'Date Created': true,
+      'Date Modified': true,
+      'Date Modified Key': 'modified',
+      'Date Created Key': 'created',
+      'metadata: file created time': '2020-01-01T00:00:00-00:00',
+      'metadata: file modified time': '2020-02-02T00:00:00-00:00',
+      'Format': 'dddd, MMMM Do YYYY, h:mm:ss a',
+      'Already Modified': false,
+      'Always Update Date Modified': true,
+      'moment': moment,
     };
     expect(rulesDict['yaml-timestamp'].apply(before, options)).toBe(after);
   });


### PR DESCRIPTION
Fixes #214 
Fixes #240 
Fixes #143 

Changes Made:
- Date modified and date created are updated on format change
- Date modified is updated if file changed time is more than 5 seconds away from the value in the yaml
  - This does not change the fact that the linter must be triggered manually 
- Locale can now be set for the plugin
- Date Created and Modified are updated on locale change
- Used the current time from just before the modified and created key rule is run to update the modified at time to prevent an issue where you modify a file and come back more than 5 seconds later and lint (this would use the old metadata which would be older than 5 seconds) then when the next time the linter is run, it would update the yaml value despite nothing truly changing until this were done two times in uder 5 seconds
- Added tests for the above scenarios