### PR TITLE
Ignore Space at Start of List Items for Fullwidth Characters

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2058,12 +2058,12 @@ Ensures that fullwidth characters are not followed by whitespace (either single 
 
 
 
-Example: Remove Spaces and Tabs around Fullwidth Characrters
+Example: Remove Spaces and Tabs around Fullwidth Characters
 
 Before:
 
 ``````markdown
-Full list of affected charaters: ０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
+Full list of affected characters: ０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
 This is a fullwidth period	 。 with text after it.
 This is a fullwidth comma	，  with text after it.
 This is a fullwidth left parenthesis （ 	with text after it.
@@ -2076,7 +2076,7 @@ This is a fullwidth semicolon ；  with text after it.
 After:
 
 ``````markdown
-Full list of affected charaters:０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
+Full list of affected characters:０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
 This is a fullwidth period。with text after it.
 This is a fullwidth comma，with text after it.
 This is a fullwidth left parenthesis（with text after it.
@@ -2084,6 +2084,37 @@ This is a fullwidth right parenthesis）with text after it.
 This is a fullwidth colon：with text after it.
 This is a fullwidth semicolon；with text after it.
 Ｒemoves space at start of line
+``````
+Example: Fullwidth Characters in List Do not Affect List Markdown Syntax
+
+Before:
+
+``````markdown
+# List indicators should not have the space after them removed if they are followed by a fullwidth character
+
+- ［ contents here］
+  - 	［ more contents here］ more text here
++ 	［ another item here］
+* ［ one last item here］
+
+# Nested in a block quote
+
+> - ［ contents here ］
+``````
+
+After:
+
+``````markdown
+# List indicators should not have the space after them removed if they are followed by a fullwidth character
+
+- ［contents here］
+  - ［more contents here］more text here
++ ［another item here］
+* ［one last item here］
+
+# Nested in a block quote
+
+> - ［contents here］
 ``````
 
 ### Space after list markers

--- a/src/rules/remove-space-around-fullwidth-characters.ts
+++ b/src/rules/remove-space-around-fullwidth-characters.ts
@@ -72,7 +72,18 @@ export default class RemoveSpaceAroundFullwidthCharacters extends RuleBuilder<Re
           ${''}
           # Nested in a block quote
           ${''}
-          > - ［ contents here ］
+          > - ［ contents here］
+          >   - \t［ more contents here］ more text here
+          > + \t［ another item here］
+          > * ［ one last item here］
+          ${''}
+          # Doubly nested in a block quote
+          ${''}
+          > The following is doubly nested
+          > > - ［ contents here］
+          > >   - \t［ more contents here］ more text here
+          > > + \t［ another item here］
+          > > * ［ one last item here］
         `,
         after: dedent`
           # List indicators should not have the space after them removed if they are followed by a fullwidth character
@@ -85,6 +96,17 @@ export default class RemoveSpaceAroundFullwidthCharacters extends RuleBuilder<Re
           # Nested in a block quote
           ${''}
           > - ［contents here］
+          >   - ［more contents here］more text here
+          > + ［another item here］
+          > * ［one last item here］
+          ${''}
+          # Doubly nested in a block quote
+          ${''}
+          > The following is doubly nested
+          > > - ［contents here］
+          > >   - ［more contents here］more text here
+          > > + ［another item here］
+          > > * ［one last item here］
         `,
       }),
     ];

--- a/src/rules/remove-space-around-fullwidth-characters.ts
+++ b/src/rules/remove-space-around-fullwidth-characters.ts
@@ -2,6 +2,7 @@ import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {updateListItemText} from '../utils/mdast';
 
 class RemoveSpaceAroundFullwidthCharactersOptions implements Options {
 }
@@ -21,16 +22,25 @@ export default class RemoveSpaceAroundFullwidthCharacters extends RuleBuilder<Re
     return RuleType.SPACING;
   }
   apply(text: string, options: RemoveSpaceAroundFullwidthCharactersOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      return text.replace(/([ \t])+([\u2013\u2014\u2026\u3001\u3002\u300a\u300d-\u300f\u3014\u3015\u3008-\u3011\uff00-\uffff])/g, '$2').replace(/([\u2013\u2014\u2026\u3001\u3002\u300a\u300d-\u300f\u3014\u3015\u3008-\u3011\uff00-\uffff])([ \t])+/g, '$1');
-    });
+    const fullwidthCharacterWithTextAtStart = /([ \t])+([\u2013\u2014\u2026\u3001\u3002\u300a\u300d-\u300f\u3014\u3015\u3008-\u3011\uff00-\uffff])/g;
+    const fullwidthCharacterWithTextAtEnd = /([\u2013\u2014\u2026\u3001\u3002\u300a\u300d-\u300f\u3014\u3015\u3008-\u3011\uff00-\uffff])([ \t])+/g;
+
+    const replaceWhitespaceAroundFullwidthCharacters = function(text: string): string {
+      return text.replace(fullwidthCharacterWithTextAtStart, '$2').replace(fullwidthCharacterWithTextAtEnd, '$1');
+    };
+
+    let newText = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.list], text, replaceWhitespaceAroundFullwidthCharacters);
+
+    newText = updateListItemText(newText, replaceWhitespaceAroundFullwidthCharacters);
+
+    return newText;
   }
   get exampleBuilders(): ExampleBuilder<RemoveSpaceAroundFullwidthCharactersOptions>[] {
     return [
       new ExampleBuilder({
-        description: 'Remove Spaces and Tabs around Fullwidth Characrters',
+        description: 'Remove Spaces and Tabs around Fullwidth Characters',
         before: dedent`
-          Full list of affected charaters: ０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
+          Full list of affected characters: ０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
           This is a fullwidth period\t 。 with text after it.
           This is a fullwidth comma\t，  with text after it.
           This is a fullwidth left parenthesis （ \twith text after it.
@@ -40,7 +50,7 @@ export default class RemoveSpaceAroundFullwidthCharacters extends RuleBuilder<Re
             Ｒemoves space at start of line
         `,
         after: dedent`
-          Full list of affected charaters:０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
+          Full list of affected characters:０１２３４５６７８９ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ，．：；！？＂＇｀＾～￣＿＆＠＃％＋－＊＝＜＞（）［］｛｝｟｠｜￤／＼￢＄￡￠￦￥。、「」『』〔〕【】—…–《》〈〉
           This is a fullwidth period。with text after it.
           This is a fullwidth comma，with text after it.
           This is a fullwidth left parenthesis（with text after it.
@@ -48,6 +58,48 @@ export default class RemoveSpaceAroundFullwidthCharacters extends RuleBuilder<Re
           This is a fullwidth colon：with text after it.
           This is a fullwidth semicolon；with text after it.
           Ｒemoves space at start of line
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Fullwidth Characters in List Do not Affect List Markdown Syntax',
+        before: dedent`
+          # List indicators should not have the space after them removed if they are followed by a fullwidth character
+          ${''}
+          - ［ contents here］
+            - \t［ more contents here］ more text here
+          + \t［ another item here］
+          * ［ one last item here］
+          ${''}
+          # Nested in a block quote
+          ${''}
+          > - ［ contents here ］
+        `,
+        after: dedent`
+          # List indicators should not have the space after them removed if they are followed by a fullwidth character
+          ${''}
+          - ［contents here］
+            - ［more contents here］more text here
+          + ［another item here］
+          * ［one last item here］
+          ${''}
+          # Nested in a block quote
+          ${''}
+          > - ［contents here］
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Fullwidth Characters in Block Quote Do not Affect Block Quote Markdown Syntax',
+        before: dedent`
+          # A fullwidth character as the first non-whitespace character in a block quote should not mess with the the blockquote syntax
+          ${''}
+          > ［ contents here ］
+          >    ［ contents here ］
+        `,
+        after: dedent`
+          # A fullwidth character as the first non-whitespace character in a block quote should not mess with the the blockquote syntax
+          ${''}
+          > ［contents here］
+          > ［contents here］
         `,
       }),
     ];

--- a/src/rules/remove-space-around-fullwidth-characters.ts
+++ b/src/rules/remove-space-around-fullwidth-characters.ts
@@ -87,21 +87,6 @@ export default class RemoveSpaceAroundFullwidthCharacters extends RuleBuilder<Re
           > - ［contents here］
         `,
       }),
