### PR TITLE
Add Option to Remove Empty Line Between Header and Yaml, Add Blockquote Support and Other List Markers to List Item Removal, and Minifier Process Update

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1225,6 +1225,14 @@ Before:
 - item 1
 -
 - item 2
+
+* list 2 item 1
+    *
+* list 2 item 2
+
++ list 3 item 1
++
++ list 3 item 2
 ``````
 
 After:
@@ -1232,6 +1240,60 @@ After:
 ``````markdown
 - item 1
 - item 2
+
+* list 2 item 1
+* list 2 item 2
+
++ list 3 item 1
++ list 3 item 2
+``````
+Example: Removes empty ordered list markers.
+
+Before:
+
+``````markdown
+1. item 1
+2.
+3. item 2
+
+1. list 2 item 1
+2. list 2 item 2
+3. 
+
+_Note that this rule does not make sure that the ordered list is sequential after removal_
+``````
+
+After:
+
+``````markdown
+1. item 1
+3. item 2
+
+1. list 2 item 1
+2. list 2 item 2
+
+_Note that this rule does not make sure that the ordered list is sequential after removal_
+``````
+Example: Removes empty checklist markers.
+
+Before:
+
+``````markdown
+- [ ]  item 1
+- [x]
+- [ ] item 2
+- [ ]   
+
+_Note that this will affect checked and uncheck checked list items_
+``````
+
+After:
+
+``````markdown
+- [ ]  item 1
+- [ ] item 2
+
+_Note that this will affect checked and uncheck checked list items_
 ``````
 
 ### Remove Hyphenated Line Breaks

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1295,6 +1295,68 @@ After:
 
 _Note that this will affect checked and uncheck checked list items_
 ``````
+Example: Removes empty list, checklist, and ordered list markers in callouts/blockquotes
+
+Before:
+
+``````markdown
+> Checklist in blockquote
+> - [ ]  item 1
+> - [x]
+> - [ ] item 2
+> - [ ]   
+
+> Ordered List in blockquote
+> > 1. item 1
+> > 2.
+> > 3. item 2
+> > 4.  
+
+> Regular lists in blockquote
+>
+> - item 1
+> -
+> - item 2
+>
+> List 2
+>
+> * item 1
+>     *
+> * list 2 item 2
+>
+> List 3
+>
+> + item 1
+> + 
+> + item 2
+``````
+
+After:
+
+``````markdown
+> Checklist in blockquote
+> - [ ]  item 1
+> - [ ] item 2
+
+> Ordered List in blockquote
+> > 1. item 1
+> > 3. item 2
+
+> Regular lists in blockquote
+>
+> - item 1
+> - item 2
+>
+> List 2
+>
+> * item 1
+> * list 2 item 2
+>
+> List 3
+>
+> + item 1
+> + item 2
+``````
 
 ### Remove Hyphenated Line Breaks
 
