### PR TITLE
Cleanup Logic and Add Fenced Code Block Empty Lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
 - [line-break-at-document-end](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#line-break-at-document-end)
 - [empty-line-around-tables](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#empty-line-around-tables)
+- [empty-line-around-code-fences](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#empty-line-around-code-fences)
 - [space-between-chinese-and-english-or-numbers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-between-chinese-and-english-or-numbers)
 - [remove-space-around-fullwidth-characters](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-space-around-fullwidth-characters)
 - [remove-link-spacing](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-link-spacing)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1964,6 +1964,57 @@ foo | bar
 New paragraph.
 ``````
 
+### Empty Line Around Code Fences
+
+Alias: `empty-line-around-code-fences`
+
+Ensures that there is an empty line around code fences unless they start or end a document.
+
+
+
+Example: Fenced code blocks that start a document do not get an empty line before them.
+
+Before:
+
+``````markdown
+``` js
+var temp = 'text';
+// this is a code block
+```
+Text after code block.
+``````
+
+After:
+
+``````markdown
+``` js
+var temp = 'text';
+// this is a code block
+```
+
+Text after code block.
+``````
+Example: Fenced code blocs that end a document do not get an empty line after them.
+
+Before:
+
+``````markdown
+# Heading 1
+```
+Here is a code block
+```
+``````
+
+After:
+
+``````markdown
+# Heading 1
+
+```
+Here is a code block
+```
+``````
+
 ### Space between Chinese and English or numbers
 
 Alias: `space-between-chinese-and-english-or-numbers`

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1364,6 +1364,71 @@ export const rules: Rule[] = [
       ],
   ),
 
+  new Rule(
+      'Empty Line Around Code Fences',
+      'Ensures that there is an empty line around code fences unless they start or end a document.',
+      RuleType.SPACING,
+      (text: string) => {
+        const matches = text.match(/(^|(\n+)?)`{3}( ?[\S]+)?\n([\s\S]+)\n`{3}(\n+)?/gm);
+        if (matches == null) {
+          return text;
+        }
+
+        for (const fencedCodeBlock of matches) {
+          const start = text.indexOf(fencedCodeBlock);
+          const end = start + fencedCodeBlock.length;
+
+          let newFencedCodeBlock = fencedCodeBlock.trim();
+          if (start !== 0) {
+            newFencedCodeBlock = '\n\n' + newFencedCodeBlock;
+          }
+
+          if (end < text.length) {
+            newFencedCodeBlock = newFencedCodeBlock + '\n\n';
+          }
+
+          text = text.replace(fencedCodeBlock, newFencedCodeBlock);
+        }
+
+        return text;
+      },
+      [
+        new Example(
+            'Fenced code blocks that start a document do not get an empty line before them.',
+            dedent`
+            \`\`\` js
+            var temp = 'text';
+            // this is a code block
+            \`\`\`
+            Text after code block.
+`,
+            dedent`
+            \`\`\` js
+            var temp = 'text';
+            // this is a code block
+            \`\`\`
+
+            Text after code block.
+`,
+        ),
+        new Example(
+            'Fenced code blocs that end a document do not get an empty line after them.',
+            dedent`
+      # Heading 1
+      \`\`\`
+      Here is a code block
+      \`\`\`
+`,
+            dedent`
+      # Heading 1
+
+      \`\`\`
+      Here is a code block
+      \`\`\``,
+        ),
+      ],
+  ),
+
   // YAML rules
 
   new Rule(


### PR DESCRIPTION
Relates to #32 

Did some code cleanup with regards to values that come from the window making them available for Typescript to validate information around. Also added a new rule for fenced code blocks getting empty lines around them. Replaced custom normalize path with normalize path from obsidian.

Changes Made:
- Added a window interface to allow for Typescript to recognize `moment` and a command to help with not needing to do any casts (I am working on the casts to any and removing them)
- Replaced normalize path function with the one from Obsidian to cut down on code creation since we can use the provided API
- Added a new rule for adding an empty line around fenced code blocks