### PR TITLE
Table Regex Includes Full Table when Pipes at Start and End are Missing

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1935,12 +1935,11 @@ Before:
 | foo      | bar      | blob     |
 | baz      | qux      | trust    |
 | quux     | quuz     | glob     |
-# Table 2
+# Table 2 without Pipe at Start and End
 | Column 1 | Column 2 |
-|----------|----------|
-| foo      | bar      |
-| baz      | qux      |
-| quux     | quuz     |
+:-: | -----------:
+bar | baz
+foo | bar
 New paragraph.
 ``````
 
@@ -1955,13 +1954,12 @@ After:
 | baz      | qux      | trust    |
 | quux     | quuz     | glob     |
 
-# Table 2
+# Table 2 without Pipe at Start and End
 
 | Column 1 | Column 2 |
-|----------|----------|
-| foo      | bar      |
-| baz      | qux      |
-| quux     | quuz     |
+:-: | -----------:
+bar | baz
+foo | bar
 
 New paragraph.
 ``````

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1337,12 +1337,11 @@ export const rules: Rule[] = [
       | foo      | bar      | blob     |
       | baz      | qux      | trust    |
       | quux     | quuz     | glob     |
-      # Table 2
+      # Table 2 without Pipe at Start and End
       | Column 1 | Column 2 |
-      |----------|----------|
-      | foo      | bar      |
-      | baz      | qux      |
-      | quux     | quuz     |
+      :-: | -----------:
+      bar | baz
+      foo | bar
       New paragraph.
 `,
             dedent`
@@ -1354,13 +1353,12 @@ export const rules: Rule[] = [
       | baz      | qux      | trust    |
       | quux     | quuz     | glob     |
       
-      # Table 2
-
+      # Table 2 without Pipe at Start and End
+      
       | Column 1 | Column 2 |
-      |----------|----------|
-      | foo      | bar      |
-      | baz      | qux      |
-      | quux     | quuz     |
+      :-: | -----------:
+      bar | baz
+      foo | bar
       
       New paragraph.
 `,

--- a/src/test/remove-multiple-spaces.test.ts
+++ b/src/test/remove-multiple-spaces.test.ts
@@ -52,6 +52,7 @@ describe('Remove Multiple Spaces', () => {
 
     expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
   });
+  // accounts for https://github.com/platers/obsidian-linter/issues/244
   it('Tables are ignored', () => {
     const before = dedent`
     # Table 1

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeB
 export const wikiLinkRegex = /(!?)(\[{2}[^[\n\]]*\]{2})/g;
 export const tagRegex = /#[^\s#]{1,}/g;
 export const obsidianMultilineCommentRegex = /%%\n[^%]*\n%%/g;
-export const tableRegex = /([ ]{0,3}\[.*?\][ \t]*\n)?([ ]{0,3}\S+.*?\|.*?\n([^\n]*?\|[^\n]*?\n)*?)?[ ]{0,3}[|\-+:.][ \-+|:.]*?\|[ \-+|:.]*(?:\n?[^\n]*?\|[^\n]*?(\n)?)+/g;
+export const tableRegex = /([ ]{0,3}\[.*?\][ \t]*\n)?([ ]{0,3}\S+.*?\|.*?\n([^\n]*?\|[^\n]*?\n)*?)?[ ]{0,3}[|\-+:.][ \-+|:.]*?\|[ \-+|:.]*(?:\n?[^\n]*?\|([^\n]*?)*(\n)?)+/g;
 
 // Reused placeholders
 


### PR DESCRIPTION
Makes sure that the following is considered a table instead of just up to `bar |`
``` markdown
| column 1 | column 2 |
:-: | -----------:
bar | baz
```

Changes Made:
- Updated example to show a table without pipes at the start and end
- Made sure to account for the missing pipe at the start and end of the table line