-      new ExampleBuilder({
-        description: 'Fullwidth Characters in Block Quote Do not Affect Block Quote Markdown Syntax',
-        before: dedent`
-          # A fullwidth character as the first non-whitespace character in a block quote should not mess with the the blockquote syntax
-          ${''}
-          > ［ contents here ］
-          >    ［ contents here ］
-        `,
-        after: dedent`
-          # A fullwidth character as the first non-whitespace character in a block quote should not mess with the the blockquote syntax
-          ${''}
-          > ［contents here］
-          > ［contents here］
-        `,
-      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<RemoveSpaceAroundFullwidthCharactersOptions>[] {

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -15,6 +15,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   thematicBreak: {replaceAction: 'thematicBreak', placeholder: '{HORIZONTAL_RULE_PLACEHOLDER}', replaceDollarSigns: false},
   italics: {replaceAction: 'emphasis', placeholder: '{ITALICS_PLACEHOLDER}', replaceDollarSigns: false},
   bold: {replaceAction: 'strong', placeholder: '{STRONG_PLACEHOLDER}', replaceDollarSigns: false},
+  list: {replaceAction: 'list', placeholder: '{LIST_PLACEHOLDER}', replaceDollarSigns: false},
   // RegExp
   yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns('---\n---'), replaceDollarSigns: true},
   wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}', replaceDollarSigns: false},

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -11,6 +11,8 @@ const mdastTypes: Record<string, string> = {
   paragraph: 'paragraph',
   italics: 'emphasis',
   bold: 'strong',
+  listItem: 'listItem',
+  blockquote: 'blockquote',
 };
 
 function parseTextToAST(text: string): Root {
@@ -280,6 +282,55 @@ export function updateBoldText(text: string, func:(text: string) => string): str
     boldText = func(boldText);
 
     text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset+2, position.end.offset-2, boldText);
+  }
+
+  return text;
+}
+
+export function updateListItemText(text: string, func:(text: string) => string): string {
+  const positions: Position[] = getPositions(mdastTypes.listItem, text);
+
+  for (const position of positions) {
+    const startIndex = position.start.offset+2;
+    let endIndex = position.end.offset;
+    let listText = text.substring(startIndex, position.end.offset);
+    // This helps account for a weird scenario where list items is pulling back multiple list items in one go sometimes
+    const end = listText.search(/\n( |\t)*(\*|-|\+|- \[( | x)\]|\d+\.)( | ]t)+/);
+    if (end !== -1) {
+      endIndex = startIndex + end;
+      listText = listText.substring(0, end);
+    }
+
+    console.log(listText);
+
+    listText = func(listText);
+
+    text = replaceTextBetweenStartAndEndWithNewValue(text, startIndex, endIndex, listText);
+  }
+
+  return text;
+}
+
+
+export function updateBlockquoteText(text: string, func:(text: string) => string): string {
+  const positions: Position[] = getPositions(mdastTypes.blockquote, text);
+
+  for (const position of positions) {
+    const startIndex = position.start.offset+2;
+    let endIndex = position.end.offset;
+    let listText = text.substring(startIndex, position.end.offset);
+    // This helps account for a weird scenario where list items is pulling back multiple list items in one go sometimes
+    const end = listText.search(/\n( |\t)*(\*|-|\+|- \[( | x)\]|\d+\.)( | ]t)+/);
+    if (end !== -1) {
+      endIndex = startIndex + end;
+      listText = listText.substring(0, end);
+    }
+
+    console.log(listText);
+
+    listText = func(listText);
+
+    text = replaceTextBetweenStartAndEndWithNewValue(text, startIndex, endIndex, listText);
   }
 
   return text;

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -296,6 +296,7 @@ export function updateListItemText(text: string, func:(text: string) => string):
     let listText = text.substring(startIndex, position.end.offset);
     // This helps account for a weird scenario where list items is pulling back multiple list items in one go sometimes
     const end = listText.search(/\n( |\t)*(\*|-|\+|- \[( | x)\]|\d+\.)( | ]t)+/);
