### PR TITLE
Remove Space Around Fullwidth Punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
 - [line-break-at-document-end](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#line-break-at-document-end)
 - [space-between-chinese-and-english-or-numbers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-between-chinese-and-english-or-numbers)
+- [remove-space-around-chinese-punctuation](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-space-around-chinese-punctuation)
 - [remove-link-spacing](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-link-spacing)
 
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1747,6 +1747,42 @@ After:
 #标签A #标签2标签
 ```
 
+### Remove Space around Chinese Punctuation
+
+Alias: `remove-space-around-chinese-punctuation`
+
+Ensures that Chinese/fullwidth punctuation is not followed by whitespace (either single spaces or a tab)
+
+
+
+Example: Remove Spaces and Tabs around Fullwidth Punctuation
+
+Before:
+
+```markdown
+This is a fullwidth period	 。 with text after it.
+This is a fullwidth comma	，  with text after it.
+This is a fullwidth left parenthesis （ 	with text after it.
+This is a fullwidth right parenthesis ）  with text after it.
+This is a fullwidth opening double quote	 	“  with text after it.
+This is a fullwidth opening single ”  	with text after it.
+This is a fullwidth colon ：  with text after it.
+This is a fullwidth semicolon ；  with text after it.
+```
+
+After:
+
+```markdown
+This is a fullwidth period。with text after it.
+This is a fullwidth comma，with text after it.
+This is a fullwidth left parenthesis（with text after it.
+This is a fullwidth right parenthesis）with text after it.
+This is a fullwidth opening double quote“with text after it.
+This is a fullwidth opening single”with text after it.
+This is a fullwidth colon：with text after it.
+This is a fullwidth semicolon；with text after it.
+```
+
 ### Remove link spacing
 
 Alias: `remove-link-spacing`

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2369,6 +2369,42 @@ export const rules: Rule[] = [
       ],
   ),
   new Rule(
+      'Remove Space around Chinese Punctuation',
+      'Ensures that Chinese/fullwidth punctuation is not followed by whitespace (either single spaces or a tab)',
+      RuleType.SPACING,
+      (text: string) => {
+        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+          return text.replace(/([ \t])+([\u3002\uFF08\uFF0C\uFF09\u201C\u201D\uFF1A\uFF1B])/g, '$2').replace(/([\u3002\uFF08\uFF0C\uFF09\u201C\u201D\uFF1A\uFF1B])([ \t])+/g, '$1');
+        });
+      },
+      [
+
+        new Example(
+            'Remove Spaces and Tabs around Fullwidth Punctuation',
+            dedent`
+          This is a fullwidth period\t 。 with text after it.
+          This is a fullwidth comma\t，  with text after it.
+          This is a fullwidth left parenthesis （ \twith text after it.
+          This is a fullwidth right parenthesis ）  with text after it.
+          This is a fullwidth opening double quote\t \t“  with text after it.
+          This is a fullwidth opening single ”  \twith text after it.
+          This is a fullwidth colon ：  with text after it.
+          This is a fullwidth semicolon ；  with text after it.
+      `,
+            dedent`
+          This is a fullwidth period。with text after it.
+          This is a fullwidth comma，with text after it.
+          This is a fullwidth left parenthesis（with text after it.
+          This is a fullwidth right parenthesis）with text after it.
+          This is a fullwidth opening double quote“with text after it.
+          This is a fullwidth opening single”with text after it.
+          This is a fullwidth colon：with text after it.
+          This is a fullwidth semicolon；with text after it.
+      `,
+        ),
+      ],
+  ),
+  new Rule(
       'Remove link spacing',
       'Removes spacing around link text.',
       RuleType.SPACING,


### PR DESCRIPTION
It was brought to my attention that there is such a thing as fullwidth punctuation and that English uses halfwidth punctuation. Fullwidth punctuation should not have spaces around it, so a rule has been added that should address that.

Changes Made:
- Added a rule with an example of what it does with removing whitespace around fullwidth punctuation