### PR TITLE
Ignore Multiple Spaces at Start of Block Quote and Callouts

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -644,7 +644,7 @@ export const rules: Rule[] = [
       RuleType.CONTENT,
       (text: string) => {
         return ignoreListOfTypes([IgnoreTypes.table, IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-          return text.replace(/([^\s])( ){2,}([^\s])/g, '$1 $3');
+          return text.replace(/(?!^>)([^\s])( ){2,}([^\s])/gm, '$1 $3');
         });
       },
       [

--- a/src/test/remove-multiple-spaces.test.ts
+++ b/src/test/remove-multiple-spaces.test.ts
@@ -96,4 +96,91 @@ describe('Remove Multiple Spaces', () => {
 
     expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
   });
+  // accounts for https://github.com/platers/obsidian-linter/issues/289
+  it('Callouts and block quotes allow multiple spaces at start to allow for code and list item indentation', () => {
+    const before = dedent`
+      # List Item in Callout
+        
+      > [!info] Unordered List
+      > - First Level
+      > - First Level
+      >   - Second Level
+      >     - Third Level
+      > - First Level
+
+      # Code in Callout
+
+      > [!info] Code
+      >     Line 1
+      >     Line 2
+      >     Line 3
+
+      # List Item in Block Quote
+        
+      > Unordered List
+      > - First Level
+      > - First Level
+      >   - Second Level
+      >     - Third Level
+      > - First Level
+
+      # Code in Block Quote
+      
+      > Code
+      >     Line 1
+      >     Line 2
+      >     Line 3
+    `;
+
+    const after = dedent`
+      # List Item in Callout
+        
+      > [!info] Unordered List
+      > - First Level
+      > - First Level
+      >   - Second Level
+      >     - Third Level
+      > - First Level
+
+      # Code in Callout
+
+      > [!info] Code
+      >     Line 1
+      >     Line 2
+      >     Line 3
+
+      # List Item in Block Quote
+        
+      > Unordered List
+      > - First Level
+      > - First Level
+      >   - Second Level
+      >     - Third Level
+      > - First Level
+
+      # Code in Block Quote
+      
+      > Code
+      >     Line 1
+      >     Line 2
+      >     Line 3
+    `;
+
+    expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
+  });
+  it('Multiple spaces after ">" are still removed if not the start of a line', () => {
+    const before = dedent`
+    # Text with > with multiple spaces after it
+      
+    Text >  other text
+    `;
+
+    const after = dedent`
+    # Text with > with multiple spaces after it
+      
+    Text > other text
+    `;
+
+    expect(rulesDict['remove-multiple-spaces'].apply(before)).toBe(after);
+  });
 });


### PR DESCRIPTION
Fixes #289 

Made sure to keep indentation formatting at the start of a callout or block quote to prevent breaking things like code and indented lists in them.

Changes Made:
- Updated regex to ignore a callout or block quote at the start of a line
- Added tests to make sure that the callout and block quotes do not accidentally have their formatting removed at the start of the content on the line