### PR TITLE
Bug Fix and VS Code Settings Addition 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 .idea
 
 # VSCode
-.vscode/
+.vscode/*
+!/.vscode/settings.json
 
 # npm
 node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact"
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true,
+    },
+    "editor.tabSize": 2,
+    "files.eol": "\n",
+    "files.insertFinalNewline": true,
+    "editor.detectIndentation": true,
+    "files.encoding": "utf8",
+    "files.trimTrailingWhitespace": false,
+}

--- a/src/rules/capitalize-headings.ts
+++ b/src/rules/capitalize-headings.ts
@@ -87,17 +87,17 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
               }
 
               const ignoreCasedWord =
-              options.ignoreCasedWords &&
-              headerWords[j] !== headerWords[j].toLowerCase();
+                options.ignoreCasedWords &&
+                headerWords[j] !== headerWords[j].toLowerCase();
               const keepWordCasing =
-              ignoreCasedWord || keepCasing.includes(headerWords[j]);
+                ignoreCasedWord || keepCasing.includes(headerWords[j]);
               if (!keepWordCasing) {
                 headerWords[j] = headerWords[j].toLowerCase();
                 const ignoreWord = ignoreShortWords.includes(headerWords[j]);
                 if (!ignoreWord || firstWord === true) {
-                // ignore words that are not capitalized in titles except if they are the first word
+                  // ignore words that are not capitalized in titles except if they are the first word
                   headerWords[j] =
-                  headerWords[j][0].toUpperCase() + headerWords[j].slice(1);
+                    headerWords[j][0].toUpperCase() + headerWords[j].slice(1);
                 }
               }
 

--- a/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
+++ b/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
@@ -36,24 +36,24 @@ export default class RemoveEmptyLinesBetweenListMarkersAndChecklists extends Rul
 
       /* eslint-disable no-useless-escape */
       // account for '- [x]' and  '- [ ]' checkbox markers
