### PR TITLE
Try to Ensure Footnotes Show Up in Proper Order

### DIFF
--- a/src/rules/re-index-footnotes.ts
+++ b/src/rules/re-index-footnotes.ts
@@ -15,7 +15,7 @@ export default class ReIndexFootnotes extends RuleBuilder<ReIndexFootnotesOption
     return 'Re-Index Footnotes';
   }
   get description(): string {
-    return 'Re-indexes footnote keys and footnote, based on the order of occurence (NOTE: This rule deliberately does *not* preserve the relation between key and footnote, to be able to re-index duplicate keys.)';
+    return 'Re-indexes footnote keys and footnote, based on the order of occurrence (NOTE: This rule deliberately does *not* preserve the relation between key and footnote, to be able to re-index duplicate keys.)';
   }
   get type(): RuleType {
     return RuleType.FOOTNOTE;

--- a/src/test/move-footnotes-to-the-bottom.test.ts
+++ b/src/test/move-footnotes-to-the-bottom.test.ts
@@ -8,11 +8,13 @@ ruleTest({
     {
       testName: 'Simple case',
       before: dedent`
+        This has a footnote reference at the end [^alpha]
         [^alpha]: bravo and charlie.
         ${''}
         Line
       `,
       after: dedent`
+        This has a footnote reference at the end [^alpha]
         Line
         ${''}
         [^alpha]: bravo and charlie.
@@ -119,15 +121,40 @@ ruleTest({
     {
       testName: 'Footnote already at the bottom does not add an extra newline',
       before: dedent`
-        Line
+        Line [^alpha]
         ${''}
         [^alpha]: bravo and charlie.
       `,
       after: dedent`
-        Line
+        Line [^alpha]
         ${''}
         [^alpha]: bravo and charlie.
       `,
     },
+    {
+      testName: 'Make sure that a footnote placed between footnotes that already have content at the end of the file properly gets properly ordered',
+      before: dedent`
+        reference A [^1]
+        ${''}
+        reference C [^2]
+        [^2]: footnote C (inserted between A and B)
+        ${''}
+        reference B [^2]
+        ${''}
+        [^1]: footnote A (first in document)
+        [^2]: footnote B (last in document)
+      `,
+      after: dedent`
+        reference A [^1]
+        ${''}
+        reference C [^2]
+        reference B [^2]
+        ${''}
+        [^1]: footnote A (first in document)
+        [^2]: footnote C (inserted between A and B)
+        [^2]: footnote B (last in document)
+      `,
+    },
   ],
 });
+

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -59,7 +59,26 @@ export function getPositions(type: MDAstTypes, text: string): Position[] {
  */
 export function moveFootnotesToEnd(text: string) {
   const positions: Position[] = getPositions(MDAstTypes.Footnote, text);
-  const footnotes: string[] = [];
+  let footnotes: string[] = [];
+
+  const alreadyUsedReferencePositions = new Set<number>();
+  const mapOfFootnoteToFootnoteReferenceIndex = new Map<string, number>();
+  const referencePosition = function(footnote: string, startOfFootnoteReferenceSearch: number): number {
+    const footnoteReference = footnote.match(/\[\^.*?\]/)[0];
+    let footnoteReferenceLocation: number;
+    do {
+      footnoteReferenceLocation = text.lastIndexOf(footnoteReference, startOfFootnoteReferenceSearch);
+      startOfFootnoteReferenceSearch = footnoteReferenceLocation;
+    } while (alreadyUsedReferencePositions.has(footnoteReferenceLocation) && footnoteReferenceLocation !== -1 );
+
+    if (footnoteReferenceLocation === -1) {
+      throw new Error(`Footnote '${footnote}' has no corresponding footnote reference before the footnote contents and cannot be processed. Please make sure that all footnotes have a corresponding reference before the content of the footnote.`);
+    }
+
+    alreadyUsedReferencePositions.add(footnoteReferenceLocation);
+    return footnoteReferenceLocation;
+  };
+
 
   for (const position of positions) {
     const footnote = text.substring(position.start.offset, position.end.offset);
@@ -73,10 +92,13 @@ export function moveFootnotesToEnd(text: string) {
       text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
     }
     text = text.substring(0, position.start.offset) + text.substring(position.end.offset);
+    mapOfFootnoteToFootnoteReferenceIndex.set(footnote, referencePosition(footnote, position.start.offset));
   }
 
-  // Reverse the footnotes so that they are in the same order as the original text
-  footnotes.reverse();
+  // Sort the footnotes into the order of their references in the text
+  footnotes = footnotes.sort((f1: string, f2: string) => {
+    return mapOfFootnoteToFootnoteReferenceIndex.get(f1) - mapOfFootnoteToFootnoteReferenceIndex.get(f2);
+  });
 
   // Add the footnotes to the end of the document
   if (footnotes.length > 0) {


### PR DESCRIPTION
When a footnote is inserted in a document where the footnotes were already moved to the end of the file, the values for the footnotes were not being moved to the end and associated with the proper reference. As a result, the logic has been updated to make it so that it will try to find the first instance of an unused footnote reference that matches the one in question and use that character index when sorting.

Changes Made:
- Footnotes must now have an associated reference or else an error will occur when it tries to move the value to the end
- Updated tests to account for new sorting and added the test for a modified version of #314 