@@ -1989,6 +2051,8 @@ All headings have a blank line both before and after (except where the heading i
 Options:
 - Bottom: Insert a blank line after headings
 	- Default: `true`
+- Empty Line Between Yaml and Header: Keep the empty line between the Yaml frontmatter and header
+	- Default: `true`
 
 Example: Headings should be surrounded by blank lines
 
@@ -2040,6 +2104,28 @@ line
 
 # H1
 line
+``````
+Example: Empty line before header and after Yaml is removed with `Empty Line Between Yaml and Header=true`
+
+Before:
+
+``````markdown
+---
+alias: ['authoughts']
+---
+# Automatic thoughts
+Paragraph here...
+``````
+
+After:
+
+``````markdown
+---
+alias: ['authoughts']
+---
+# Automatic thoughts
+
+Paragraph here...
 ``````
 
 ### Line Break at Document End

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2111,9 +2111,9 @@ Before:
 
 ``````markdown
 ---
-alias: ['authoughts']
+key: value
 ---
-# Automatic thoughts
+# Header
 Paragraph here...
 ``````
 
@@ -2121,9 +2121,9 @@ After:
 
 ``````markdown
 ---
-alias: ['authoughts']
+key: value
 ---
-# Automatic thoughts
+# Header
 
 Paragraph here...
 ``````

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
-    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --ecma 2016 --comments /GENERATED/ --output main.js",
+    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --ecma 2016 --comments \"/(GENERATED|Copyright|license)/\" --output main.js",
     "test": "jest",
     "docs": "node docs.js",
     "compile": "npm run build && npm run docs && npm run lint && npm run test",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
-    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --ecma 2016 --comments false --output main.js",
+    "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --ecma 2016 --comments /GENERATED/ --output main.js",
     "test": "jest",
     "docs": "node docs.js",
     "compile": "npm run build && npm run docs && npm run lint && npm run test",

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -2,9 +2,11 @@ import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
+import {yamlRegex} from '../utils/regex';
 
 class HeadingBlankLinesOptions implements Options {
   bottom: boolean = true;
+  emptyLineAfterYaml: boolean = true;
 }
 
 @RuleBuilder.register
@@ -31,8 +33,14 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
         text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
         text = text.replace(/(^#+\s.*)\n+/gm, '$1\n\n'); // trim blank lines after headings
       }
+
       text = text.replace(/^\n+(#+\s.*)/, '$1'); // remove blank lines before first heading
       text = text.replace(/(#+\s.*)\n+$/, '$1'); // remove blank lines after last heading
+
+      if (!options.emptyLineAfterYaml) {
+        text = text.replace(new RegExp('(' + yamlRegex.source + ')\\n+(#+\\s.*)'), '$1\n$5');
+      }
+
       return text;
     });
   }
@@ -82,6 +90,29 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
         `,
         options: {
           bottom: false,
+          emptyLineAfterYaml: true,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Empty line before header and after Yaml is removed with `Empty Line Between Yaml and Header=true`',
+        before: dedent`
+          ---
+          alias: ['authoughts']
+          ---
+          # Automatic thoughts
+          Paragraph here...
+        `,
+        after: dedent`
+          ---
+          alias: ['authoughts']
+          ---
+          # Automatic thoughts
+
+          Paragraph here...
+        `,
+        options: {
+          bottom: true,
+          emptyLineAfterYaml: false,
         },
       }),
     ];
@@ -93,6 +124,12 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
         name: 'Bottom',
         description: 'Insert a blank line after headings',
         optionsKey: 'bottom',
+      }),
+      new BooleanOptionBuilder({
+        OptionsClass: HeadingBlankLinesOptions,
+        name: 'Empty Line Between Yaml and Header',
+        description: 'Keep the empty line between the Yaml frontmatter and header',
+        optionsKey: 'emptyLineAfterYaml',
       }),
     ];
   }

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -94,19 +94,20 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
         },
       }),
       new ExampleBuilder({
+        // accounts for https://github.com/platers/obsidian-linter/issues/219
         description: 'Empty line before header and after Yaml is removed with `Empty Line Between Yaml and Header=true`',
         before: dedent`
           ---
-          alias: ['authoughts']
+          key: value
           ---
-          # Automatic thoughts
+          # Header
           Paragraph here...
         `,
         after: dedent`
           ---
-          alias: ['authoughts']
+          key: value
           ---
-          # Automatic thoughts
+          # Header
 
           Paragraph here...
         `,

--- a/src/rules/remove-empty-list-markers.ts
+++ b/src/rules/remove-empty-list-markers.ts
@@ -22,7 +22,7 @@ export default class RemoveEmptyListMarkers extends RuleBuilder<RemoveEmptyListM
   }
   apply(text: string, options: RemoveEmptyListMarkersOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      return text.replace(/^\s*-\s*\n/gm, '');
+      return text.replace(/^\s*(-|\*|\+|\d+.|- (\[( |x)\]))\s*?$\n/gm, '');
     });
   }
   get exampleBuilders(): ExampleBuilder<RemoveEmptyListMarkersOptions>[] {
@@ -33,10 +33,64 @@ export default class RemoveEmptyListMarkers extends RuleBuilder<RemoveEmptyListM
           - item 1
           -
           - item 2
+          ${''}
+          * list 2 item 1
+              *
+          * list 2 item 2
+          ${''}
+          + list 3 item 1
+          +
+          + list 3 item 2
         `,
         after: dedent`
           - item 1
           - item 2
+          ${''}
+          * list 2 item 1
+          * list 2 item 2
+          ${''}
+          + list 3 item 1
+          + list 3 item 2
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Removes empty ordered list markers.',
+        before: dedent`
+          1. item 1
+          2.
+          3. item 2
+          ${''}
+          1. list 2 item 1
+          2. list 2 item 2
+          3. ${''}
+          ${''}
+          _Note that this rule does not make sure that the ordered list is sequential after removal_
+        `,
+        after: dedent`
+          1. item 1
+          3. item 2
+          ${''}
+          1. list 2 item 1
+          2. list 2 item 2
+          ${''}
+          _Note that this rule does not make sure that the ordered list is sequential after removal_
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Removes empty checklist markers.',
+        before: dedent`
+          - [ ]  item 1
+          - [x]
+          - [ ] item 2
+          - [ ]   ${''}
+          ${''}
+          _Note that this will affect checked and uncheck checked list items_
+        `,
+        after: dedent`
+          - [ ]  item 1
+          - [ ] item 2
+          ${''}
+          _Note that this will affect checked and uncheck checked list items_
         `,
       }),
     ];