-      const checkboxMarker = new RegExp(/^(( |\t)*- \[( |x)\].+)\n{2,}(( |\t)*- \[( |x)\].+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, checkboxMarker, '$1\n$4');
+      const checkboxMarker = new RegExp(/^(( |\t)*- \[( |x)\]( |\t)+.+)\n{2,}(( |\t)*- \[( |x)\]( |\t)+.+)$/gm);
+      text = replaceEmptyLinesBetweenList(text, checkboxMarker, '$1\n$5');
 
       // account for ordered list marker
-      const orderedMarker = new RegExp(/^(( |\t)*\d+\..+)\n{2,}(( |\t)*\d+\..+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, orderedMarker, '$1\n$3');
+      const orderedMarker = new RegExp(/^(( |\t)*\d+\.( |\t)+.+)\n{2,}(( |\t)*\d+\.( |\t)+.+)$/gm);
+      text = replaceEmptyLinesBetweenList(text, orderedMarker, '$1\n$4');
 
       // account for '+' list marker
-      const plusMarker = new RegExp(/^(( |\t)*\+.+)\n{2,}(( |\t)*\+.+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, plusMarker, '$1\n$3');
+      const plusMarker = new RegExp(/^(( |\t)*\+( |\t)+.+)\n{2,}(( |\t)*\+( |\t)+.+)$/gm);
+      text = replaceEmptyLinesBetweenList(text, plusMarker, '$1\n$4');
 
       // account for '-' list marker
-      const dashMarker = new RegExp(/^(( |\t)*-(?! \[( |x)\]).+)\n{2,}(( |\t)*-(?! \[( |x)\]).+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, dashMarker, '$1\n$4');
+      const dashMarker = new RegExp(/^(( |\t)*-(?! \[( |x)\])( |\t)+.+)\n{2,}(( |\t)*-(?! \[( |x)\])( |\t)+.+)$/gm);
+      text = replaceEmptyLinesBetweenList(text, dashMarker, '$1\n$5');
 
       // account for '*' list marker
-      const splatMarker = new RegExp(/^(( |\t)*\*.+)\n{2,}(( |\t)*\*.+)$/gm);
-      return replaceEmptyLinesBetweenList(text, splatMarker, '$1\n$3');
+      const splatMarker = new RegExp(/^(( |\t)*\*( |\t)+.+)\n{2,}(( |\t)*\*( |\t)+.+)$/gm);
+      return replaceEmptyLinesBetweenList(text, splatMarker, '$1\n$4');
       /* eslint-enable no-useless-escape */
     });
   }

--- a/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
+++ b/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
@@ -22,7 +22,8 @@ export default class RemoveEmptyLinesBetweenListMarkersAndChecklists extends Rul
   }
   apply(text: string, options: RemoveEmptyLinesBetweenListMarkersAndChecklistsOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.thematicBreak], text, (text) => {
-      const replaceEmptyLinesBetweenList = function(text: string, listRegex: RegExp, replaceWith: string): string {
+      const replaceEmptyLinesBetweenList = function(text: string, listIndicatorRegexText: string, replaceWith: string): string {
+        const listRegex = new RegExp(`^${listIndicatorRegexText}\n{2,}${listIndicatorRegexText}$`, 'gm');
         let match;
         let newText = text;
 
@@ -36,24 +37,24 @@ export default class RemoveEmptyLinesBetweenListMarkersAndChecklists extends Rul
 
       /* eslint-disable no-useless-escape */
       // account for '- [x]' and  '- [ ]' checkbox markers
-      const checkboxMarker = new RegExp(/^(( |\t)*- \[( |x)\]( |\t)+.+)\n{2,}(( |\t)*- \[( |x)\]( |\t)+.+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, checkboxMarker, '$1\n$5');
+      const checkBoxMarkerRegexText = '(( |\\t)*- \\[( |x)\\]( |\\t)+.+)';
+      text = replaceEmptyLinesBetweenList(text, checkBoxMarkerRegexText, '$1\n$5');
 
       // account for ordered list marker
-      const orderedMarker = new RegExp(/^(( |\t)*\d+\.( |\t)+.+)\n{2,}(( |\t)*\d+\.( |\t)+.+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, orderedMarker, '$1\n$4');
+      const orderedMarkerRegexText = '(( |\\t)*\\d+\\.( |\\t)+.+)';
+      text = replaceEmptyLinesBetweenList(text, orderedMarkerRegexText, '$1\n$4');
 
       // account for '+' list marker
-      const plusMarker = new RegExp(/^(( |\t)*\+( |\t)+.+)\n{2,}(( |\t)*\+( |\t)+.+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, plusMarker, '$1\n$4');
+      const plusMarkerRegexText = '(( |\\t)*\\+( |\\t)+.+)';
+      text = replaceEmptyLinesBetweenList(text, plusMarkerRegexText, '$1\n$4');
 
       // account for '-' list marker
-      const dashMarker = new RegExp(/^(( |\t)*-(?! \[( |x)\])( |\t)+.+)\n{2,}(( |\t)*-(?! \[( |x)\])( |\t)+.+)$/gm);
-      text = replaceEmptyLinesBetweenList(text, dashMarker, '$1\n$5');
+      const dashMarkerRegexText = '(( |\\t)*-(?! \\[( |x)\\])( |\\t)+.+)';
+      text = replaceEmptyLinesBetweenList(text, dashMarkerRegexText, '$1\n$5');
 
       // account for '*' list marker
-      const splatMarker = new RegExp(/^(( |\t)*\*( |\t)+.+)\n{2,}(( |\t)*\*( |\t)+.+)$/gm);
-      return replaceEmptyLinesBetweenList(text, splatMarker, '$1\n$4');
+      const splatMarkerRegexText = '(( |\\t)*\\*( |\\t)+.+)';
+      return replaceEmptyLinesBetweenList(text, splatMarkerRegexText, '$1\n$4');
       /* eslint-enable no-useless-escape */
     });
   }

--- a/src/test/remove-empty-lines-between-list-markers-and-checklists.test.ts
+++ b/src/test/remove-empty-lines-between-list-markers-and-checklists.test.ts
@@ -51,5 +51,25 @@ ruleTest({
         More Text
       `,
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/318
+      testName: 'Make sure that italics followed by a blank and then italics and vice versa are left alone',
+      before: dedent`
+        *Some italicized item:* some detail
+        ${''}
+        **Some bold item:** some other detail
+        ${''}
+        *Some more italicized item:* some detail
+        ${''}
+      `,
+      after: dedent`
+        *Some italicized item:* some detail
+        ${''}
+        **Some bold item:** some other detail
+        ${''}
+        *Some more italicized item:* some detail
+        ${''}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
Fixes #318 

Changes Made:
- Updated the gitignore to allow vscode settings
- Added vscode settings to make it the equivalent of the editor config and allow for auto running eslint
- Ran linter which removed whitespace in some spaces
- Updated `Remove Empty Lines Between List Markers and Checklists` to ignore asterisks and other list and checklist indicators if they have no space after it and added a test to make sure the case in #318 is accounted for and not accidentally reintroduced later down the line