+    console.log(listText);
     if (end !== -1) {
       endIndex = startIndex + end;
       listText = listText.substring(0, end);

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -301,8 +301,6 @@ export function updateListItemText(text: string, func:(text: string) => string):
       listText = listText.substring(0, end);
     }
 
-    console.log(listText);
-
     listText = func(listText);
 
     text = replaceTextBetweenStartAndEndWithNewValue(text, startIndex, endIndex, listText);
@@ -311,27 +309,3 @@ export function updateListItemText(text: string, func:(text: string) => string):
   return text;
 }
 
-
-export function updateBlockquoteText(text: string, func:(text: string) => string): string {
-  const positions: Position[] = getPositions(mdastTypes.blockquote, text);
-
-  for (const position of positions) {
-    const startIndex = position.start.offset+2;
-    let endIndex = position.end.offset;
-    let listText = text.substring(startIndex, position.end.offset);
-    // This helps account for a weird scenario where list items is pulling back multiple list items in one go sometimes
-    const end = listText.search(/\n( |\t)*(\*|-|\+|- \[( | x)\]|\d+\.)( | ]t)+/);
-    if (end !== -1) {
-      endIndex = startIndex + end;
-      listText = listText.substring(0, end);
-    }
-
-    console.log(listText);
-
-    listText = func(listText);
-
-    text = replaceTextBetweenStartAndEndWithNewValue(text, startIndex, endIndex, listText);
-  }
-
-  return text;
-}


### PR DESCRIPTION
Fixes #308 

Changes Made:
- Made sure that when dealing with spaces between a list marker and a fullwidth character, that the full width character has one space kept before it
- Added a test to verify nesting and regular list items gets this treatment