### PR TITLE
Refactor Ignore Logic and Ignore Images for Bare URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ with making this plugin better.
 2. Clone the repository
 3. Run `npm ci` to install dependencies
 4. Add a new rule in `rules.ts`.
-   1. Insert a new rule in the corresponding rule type(spacing, headings, etc)
+   1. Insert a new rule in the corresponding rule type (spacing, headings, etc)
    2. Follow the format of the existing rules
    3. Add tests for edge cases in `src/test/rule_alias_here.test.ts`
-   4. You should probably use some helper functions from `utils.ts`, such as `ignoreCodeBlocksYAMLTagsAndLinks`.
+   4. You should probably use some helper functions from `utils.ts`, such as `formatYAML`.
 5. Run `npm run compile` to build, generate documentation, and test the plugin.
 6. Run `npm run lint` to lint the plugin.
 

--- a/src/ignore-types.ts
+++ b/src/ignore-types.ts
@@ -1,0 +1,147 @@
+import {getPositions, escapeDollarSigns, obsidianMultilineCommentRegex, tableRegex, tagRegex, wikiLinkRegex, yamlPlaceholder, yamlRegex} from './utils';
+import type {Position} from 'unist';
+
+
+export type IgnoreResults = {replacedValues: string[], newText: string};
+export type IgnoreFunction = ((text: string, placeholder: string) => IgnoreResults);
+export type IgnoreType = {replaceAction: string | RegExp | IgnoreFunction, placeholder: string, replaceDollarSigns: boolean};
+
+export const IgnoreTypes: Record<string, IgnoreType> = {
+  // mdast node types
+  code: {replaceAction: 'code', placeholder: '{CODE_BLOCK_PLACEHOLDER}', replaceDollarSigns: true},
+  image: {replaceAction: 'image', placeholder: '{IMAGE_PLACEHOLDER}', replaceDollarSigns: false},
+  // RegExp
+  yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns(yamlPlaceholder), replaceDollarSigns: true},
+  wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}', replaceDollarSigns: false},
+  tag: {replaceAction: tagRegex, placeholder: '#tag-placeholder', replaceDollarSigns: false},
+  table: {replaceAction: tableRegex, placeholder: '{TABLE_PLACEHOLDER}', replaceDollarSigns: false},
+  obsidianMultiLineComments: {replaceAction: obsidianMultilineCommentRegex, placeholder: '{OBSIDIAN_COMMENT_PLACEHOLDER}', replaceDollarSigns: false},
+  // custom functions
+  link: {replaceAction: replaceMarkdownLinks, placeholder: '{REGULAR_LINK_PLACEHOLDER}', replaceDollarSigns: false},
+};
+
+export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
+  let setOfPlaceholders: {placeholder: string, replacedValues: string[], replaceDollarSigns: boolean}[] = [];
+
+  // replace ignore blocks with their placeholders
+  for (const ignoreType of ignoreTypes) {
+    let ignoredResult: IgnoreResults;
+    if (typeof ignoreType.replaceAction === 'string') { // mdast
+      ignoredResult = replaceMdastType(text, ignoreType.placeholder, ignoreType.replaceAction);
+    } else if (ignoreType.replaceAction instanceof RegExp) {
+      ignoredResult = replaceRegex(text, ignoreType.placeholder, ignoreType.replaceAction);
+    } else if (typeof ignoreType.replaceAction === 'function') {
+      const ignoreFunc: IgnoreFunction = ignoreType.replaceAction;
+      ignoredResult = ignoreFunc(text, ignoreType.placeholder);
+    }
+
+    text = ignoredResult.newText;
+    setOfPlaceholders.push({replacedValues: ignoredResult.replacedValues, placeholder: ignoreType.placeholder, replaceDollarSigns: ignoreType.replaceDollarSigns});
+  }
+
+  text = func(text);
+
+  setOfPlaceholders = setOfPlaceholders.reverse();
+  // add back values that were replaced with their placeholders
+  if (setOfPlaceholders != null && setOfPlaceholders.length > 0) {
+    setOfPlaceholders.forEach((replacedInfo: {placeholder: string, replacedValues: string[], replaceDollarSigns: boolean}) => {
+      replacedInfo.replacedValues.forEach((replacedValue: string) => {
+        if (replacedInfo.replaceDollarSigns == true) {
+          replacedValue = escapeDollarSigns(replacedValue);
+        }
+
+        // Regex was added to fix capitalization issue  where another rule made the text not match the original place holder's case
+        // see https://github.com/platers/obsidian-linter/issues/201
+        text = text.replace(new RegExp(replacedInfo.placeholder, 'i'), replacedValue);
+      });
+    });
+  }
+
+  return text;
+}
+
+/**
+ * Replaces all mdast type instances in the given text with a placeholder.
+ * @param {string} text The text to replace the given mdast node type in
+ * @param {string} placeholder The placeholder to use
+ * @param {string} type The type of node to ignore by replacing with the specified placeholder
+ * @return {string} The text with mdast nodes types specified replaced
+ * @return {string[]} The mdast nodes values replaced
+ */
+function replaceMdastType(text: string, placeholder: string, type: string): IgnoreResults {
+  const positions: Position[] = getPositions(type, text);
+  const replacedValues: string[] = [];
+
+  for (const position of positions) {
+    const valueToReplace = text.substring(position.start.offset, position.end.offset);
+    replacedValues.push(valueToReplace);
+    text = text.substring(0, position.start.offset) + placeholder + text.substring(position.end.offset);
+  }
+
+  // Reverse the replaced values so that they are in the same order as the original text
+  replacedValues.reverse();
+
+  return {newText: text, replacedValues};
+}
+
+/**
+ * Replaces all regex matches in the given text with a placeholder.
+ * @param {string} text The text to replace the regex matches in
+ * @param {string} placeholder The placeholder to use
+ * @param {RegExp} regex The regex to use to find what to replace with the placeholder
+ * @return {string} The text with regex matches replaced
+ * @return {string[]} The regex matches replaced
+ */
+function replaceRegex(text: string, placeholder: string, regex: RegExp): IgnoreResults {
+  const regexMatches = text.match(regex);
+  const textMatches: string[] = [];
+  if (regex.flags.includes('g')) {
+    text = text.replaceAll(regex, placeholder);
+
+    if (regexMatches) {
+      for (const matchText of regexMatches) {
+        textMatches.push(matchText);
+      }
+    }
+  } else {
+    text = text.replace(regex, placeholder);
+
+    if (regexMatches) {
+      textMatches.push(regexMatches[0]);
+    }
+  }
+
+  return {newText: text, replacedValues: textMatches};
+}
+
+/**
+ * Replaces all markdown links in the given text with a placeholder.
+ * @param {string} text The text to replace links in
+ * @param {string} regularLinkPlaceholder The placeholder to use for regular markdown links
+ * @return {string} The text with links replaced
+ * @return {string[]} The regular markdown links replaced
+ */
+function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): IgnoreResults {
+  const positions: Position[] = getPositions('link', text);
+  const replacedRegularLinks: string[] = [];
+
+  for (const position of positions) {
+    if (position == undefined) {
+      continue;
+    }
+
+    const regularLink = text.substring(position.start.offset, position.end.offset);
+    // skip links that are not in markdown format
+    if (!regularLink.includes('[')) {
+      continue;
+    }
+
+    replacedRegularLinks.push(regularLink);
+    text = text.substring(0, position.start.offset) + regularLinkPlaceholder + text.substring(position.end.offset);
+  }
+
+  // Reverse the regular links so that they are in the same order as the original text
+  replacedRegularLinks.reverse();
+
+  return {newText: text, replacedValues: replacedRegularLinks};
+}

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -4,7 +4,6 @@ import {
   escapeDollarSigns,
   formatYAML,
   headerRegex,
-  ignoreCodeBlocksYAMLTagsAndLinks,
   initYAML,
   insert,
   loadYAML,
@@ -19,8 +18,6 @@ import {
   setYamlSection,
   getYamlSectionValue,
   removeYamlSection,
-  ignoreObsidianMultilineComments,
-  ignoreTables,
   ensureEmptyLinesAroundTables,
 } from './utils';
 import {
@@ -32,6 +29,7 @@ import {
   DropdownRecord,
   TextAreaOption,
 } from './option';
+import {ignoreListOfTypes, IgnoreTypes} from './ignore-types';
 
 export type Options = { [optionName: string]: any };
 type ApplyFunction = (text: string, options?: Options) => string;
@@ -196,7 +194,7 @@ export const rules: Rule[] = [
       'Removes extra spaces after every line.',
       RuleType.SPACING,
       (text: string, options = {}) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           if (options['Two Space Linebreak'] === false) {
             return text.replace(/[ \t]+$/gm, '');
           } else {
@@ -241,7 +239,7 @@ export const rules: Rule[] = [
       'All headings have a blank line both before and after (except where the heading is at the beginning or end of the document).',
       RuleType.SPACING,
       (text: string, options = {}) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           if (options['Bottom'] === false) {
             text = text.replace(/(^#+\s.*)\n+/gm, '$1\n'); // trim blank lines after headings
             text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
@@ -308,7 +306,7 @@ export const rules: Rule[] = [
       'All paragraphs should have exactly one blank line both before and after.',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreObsidianMultilineComments(text, makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs);
+        return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml], text, makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs);
       },
       [
         new Example(
@@ -333,7 +331,7 @@ export const rules: Rule[] = [
       'There should be a single space after list markers and checkboxes.',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
         // Space after marker
           text = text.replace(/^(\s*\d+\.|\s*[-+*])[^\S\r\n]+/gm, '$1 ');
           // Space after checkbox
@@ -370,7 +368,7 @@ export const rules: Rule[] = [
       'There should not be any empty lines between list markers and checklists.',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           const replaceEmptyLinesBetweenList = function(text: string, listRegex: RegExp, replaceWith: string): string {
             let match;
             let newText = text;
@@ -540,7 +538,7 @@ export const rules: Rule[] = [
       'There should be at most one consecutive blank line.',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return text.replace(/\n{2,}/g, '\n\n');
         });
       },
@@ -566,7 +564,7 @@ export const rules: Rule[] = [
       'Converts leading spaces to tabs.',
       RuleType.SPACING,
       (text: string, options = {}) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           const tabsize = String(options['Tabsize']);
           const tabsize_regex = new RegExp(
               '^(\t*) {' + String(tabsize) + '}',
@@ -650,9 +648,9 @@ export const rules: Rule[] = [
       'Removes two or more consecutive spaces. Ignores spaces at the beginning and ending of the line. ',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreTables(text, (text) => ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.table, IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return text.replace(/([^\s])( ){2,}([^\s])/g, '$1 $3');
-        }));
+        });
       },
       [
         new Example(
@@ -671,7 +669,7 @@ export const rules: Rule[] = [
       'Removes hyphenated line breaks. Useful when pasting text from textbooks.',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return text.replace(/\b[-‐] \b/g, '');
         });
       },
@@ -692,7 +690,7 @@ export const rules: Rule[] = [
       'Removes consecutive list markers. Useful when copy-pasting list items.',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return text.replace(/^([ |\t]*)- - \b/gm, '$1- ');
         });
       },
@@ -721,7 +719,7 @@ export const rules: Rule[] = [
       'Removes empty list markers, i.e. list items without content.',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return text.replace(/^\s*-\s*\n/gm, '');
         });
       },
@@ -745,7 +743,7 @@ export const rules: Rule[] = [
       'Converts common bullet list marker symbols to markdown list markers.',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
         // Convert [•, §] to - if it's the first non space character on the line
           return text.replace(/^([^\S\n]*)([•§])([^\S\n]*)/gm, '$1-$3');
         });
@@ -782,7 +780,7 @@ export const rules: Rule[] = [
       'Replaces three consecutive dots with an ellipsis.',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return text.replaceAll('...', '…');
         });
       },
