### PR TITLE
Added Rule to Remove Specified YAML Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 - [yaml-title-alias](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#yaml-title-alias)
 - [escape-yaml-special-characters](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#escape-yaml-special-characters)
 - [yaml-key-sort](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#yaml-key-sort)
+- [remove-yaml-keys](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-yaml-keys)
 
 ### Heading rules
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -528,6 +528,53 @@ language: Typescript
 ---
 ``````
 
+### Remove YAML Keys
+
+Alias: `remove-yaml-keys`
+
+Removes the YAML keys specified
+
+Options:
+- YAML Keys to Remove: The yaml keys to remove from the yaml frontmatter with or without colons
+	- Default: ``
+
+Example: Removes the values specified in `YAML Keys to Remove` = "status:
+keywords
+date"
+
+Before:
+
+``````markdown
+---
+language: Typescript
+type: programming
+tags: computer
+keywords:
+  - keyword1
+  - keyword2
+status: WIP
+date: 02/15/2022
+---
+
+# Header Context
+
+Text
+``````
+
+After:
+
+``````markdown
+---
+language: Typescript
+type: programming
+tags: computer
+---
+
+# Header Context
+
+Text
+``````
+
 ## Heading
 ### Header Increment
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2496,6 +2496,68 @@ export const rules: Rule[] = [
       ],
   ),
 
+  new Rule(
+      'Remove YAML Keys',
+      'Removes the YAML keys specified',
+      RuleType.YAML,
+      (text: string, options = {}) => {
+        const yamlKeysToRemove: string[] = options['YAML Keys to Remove'].split('\n');
+        const yaml = text.match(yamlRegex);
+        if (!yaml || yamlKeysToRemove.length === 0) {
+          return text;
+        }
+
+        let yamlText = yaml[1];
+        for (const key of yamlKeysToRemove) {
+          let actualKey = key.trim();
+          if (actualKey.endsWith(':')) {
+            actualKey = actualKey.substring(0, actualKey.length - 1);
+          }
+
+          yamlText = removeYamlSection(yamlText, actualKey);
+        }
+
+
+        return text.replace(yaml[1], yamlText);
+      },
+      [
+        new Example(
+            'Removes the values specified in `YAML Keys to Remove` = "status:\nkeywords\ndate"',
+            dedent`
+            ---
+            language: Typescript
+            type: programming
+            tags: computer
+            keywords:
+              - keyword1
+              - keyword2
+            status: WIP
+            date: 02/15/2022
+            ---
+
+            # Header Context
+
+            Text
+            `,
+            dedent`
+            ---
+            language: Typescript
+            type: programming
+            tags: computer
+            ---
+
+            # Header Context
+
+            Text
+            `,
+            {'YAML Keys to Remove': 'status:\nkeywords\ndate'},
+        ),
+      ],
+      [
+        new TextAreaOption('YAML Keys to Remove', 'The yaml keys to remove from the yaml frontmatter with or without colons', ''),
+      ],
+  ),
+
   // Heading rules
 
   new Rule(


### PR DESCRIPTION
Fixes #288 

Added a rule to remove YAML keys.

Change Made:
- Added logic to remove a list of yaml keys specified in the setting