### PR TITLE
Make Logging Simpler and Human Readable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/js-yaml": "^4.0.3",
         "diff-match-patch": "^1.0.5",
         "js-yaml": "^3.14.1",
+        "loglevel": "^1.8.0",
         "moment": "^2.29.2",
         "remark": "^14.0.1",
         "remark-gfm": "^3.0.0",
@@ -5772,6 +5773,18 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
+    },
+    "node_modules/loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.0.0",
@@ -12708,6 +12721,11 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
+    },
+    "loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
     },
     "longest-streak": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/js-yaml": "^4.0.3",
     "diff-match-patch": "^1.0.5",
     "js-yaml": "^3.14.1",
+    "loglevel": "^1.8.0",
     "moment": "^2.29.2",
     "remark": "^14.0.1",
     "remark-gfm": "^3.0.0",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,84 @@
+import log from 'loglevel';
+
+const logPrefix: string = '[Obsidian Linter]';
+
+/**
+ * Allows for the logging of errors
+ * @param {string} labelForError The label for the error
+ * @param {Error} error The error that is to be logged to the console
+ */
+export function logError(labelForError: string, error: Error) {
+  let message = `${logPrefix} ${labelForError}:` + '\n';
+  if (error.stack) {
+    message += error.stack;
+  } else {
+    message += `${error.name} ${error.message}`;
+  }
+
+  log.error(message);
+}
+
+/**
+ * Allows for the logging of a message as info in the console
+ * @param {string} message The message to log to the console
+ */
+export function logInfo(message: string) {
+  log.info(`${logPrefix} ${message}`);
+}
+
+/**
+ * Allows for the logging of a message as a trace in the console
+ * @param {string} message The message to log to the console
+ */
+export function logTrace(message: string) {
+  log.trace(`${logPrefix} ${message}`);
+}
+
+/**
+ * Allows for the logging of a message as debug info in the console
+ * @param {string} message The message to log to the console
+ */
+export function logDebug(message: string) {
+  log.debug(`${logPrefix} ${message}`);
+}
+
+/**
+ * Allows for the logging of a message as a warning in the console
+ * @param {string} message The message to log to the console
+ */
+export function logWarn(message: string) {
+  log.warn(`${logPrefix} ${message}`);
+}
+
+/**
+ * Allows the user to set the minimum logging level to display messages for
+ * @param {number} logLevel The minimum log level to display in the console
+ */
+export function setLogLevel(logLevel: number) {
+  switch (logLevel) {
+    case log.levels.INFO: {
+      log.setLevel('info');
+      break;
+    }
+    case log.levels.TRACE: {
+      log.setLevel('trace');
+      break;
+    }
+    case log.levels.DEBUG: {
+      log.setLevel('debug');
+      break;
+    }
+    case log.levels.SILENT: {
+      log.setLevel('silent');
+      break;
+    }
+    case log.levels.ERROR: {
+      log.setLevel('error');
+      break;
+    }
+    case log.levels.WARN: {
+      log.setLevel('warn');
+      break;
+    }
+  }
+}

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -36,6 +36,7 @@ export interface LinterSettings {
   displayChanged: boolean;
   foldersToIgnore: string[];
   linterLocale: string;
+  logLevel: number;
 }
 /* eslint-disable no-unused-vars */
 enum RuleType {


### PR DESCRIPTION
Updated logging to make output human readable and allow for setting the level of logs to see from the plugin. This is meant to be a dev feature right now which is why it does not include an option in the settings tab. We can add that later if we deem it necessary or desired.

Changes Made:
- Added loglevel as a small logging package to help filter logs for the plugin based on log level
  - The default for the plugin is error 
- Added a logging file that exports methods needed for logging
- Added a setting for log level and defaulted it to error when no other value is present in the `data.json`
- Fixed a variable name typo
- Updated console logs to their corresponding logger method usage