### PR TITLE
Performance Enhancement and Bug Fixes

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2178,6 +2178,50 @@ After:
 ``````markdown
 #标签A #标签2标签
 ``````
+Example: Make sure that spaces are not added between italics and chinese characters to preserve markdown syntax
+
+Before:
+
+``````markdown
+_这是一个数学公式_
+*这是一个数学公式english*
+
+# Handling bold and italics nested in each other is not supported at this time
+
+**_这是一_个数学公式**
+*这是一hello__个数学world公式__*
+``````
+
+After:
+
+``````markdown
+_这是一个数学公式_
+*这是一个数学公式 english*
+
+# Handling bold and italics nested in each other is not supported at this time
+
+**_ 这是一 _ 个数学公式**
+*这是一 hello__ 个数学 world 公式 __*
+``````
+Example: Images and links are ignored
+
+Before:
+
+``````markdown
+[[这是一个数学公式english]]
+![[这是一个数学公式english.jpg]]
+[这是一个数学公式english](这是一个数学公式english.md)
+![这是一个数学公式english](这是一个数学公式english.jpg)
+``````
+
+After:
+
+``````markdown
+[[这是一个数学公式english]]
+![[这是一个数学公式english.jpg]]
+[这是一个数学公式english](这是一个数学公式english.md)
+![这是一个数学公式english](这是一个数学公式english.jpg)
+``````
 
 ### Trailing spaces
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
-    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --comments false --output main.js",
+    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --ecma 2016 --comments false --output main.js",
     "test": "jest",
     "docs": "node docs.js",
     "compile": "npm run build && npm run docs && npm run lint && npm run test",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
-    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --ecma 2016 --comments false --output main.js",
+    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --comments false --output main.js",
     "test": "jest",
     "docs": "node docs.js",
     "compile": "npm run build && npm run docs && npm run lint && npm run test",

--- a/src/main.ts
+++ b/src/main.ts
@@ -420,7 +420,7 @@ export default class LinterPlugin extends Plugin {
   }
 
   // based on https://github.com/liamcain/obsidian-calendar-ui/blob/03ceecbf6d88ef260dadf223ee5e483d98d24ffc/src/localization.ts#L85-L109
-  setOrUpdateMomentInstance() {
+  async setOrUpdateMomentInstance() {
     const obsidianLang: string = localStorage.getItem('language') || 'en';
     const systemLang = navigator.language?.toLowerCase();
 
@@ -434,7 +434,7 @@ export default class LinterPlugin extends Plugin {
     }
 
     const currentLocale = moment.locale(momentLocale);
-    logDebug(`Trying to switch Moment.js global locale to ${momentLocale}, got ${currentLocale}`);
+    logDebug(`Trying to switch Moment.js locale to ${momentLocale}, got ${currentLocale}`);
   }
 
   private displayChangedMessage(charsAdded: number, charsRemoved: number) {
@@ -536,7 +536,7 @@ class SettingTab extends PluginSettingTab {
           dropdown.setValue(this.plugin.settings.linterLocale);
           dropdown.onChange(async (value) => {
             this.plugin.settings.linterLocale = value;
-            this.plugin.setOrUpdateMomentInstance();
+            await this.plugin.setOrUpdateMomentInstance();
             await this.plugin.saveSettings();
           });
         });

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -13,6 +13,8 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   code: {replaceAction: 'code', placeholder: '{CODE_BLOCK_PLACEHOLDER}', replaceDollarSigns: true},
   image: {replaceAction: 'image', placeholder: '{IMAGE_PLACEHOLDER}', replaceDollarSigns: false},
   thematicBreak: {replaceAction: 'thematicBreak', placeholder: '{HORIZONTAL_RULE_PLACEHOLDER}', replaceDollarSigns: false},
+  italics: {replaceAction: 'emphasis', placeholder: '{ITALICS_PLACEHOLDER}', replaceDollarSigns: false},
+  bold: {replaceAction: 'strong', placeholder: '{STRONG_PLACEHOLDER}', replaceDollarSigns: false},
   // RegExp
   yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns('---\n---'), replaceDollarSigns: true},
   wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}', replaceDollarSigns: false},

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -9,6 +9,8 @@ const mdastTypes: Record<string, string> = {
   link: 'link',
   footnote: 'footnoteDefinition',
   paragraph: 'paragraph',
+  italics: 'emphasis',
+  bold: 'strong',
 };
 
 function parseTextToAST(text: string): Root {
@@ -250,6 +252,34 @@ export function removeSpacesInLinkText(text: string): string {
     const endLinkTextPosition = regularLink.lastIndexOf(']');
     const newLink = regularLink.substring(0, 1) + regularLink.substring(1, endLinkTextPosition).trim() + regularLink.substring(endLinkTextPosition);
     text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, newLink);
+  }
+
+  return text;
+}
+
+export function updateItalicsText(text: string, func:(text: string) => string): string {
+  const positions: Position[] = getPositions(mdastTypes.italics, text);
+
+  for (const position of positions) {
+    let italicText = text.substring(position.start.offset+1, position.end.offset-1);
+
+    italicText = func(italicText);
+
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset+1, position.end.offset-1, italicText);
+  }
+
+  return text;
+}
+
+export function updateBoldText(text: string, func:(text: string) => string): string {
+  const positions: Position[] = getPositions(mdastTypes.bold, text);
+
+  for (const position of positions) {
+    let boldText = text.substring(position.start.offset+2, position.end.offset-2);
+
+    boldText = func(boldText);
+
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset+2, position.end.offset-2, boldText);
   }
 
   return text;


### PR DESCRIPTION
Fixes #302 
Fixes #301 

Changes Made:
- made sure to not wait on locale change to continue loading plugin as that is not necessary and it is almost always guaranteed to load before a user would get to the settings tab option
- Updated debug message to make it clear that the change made only affects this plugin
- Updated spaces between Chinese and English characters to ignore images and to only affect the contents of either bold or italics text
  - **Note: that nesting of italics and bold is not currently supported**
- Added tests to help ensure that we do not accidentally reintroduce these issues down the line
- Added helper methods to mdast
- Added ignore types for bold and italics