--- a/src/rules/remove-empty-list-markers.ts
+++ b/src/rules/remove-empty-list-markers.ts
@@ -22,7 +22,7 @@ export default class RemoveEmptyListMarkers extends RuleBuilder<RemoveEmptyListM
   }
   apply(text: string, options: RemoveEmptyListMarkersOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      return text.replace(/^\s*(-|\*|\+|\d+.|- (\[( |x)\]))\s*?$\n/gm, '');
+      return text.replace(/^\s*(>\s*)*(-|\*|\+|\d+.|- (\[( |x)\]))\s*?$\n/gm, '');
     });
   }
   get exampleBuilders(): ExampleBuilder<RemoveEmptyListMarkersOptions>[] {
@@ -91,6 +91,64 @@ export default class RemoveEmptyListMarkers extends RuleBuilder<RemoveEmptyListM
           - [ ] item 2
           ${''}
           _Note that this will affect checked and uncheck checked list items_
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Removes empty list, checklist, and ordered list markers in callouts/blockquotes',
+        before: dedent`
+          > Checklist in blockquote
+          > - [ ]  item 1
+          > - [x]
+          > - [ ] item 2
+          > - [ ]   ${''}
+          ${''}
+          > Ordered List in blockquote
+          > > 1. item 1
+          > > 2.
+          > > 3. item 2
+          > > 4.  ${''}
+          ${''}
+          > Regular lists in blockquote
+          >
+          > - item 1
+          > -
+          > - item 2
+          >
+          > List 2
+          >
+          > * item 1
+          >     *
+          > * list 2 item 2
+          >
+          > List 3
+          >
+          > + item 1
+          > + 
+          > + item 2
+        `,
+        after: dedent`
+          > Checklist in blockquote
+          > - [ ]  item 1
+          > - [ ] item 2
+          ${''}
+          > Ordered List in blockquote
+          > > 1. item 1
+          > > 3. item 2
+          ${''}
+          > Regular lists in blockquote
+          >
+          > - item 1
+          > - item 2
+          >
+          > List 2
+          >
+          > * item 1
+          > * list 2 item 2
+          >
+          > List 3
+          >
+          > + item 1
+          > + item 2
         `,
       }),
     ];


### PR DESCRIPTION
Fixes #331
Fixes #219 

Changes Made:
- Updated build command to make sure that for production it keeps the license comments and banner that states that the js file is generated
- Updated `heading-blank-lines` to allow the user to decide if they want an empty line before the Yaml frontmatter and the first header (the default is to have one)
- Updated `remove-empty-list-markers` to account for nesting in blockquotes or callouts and also added `+`, `#.`, `*`, `- [ ]` and `- [x]` to the list of empty list markers