### PR TITLE
Ignore HRs for Removing Empty Lines Between Checklists and Lists

### DIFF
--- a/src/ignore-types.ts
+++ b/src/ignore-types.ts
@@ -10,6 +10,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   // mdast node types
   code: {replaceAction: 'code', placeholder: '{CODE_BLOCK_PLACEHOLDER}', replaceDollarSigns: true},
   image: {replaceAction: 'image', placeholder: '{IMAGE_PLACEHOLDER}', replaceDollarSigns: false},
+  thematicBreak: {replaceAction: 'thematicBreak', placeholder: '{HORIZONTAL_RULE_PLACEHOLDER}', replaceDollarSigns: false},
   // RegExp
   yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns(yamlPlaceholder), replaceDollarSigns: true},
   wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}', replaceDollarSigns: false},

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -368,7 +368,7 @@ export const rules: Rule[] = [
       'There should not be any empty lines between list markers and checklists.',
       RuleType.SPACING,
       (text: string) => {
-        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
+        return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.thematicBreak], text, (text) => {
           const replaceEmptyLinesBetweenList = function(text: string, listRegex: RegExp, replaceWith: string): string {
             let match;
             let newText = text;

--- a/src/test/remove-empty-lines-between-list-markers-and-checklists.test.ts
+++ b/src/test/remove-empty-lines-between-list-markers-and-checklists.test.ts
@@ -1,0 +1,51 @@
+import dedent from 'ts-dedent';
+import {rulesDict} from '../rules';
+
+describe('Remove Empty Lines Between List Markers and Checklists', () => {
+  // accounts for https://github.com/platers/obsidian-linter/issues/283
+  it('Horizontal Rules after list should not be affected', () => {
+    const before = dedent`
+    Starting Text
+
+    ---
+
+    - Some list item 1
+    - Some list item 2
+    
+    ---
+    
+    Some text
+
+    ***
+
+    * Some list item 1
+    * Some list item 2
+    
+    ***
+
+    More Text
+    `;
+    const after = dedent`
+    Starting Text
+
+    ---
+
+    - Some list item 1
+    - Some list item 2
+    
+    ---
+    
+    Some text
+
+    ***
+
+    * Some list item 1
+    * Some list item 2
+    
+    ***
+
+    More Text
+    `;
+    expect(rulesDict['remove-empty-lines-between-list-markers-and-checklists'].apply(before)).toBe(after);
+  });
+});


### PR DESCRIPTION
Fixes #283 

Changes Made:
- Added UT for the scenario in question to make sure it does not accidentally happen again
- Updated rule to ignore HRs prior to running regex