### PR TITLE
Add Table Regex and Ignore Table Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [consecutive-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#consecutive-blank-lines)
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
 - [line-break-at-document-end](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#line-break-at-document-end)
+- [empty-line-around-tables](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#empty-line-around-tables)
 - [space-between-chinese-and-english-or-numbers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-between-chinese-and-english-or-numbers)
 - [remove-space-around-fullwidth-characters](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-space-around-fullwidth-characters)
 - [remove-link-spacing](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-link-spacing)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1868,6 +1868,104 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 
 ``````
 
+### Empty Line Around Tables
+
+Alias: `empty-line-around-tables`
+
+Ensures that there is an empty line around tables unless they start or end a document.
+
+
+
+Example: Tables that start a document do not get an empty line before them.
+
+Before:
+
+``````markdown
+| Column 1 | Column 2 |
+|----------|----------|
+| foo      | bar      |
+| baz      | qux      |
+| quux     | quuz     |
+New paragraph.
+``````
+
+After:
+
+``````markdown
+| Column 1 | Column 2 |
+|----------|----------|
+| foo      | bar      |
+| baz      | qux      |
+| quux     | quuz     |
+
+New paragraph.
+``````
+Example: Tables that end a document do not get an empty line after them.
+
+Before:
+
+``````markdown
+# Heading 1
+| Column 1 | Column 2 |
+|----------|----------|
+| foo      | bar      |
+| baz      | qux      |
+| quux     | quuz     |
+``````
+
+After:
+
+``````markdown
+# Heading 1
+
+| Column 1 | Column 2 |
+|----------|----------|
+| foo      | bar      |
+| baz      | qux      |
+| quux     | quuz     |
+``````
+Example: Tables that are not at the start or the end of the document will have an empty line added before and after them
+
+Before:
+
+``````markdown
+# Table 1
+| Column 1 | Column 2 | Column 3 |
+|----------|----------|----------|
+| foo      | bar      | blob     |
+| baz      | qux      | trust    |
+| quux     | quuz     | glob     |
+# Table 2
+| Column 1 | Column 2 |
+|----------|----------|
+| foo      | bar      |
+| baz      | qux      |
+| quux     | quuz     |
+New paragraph.
+``````
+
+After:
+
+``````markdown
+# Table 1
+
+| Column 1 | Column 2 | Column 3 |
+|----------|----------|----------|
+| foo      | bar      | blob     |
+| baz      | qux      | trust    |
+| quux     | quuz     | glob     |
+
+# Table 2
+
+| Column 1 | Column 2 |
+|----------|----------|
+| foo      | bar      |
+| baz      | qux      |
+| quux     | quuz     |
+
+New paragraph.
+``````
+
 ### Space between Chinese and English or numbers
 
 Alias: `space-between-chinese-and-english-or-numbers`

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -20,6 +20,8 @@ import {
   getYamlSectionValue,
   removeYamlSection,
   ignoreObsidianMultilineComments,
+  ignoreTables,
+  ensureEmptyLinesAroundTables,
 } from './utils';
 import {
   Option,
@@ -648,9 +650,9 @@ export const rules: Rule[] = [
       'Removes two or more consecutive spaces. Ignores spaces at the beginning and ending of the line. ',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreTables(text, (text) => ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
           return text.replace(/([^\s])( ){2,}([^\s])/g, '$1 $3');
-        });
+        }));
       },
       [
         new Example(
@@ -1274,6 +1276,94 @@ export const rules: Rule[] = [
             Even more content here
 
         `,
+        ),
+      ],
+  ),
+
+  new Rule(
+      'Empty Line Around Tables',
+      'Ensures that there is an empty line around tables unless they start or end a document.',
+      RuleType.SPACING,
+      (text: string) => {
+        return ensureEmptyLinesAroundTables(text);
+      },
+      [
+        new Example(
+            'Tables that start a document do not get an empty line before them.',
+            dedent`
+        | Column 1 | Column 2 |
+        |----------|----------|
+        | foo      | bar      |
+        | baz      | qux      |
+        | quux     | quuz     |
+        New paragraph.
+  `,
+            dedent`
+        | Column 1 | Column 2 |
+        |----------|----------|
+        | foo      | bar      |
+        | baz      | qux      |
+        | quux     | quuz     |
+        
+        New paragraph.
+  `,
+        ),
+        new Example(
+            'Tables that end a document do not get an empty line after them.',
+            dedent`
+        # Heading 1
+        | Column 1 | Column 2 |
+        |----------|----------|
+        | foo      | bar      |
+        | baz      | qux      |
+        | quux     | quuz     |
+  `,
+            dedent`
+        # Heading 1
+
+        | Column 1 | Column 2 |
+        |----------|----------|
+        | foo      | bar      |
+        | baz      | qux      |
+        | quux     | quuz     |
+  `,
+        ),
+        new Example(
+            'Tables that are not at the start or the end of the document will have an empty line added before and after them',
+            dedent`
+      # Table 1
+      | Column 1 | Column 2 | Column 3 |
+      |----------|----------|----------|
+      | foo      | bar      | blob     |
+      | baz      | qux      | trust    |
+      | quux     | quuz     | glob     |
+      # Table 2
+      | Column 1 | Column 2 |
+      |----------|----------|
+      | foo      | bar      |
+      | baz      | qux      |
+      | quux     | quuz     |
+      New paragraph.
+`,
+            dedent`
+      # Table 1
+      
+      | Column 1 | Column 2 | Column 3 |
+      |----------|----------|----------|
+      | foo      | bar      | blob     |
+      | baz      | qux      | trust    |
+      | quux     | quuz     | glob     |
+      
+      # Table 2
+
+      | Column 1 | Column 2 |
+      |----------|----------|
+      | foo      | bar      |
+      | baz      | qux      |
+      | quux     | quuz     |
+      
+      New paragraph.
+`,
         ),
       ],
   ),

--- a/src/test/remove-multiple-spaces.test.ts
+++ b/src/test/remove-multiple-spaces.test.ts
@@ -52,4 +52,47 @@ describe('Remove Multiple Spaces', () => {
 
     expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
   });
+  it('Tables are ignored', () => {
+    const before = dedent`
+    # Table 1
+      
+    | Column 1 | Column 2 | Column 3 |
+    |----------|----------|----------|
+    | foo      | bar      | blob     |
+    | baz      | qux      | trust    |
+    | quux     | quuz     | glob     |
+    
+    # Table 2
+
+    | Column 1 | Column 2 |
+    |----------|----------|
+    | foo      | bar      |
+    | baz      | qux      |
+    | quux     | quuz     |
+    
+    New paragraph.
+      `;
+
+    const after = dedent`
+      # Table 1
+        
+      | Column 1 | Column 2 | Column 3 |
+      |----------|----------|----------|
+      | foo      | bar      | blob     |
+      | baz      | qux      | trust    |
+      | quux     | quuz     | glob     |
+      
+      # Table 2
+
+      | Column 1 | Column 2 |
+      |----------|----------|
+      | foo      | bar      |
+      | baz      | qux      |
+      | quux     | quuz     |
+      
+      New paragraph.
+      `;
+
+    expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
+  });
 });


### PR DESCRIPTION
Fixes #194 
Fixes #244 

Makes sure that a table that does not start a file gets a blank line before it and a table that does not end a file gets a blank line after it. Also makes sure to ignore tables for removing multiple spaces as that is a part of the formatting.

Changes Made:
- Added table regex
- Added ability to ignore a table if need be
- Added a method for having a blank line before and after a table (unless it starts and or ends the file and thus does not get a blank line there)