@@ -803,7 +801,7 @@ export const rules: Rule[] = [
       'Makes sure the emphasis style is consistent.',
       RuleType.CONTENT,
       (text: string, options = {}) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return makeEmphasisOrBoldConsistent(text, options['Style'], 'emphasis');
         });
       },
@@ -958,7 +956,7 @@ export const rules: Rule[] = [
       'Makes sure the strong style is consistent.',
       RuleType.CONTENT,
       (text: string, options = {}) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return makeEmphasisOrBoldConsistent(text, options['Style'], 'strong');
         });
       },
@@ -1113,7 +1111,7 @@ export const rules: Rule[] = [
       'Encloses bare URLs with angle brackets except when enclosed in back ticks, square braces, or single or double quotes.',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.image], text, (text) => {
           const URLMatches = text.match(/(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'">]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'">]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'">]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'">]{2,})/gi);
 
           if (!URLMatches) {
@@ -1191,7 +1189,7 @@ export const rules: Rule[] = [
       'Makes sure that two spaces are added to the ends of lines with content continued on the next line for paragraphs, blockquotes, and list items',
       RuleType.CONTENT,
       (text: string) => {
-        return ignoreObsidianMultilineComments(text, addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent);
+        return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml], text, addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent);
       },
       [
         new Example(
@@ -1354,7 +1352,7 @@ export const rules: Rule[] = [
       | quux     | quuz     | glob     |
       
       # Table 2 without Pipe at Start and End
-      
+
       | Column 1 | Column 2 |
       :-: | -----------:
       bar | baz
@@ -1690,7 +1688,7 @@ export const rules: Rule[] = [
       RuleType.YAML,
       (text: string, options = {}) => {
         text = initYAML(text);
-        let title = ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           const result = text.match(/^#\s+(.*)/m);
           if (result) {
             return result[1];
@@ -1767,7 +1765,7 @@ export const rules: Rule[] = [
         };
 
         text = initYAML(text);
-        let title = ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           const result = text.match(/^#\s+(.*)/m);
           if (result) {
             return result[1];
@@ -2466,7 +2464,7 @@ export const rules: Rule[] = [
       'Heading levels should only increment by one level at a time',
       RuleType.HEADING,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           const lines = text.split('\n');
           let lastLevel = 0; // level of last header processed
           let decrement = 0; // number of levels to decrement following headers
@@ -2570,7 +2568,7 @@ export const rules: Rule[] = [
       'Inserts the file name as a H1 heading if no H1 heading exists.',
       RuleType.HEADING,
       (text: string, options = {}) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
         // check if there is a H1 heading
           const hasH1 = text.match(/^#\s.*/m);
           if (hasH1) {
@@ -2621,7 +2619,7 @@ export const rules: Rule[] = [
       'Headings should be formatted with capitalization',
       RuleType.HEADING,
       (text: string, options = {}) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           const lines = text.split('\n');
           for (let i = 0; i < lines.length; i++) {
             const match = lines[i].match(headerRegex); // match only headings
@@ -2780,7 +2778,7 @@ export const rules: Rule[] = [
       'Move all footnotes to the bottom of the document.',
       RuleType.FOOTNOTE,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return moveFootnotesToEnd(text);
         });
       },
@@ -2814,7 +2812,7 @@ export const rules: Rule[] = [
       'Re-indexes footnote keys and footnote, based on the order of occurence (NOTE: This rule deliberately does *not* preserve the relation between key and footnote, to be able to re-index duplicate keys.)',
       RuleType.FOOTNOTE,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
         // re-index footnote-text
           let ft_index = 0;
           text = text.replace(/^\[\^\w+\]: /gm, function() {
@@ -2887,7 +2885,7 @@ export const rules: Rule[] = [
       'Ensures that footnote references are placed after punctuation, not before.',
       RuleType.FOOTNOTE,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
         // regex uses hack to treat lookahead as lookaround https://stackoverflow.com/a/43232659
         // needed to ensure that no footnote text followed by ":" is matched
           return text.replace(/(?!^)(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
@@ -2910,7 +2908,7 @@ export const rules: Rule[] = [
       'Ensures that Chinese and English or numbers are separated by a single space. Follow this [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           const head = /([\u4e00-\u9fa5])( *)(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+'"([{¥$]|\*[^*])/gm;
           const tail = /(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+;:'"°%)\]}]|[^*]\*)( *)([\u4e00-\u9fa5])/gm;
           return text.replace(head, '$1 $3').replace(tail, '$1 $3');
@@ -2961,12 +2959,11 @@ export const rules: Rule[] = [
       'Ensures that fullwidth characters are not followed by whitespace (either single spaces or a tab)',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreCodeBlocksYAMLTagsAndLinks(text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
           return text.replace(/([ \t])+([\u2013\u2014\u2026\u3001\u3002\u300a\u300d-\u300f\u3014\u3015\u3008-\u3011\uff00-\uffff])/g, '$2').replace(/([\u2013\u2014\u2026\u3001\u3002\u300a\u300d-\u300f\u3014\u3015\u3008-\u3011\uff00-\uffff])([ \t])+/g, '$1');
         });
       },
       [
-
         new Example(
             'Remove Spaces and Tabs around Fullwidth Characrters',
             dedent`

--- a/src/test/no-bare-urls.test.ts
+++ b/src/test/no-bare-urls.test.ts
@@ -1,0 +1,17 @@
+import dedent from 'ts-dedent';
+import {rulesDict} from '../rules';
+
+describe('Move Footnotes to the bottom', () => {
+  // accounts for https://github.com/platers/obsidian-linter/issues/275
+  it('Leaves markdown links and images alone', () => {
+    const before = dedent`
+    [regular link](https://google.com)
+    ![image alt text](https://github.com/favicon.ico)
+    `;
+    const after = dedent`
+    [regular link](https://google.com)
+    ![image alt text](https://github.com/favicon.ico)
+    `;
+    expect(rulesDict['no-bare-urls'].apply(before)).toBe(after);
+  });
+});


### PR DESCRIPTION
@platers , how does the refactor for the ignore logic look? Do we want to keep the intermediary methods like `ignoreTables` and `ignoreCodeBlocksYAMLTagsAndLinks` instead of `ignoreTypes`, but use `ingoreTypes` there instead?

Fixes #276 
Fixes #275 

Refactored logic for ignoring different types of elements. It should allow for extensibility down the road as needed. Also fixed an issue where images were being caught in no bare URLs.

Changes Made:
- Removed ignore methods in `utils.ts` in favor of `ignore-types.ts` functions
- There is now an object that holds the ignore types that can be used that have their actions and placeholders defined which allows for easier maintenance of all the different types to ignore
- Standardizes how ignoring types works and allows for the ability to specify as many as you would like at once
- Updated method referenced as a utility method name since the other one was removed
- Added the ability to ignore images for no bare URLs and added associated UT