### PR TITLE
Fix Issue with Capitalization in Headers Ignoring Non-English Letters

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1743,6 +1743,32 @@ After:
 > > var other text = 'this is more text';
 > > ```
 ``````
+Example: Nested fenced code blocks get empty lines added around them
+
+Before:
+
+``````markdown
+```markdown
+# Header
+
+````JavaScript
+var text = 'some string';
+````
+```
+``````
+
+After:
+
+``````markdown
+```markdown
+# Header
+
+````JavaScript
+var text = 'some string';
+````
+
+```
+``````
 
 ### Empty Line Around Tables
 

--- a/src/rules/capitalize-headings.ts
+++ b/src/rules/capitalize-headings.ts
@@ -81,7 +81,7 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
             const ignoreShortWords = options.lowercaseWords;
             let firstWord = true;
             for (let j = 1; j < headerWords.length; j++) {
-              const isWord = headerWords[j].match(/^[A-Za-z'-]+[.?!,:;]?$/);
+              const isWord = headerWords[j].match(/^[\p{L}'-]+[.?!,:;]?$/u);
               if (!isWord) {
                 continue;
               }
@@ -114,9 +114,10 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
             lines[i] = lines[i].toUpperCase(); // convert full heading to uppercase
             break;
           case 'First letter':
+            // based on https://stackoverflow.com/a/62032796 "/\p{L}/u" accounts for all unicode letters across languages
             lines[i] = lines[i]
                 .toLowerCase()
-                .replace(/^#*\s+([^a-z])*([a-z])/, (string) => string.toUpperCase()); // capitalize first letter of heading
+                .replace(/^#*\s+([^\p{L}])*([\p{L}])/u, (string) => string.toUpperCase()); // capitalize first letter of heading
             break;
         }
       }

--- a/src/rules/empty-line-around-code-fences.ts
+++ b/src/rules/empty-line-around-code-fences.ts
@@ -102,6 +102,28 @@ export default class EmptyLineAroundCodeFences extends RuleBuilder<EmptyLineArou
           > > \`\`\`
         `,
       }),
+      new ExampleBuilder({
+        description: 'Nested fenced code blocks get empty lines added around them',
+        before: dedent`
+          \`\`\`markdown
+          # Header
+          ${''}
+          \`\`\`\`JavaScript
+          var text = 'some string';
+          \`\`\`\`
+          \`\`\`
+        `,
+        after: dedent`
+          \`\`\`markdown
+          # Header
+          ${''}
+          \`\`\`\`JavaScript
+          var text = 'some string';
+          \`\`\`\`
+          ${''}
+          \`\`\`
+        `,
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<EmptyLineAroundCodeFencesOptions>[] {

--- a/src/rules/empty-line-around-tables.ts
+++ b/src/rules/empty-line-around-tables.ts
@@ -1,7 +1,6 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-// import {ensureEmptyLinesAroundRegexMatches, tableRegex} from '../utils/regex';
 import {IgnoreTypes, ignoreListOfTypes} from '../utils/ignore-types';
 import {ensureEmptyLinesAroundTables} from '../utils/mdast';
 

--- a/src/test/capitalize-headings.test.ts
+++ b/src/test/capitalize-headings.test.ts
@@ -14,6 +14,8 @@ ruleTest({
         ## I can't do this
         ## comma, comma, comma
         ## 1.1 the Header
+        ## état
+        ## this état
       `,
       after: dedent`
         # h1
@@ -22,6 +24,8 @@ ruleTest({
         ## I Can't Do This
         ## Comma, Comma, Comma
         ## 1.1 The Header
+        ## État
+        ## This État
       `,
       options: {
         style: 'Title Case',
@@ -88,6 +92,19 @@ ruleTest({
         # Heading [[docker]]
         # Heading [docker](docker)
         # Heading ![docker](docker)
+      `,
+      options: {
+        style: 'First letter',
+      },
+    },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/321
+      testName: 'Make sure non-english letters get capitalized when they are the first letter and the rule is set to capitalize the first letter',
+      before: dedent`
+        # état
+      `,
+      after: dedent`
+        # État
       `,
       options: {
         style: 'First letter',


### PR DESCRIPTION
Fixes #321 

Changes Made:
- Swapped out the English letter check for the unicode letter check
- Added test for First Letter and Title Case capitalization styles
- Added an example for fenced code blocks that shows how nested code blocks get empty lines added around them