### PR TITLE
Handle More Complex Paragraphs for Paragraph Blank Lines

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -13,6 +13,7 @@ import {
   escapeYamlString,
   makeEmphasisOrBoldConsistent,
   addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent,
+  makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs,
   removeSpacesInLinkText,
 } from './utils';
 import {
@@ -300,12 +301,7 @@ export const rules: Rule[] = [
       'All paragraphs should have exactly one blank line both before and after.',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
-          text = text.replace(/\n+([a-zA-Z].*)/g, '\n\n$1'); // trim blank lines before
-          text = text.replace(/(^[a-zA-Z].*)\n+/gm, '$1\n\n'); // trim blank lines after
-          text = text.replace(/^\n+([a-zA-Z].*)/, '$1'); // remove blank lines before first line
-          return text;
-        });
+        return makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs(text);
       },
       [
         new Example(

--- a/src/test.ts
+++ b/src/test.ts
@@ -343,6 +343,123 @@ describe('Paragraph blank lines', () => {
     `;
     expect(rulesDict['paragraph-blank-lines'].apply(before)).toBe(after);
   });
+  // accounts for https://github.com/platers/obsidian-linter/issues/250
+  it('Paragraphs that start with numbers are spaced out', () => {
+    const before = dedent`
+    # Hello world
+
+
+    123 foo
+    123 bar
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    123 foo
+
+    123 bar
+    `;
+
+    expect(rulesDict['paragraph-blank-lines'].apply(before)).toBe(after);
+  });
+  // accounts for https://github.com/platers/obsidian-linter/issues/250
+  it('Paragraphs that start with foreign characters are spaced out', () => {
+    const before = dedent`
+    # Hello world
+
+
+    测试 foo
+    测试 bar
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    测试 foo
+
+    测试 bar
+    `;
+
+    expect(rulesDict['paragraph-blank-lines'].apply(before)).toBe(after);
+  });
+  // accounts for https://github.com/platers/obsidian-linter/issues/250
+  it('Paragraphs that start with whitespace characters are spaced out', () => {
+    const before = dedent`
+    # Hello world
+
+     foo
+     bar
+    `;
+
+    const after = dedent`
+    # Hello world
+
+     foo
+
+     bar
+    `;
+
+    expect(rulesDict['paragraph-blank-lines'].apply(before)).toBe(after);
+  });
+  it('Make sure blockquotes are not affected', () => {
+    const before = dedent`
+    # Hello world
+
+    > blockquote
+    > blockquote line 2
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    > blockquote
+    > blockquote line 2
+    `;
+
+    expect(rulesDict['paragraph-blank-lines'].apply(before)).toBe(after);
+  });
+  it('Make sure lists are not affected', () => {
+    const before = dedent`
+    # Hello world
+
+    > blockquote
+    > blockquote line 2
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    > blockquote
+    > blockquote line 2
+    `;
+
+    expect(rulesDict['paragraph-blank-lines'].apply(before)).toBe(after);
+  });
+  it('Make sure lines ending in a line break are not affected', () => {
+    const before = dedent`
+    # Hello world
+
+
+    paragraph line 1 <br>
+    paragraph line 2  
+    paragraph line 3 <br/>
+    paragraph final line
+
+
+    `;
+
+    const after = dedent`
+    # Hello world
+
+    paragraph line 1 <br>
+    paragraph line 2  
+    paragraph line 3 <br/>
+    paragraph final line
+    `;
+
+    expect(rulesDict['paragraph-blank-lines'].apply(before)).toBe(after);
+  });
 });
 describe('Consecutive blank lines', () => {
   it('Handles ignores code blocks', () => {


### PR DESCRIPTION
Fixes #250 

Added a more complex setup for handling paragraph content when trying to add blank lines before and after it.

Changes Made:
- added several new tests for the scenarios listed in the issue and for a couple more that could have been affected by the use of the paragraph parser
- Updated logic to replace simpler use of regex for a more complex function to handle scenarios from the issue