### PR TITLE
Fix for a Couple of Regex Issues and Respecting Disabled Rules for Special Rules

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -240,13 +240,14 @@ export default class LinterPlugin extends Plugin {
     lintText(oldText: string, file: TFile) {
       let newText = oldText;
 
+      const disabledRules = getDisabledRules(newText);
       // escape YAML where possible before parsing yaml
-      [newText] = EscapeYamlSpecialCharacters.applyIfEnabled(newText, this.settings);
+      [newText] = EscapeYamlSpecialCharacters.applyIfEnabled(newText, this.settings, disabledRules);
+
 
       // remove hashtags from tags before parsing yaml
-      [newText] = FormatTagsInYaml.applyIfEnabled(newText, this.settings);
+      [newText] = FormatTagsInYaml.applyIfEnabled(newText, this.settings, disabledRules);
 
-      const disabledRules = getDisabledRules(newText);
       const modifiedAtTime = moment(file.stat.mtime).format();
       const createdAtTime = moment(file.stat.ctime).format();
 
@@ -266,7 +267,7 @@ export default class LinterPlugin extends Plugin {
 
       // run yaml timestamp at the end to help determine if something has changed
       let isYamlTimestampEnabled;
-      [newText, isYamlTimestampEnabled] = YamlTimestamp.applyIfEnabled(newText, this.settings, {
+      [newText, isYamlTimestampEnabled] = YamlTimestamp.applyIfEnabled(newText, this.settings, disabledRules, {
         fileCreatedTime: createdAtTime,
         fileModifiedTime: modifiedAtTime,
         currentTime: moment(),
@@ -276,7 +277,7 @@ export default class LinterPlugin extends Plugin {
 
       const yamlTimestampOptions = YamlTimestamp.getRuleOptions(this.settings);
 
-      [newText] = YamlKeySort.applyIfEnabled(newText, this.settings, {
+      [newText] = YamlKeySort.applyIfEnabled(newText, this.settings, disabledRules, {
         currentTimeFormatted: moment().format(yamlTimestampOptions.format),
         yamlTimestampDateModifiedEnabled: isYamlTimestampEnabled && yamlTimestampOptions.dateModified,
         dateModifiedKey: yamlTimestampOptions.dateModifiedKey,

--- a/src/rules/rule-builder.ts
+++ b/src/rules/rule-builder.ts
@@ -61,8 +61,12 @@ export default abstract class RuleBuilder<TOptions extends Options> extends Rule
     return false;
   }
 
-  static applyIfEnabled<TOptions extends Options>(this: typeof RuleBuilderBase & (new() => RuleBuilder<TOptions>), text: string, settings: LinterSettings, extraOptions?: TOptions): [result: string, isEnabled: boolean] {
+  static applyIfEnabled<TOptions extends Options>(this: typeof RuleBuilderBase & (new() => RuleBuilder<TOptions>), text: string, settings: LinterSettings, disabledRules: string[], extraOptions?: TOptions): [result: string, isEnabled: boolean] {
     const rule = this.getRule();
+    if (disabledRules.includes(rule.alias())) {
+      return [text, false];
+    }
+
     return RuleBuilderBase.applyIfEnabledBase(rule, text, settings, extraOptions);
   }
 

--- a/src/rules/space-between-chinese-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-and-english-or-numbers.ts
@@ -23,7 +23,7 @@ export default class SpaceBetweenChineseAndEnglishOrNumbers extends RuleBuilder<
   apply(text: string, options: SpaceBetweenChineseAndEnglishOrNumbersOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
       const head = /([\u4e00-\u9fa5])( *)(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+'"([{¥$]|\*[^*])/gm;
-      const tail = /(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+;:'"°%)\]}]|[^*]\*)( *)([\u4e00-\u9fa5])/gm;
+      const tail = /(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+;:'"°%$)\]}]|[^*]\*)( *)([\u4e00-\u9fa5])/gm;
       return text.replace(head, '$1 $3').replace(tail, '$1 $3');
     });
   }

--- a/src/test/paragraph-blank-lines.test.ts
+++ b/src/test/paragraph-blank-lines.test.ts
@@ -205,5 +205,65 @@ ruleTest({
         Line not followed by line break
       `,
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/300
+      testName: 'Make sure obsidian multiline comments with single line comment prior is not affected',
+      before: dedent`
+      %% fold %%
+
+      ## R
+      
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %%
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %% nocomment
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+      `,
+      after: dedent`
+      %% fold %%
+
+      ## R
+      
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %%
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %% nocomment
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+      `,
+    },
   ],
 });

--- a/src/test/space-between-chinese-and-english-or-numbers.test.ts
+++ b/src/test/space-between-chinese-and-english-or-numbers.test.ts
@@ -1,0 +1,19 @@
+import SpaceBetweenChineseAndEnglishOrNumbers from '../rules/space-between-chinese-and-english-or-numbers';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: SpaceBetweenChineseAndEnglishOrNumbers,
+  testCases: [
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/303
+      testName: 'Make sure that spaces are added after a dollar sign if followed by Chinese characters',
+      before: dedent`
+      这是一个数学公式$f(x)=x^2$这是一个数学公式
+      `,
+      after: dedent`
+      这是一个数学公式 $f(x)=x^2$ 这是一个数学公式
+      `,
+    },
+  ],
+});

--- a/src/test/two-spaces-between-lines-with-content.test.ts
+++ b/src/test/two-spaces-between-lines-with-content.test.ts
@@ -26,5 +26,65 @@ ruleTest({
         %%
       `,
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/300
+      testName: 'Make sure obsidian multiline comments with single line comment prior is not affected',
+      before: dedent`
+      %% fold %%
+
+      ## R
+      
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %%
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %% nocomment
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+      `,
+      after: dedent`
+      %% fold %%
+
+      ## R
+      
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %%
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+
+      # A %% fold %% nocomment
+
+      ## R
+
+      %%
+      HW:: --
+      T:: 0
+      %%
+      `,
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -10,7 +10,7 @@ export const indentedBlockRegex = '^((\t|( {4})).*\n)+';
 export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeBlockRegexTemplate}|${indentedBlockRegex}`, 'gm');
 export const wikiLinkRegex = /(!?)(\[{2}[^[\n\]]*\]{2})/g;
 export const tagRegex = /#[^\s#]{1,}/g;
-export const obsidianMultilineCommentRegex = /%%\n[^%]*\n%%/g;
+export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const tableRegex = /([ ]{0,3}\[.*?\][ \t]*\n)?([ ]{0,3}\S+.*?\|.*?\n([^\n]*?\|[^\n]*?\n)*?)?[ ]{0,3}[|\-+:.][ \-+|:.]*?\|[ \-+|:.]*(?:\n?[^\n]*?\|([^\n]*?)*(\n)?)+/g;
 export const wordSplitterRegex = /[,\s]+/;
 


### PR DESCRIPTION
Fixes #306 
Fixes #303 
Fixes #300 

Changes Made:
- Updated the running of special rules to make sure they check if the rule is disabled before trying to run it
- Updated regex for tail of English to Chinese to make sure a dollar sign is listed as something that needs a space after it
- Updated regex for multiline comments to make sure it starts a line in order to be counted as something to escape to prevent single line comments from getting caught in the regex
- Added tests to make sure we hopefully will avoid reintroducing the above problems (checking disabled rules did not have any UTs added)