### PR TITLE
Add Rule to Format Yaml Arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Documentation for all rules can be found in the [rules docs](https://github.com/
 
 - [escape-yaml-special-characters](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#escape-yaml-special-characters)
 - [format-tags-in-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#format-tags-in-yaml)
+- [format-yaml-array](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#format-yaml-array)
 - [insert-yaml-attributes](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#insert-yaml-attributes)
 - [remove-yaml-keys](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-yaml-keys)
 - [yaml-key-sort](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#yaml-key-sort)

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -716,9 +716,6 @@ ruleTest({
         aliases: [title 1, title 2]
         ---
       `,
-      options: {
-        tagArrayStyle: 'single-line',
-      },
     },
   ],
 });

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -687,7 +687,7 @@ ruleTest({
       },
     },
     {
-      testName: 'Trying to format aliases to a single-line separated by spaces when it is has an empty string will result in an empty single-line',
+      testName: 'Trying to format aliases to a single-line when it is has an empty string will result in an empty single-line',
       before: dedent`
         ---
         aliases: 
@@ -699,7 +699,25 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single-line space delimited',
+        aliasArrayStyle: 'single-line',
+      },
+    },
+    {
+      testName: 'Un-indented array items are associated with array',
+      before: dedent`
+        ---
+        aliases:
+        - title 1
+        - title 2
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: [title 1, title 2]
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single-line',
       },
     },
   ],

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -1,0 +1,182 @@
+import FormatYamlArray from '../src/rules/format-yaml-arrays';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: FormatYamlArray,
+  testCases: [
+    {
+      testName: 'Convert tags from single-line with spaces to multi-line array',
+      before: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags:
+          - tag1
+          - tag2
+          - tag3
+          - tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'multi-line',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line with spaces to single-line array',
+      before: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: [tag1, tag2, tag3, tag4]
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single-line',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line with spaces to single-line with commas',
+      before: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: tag1, tag2, tag3, tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string comma delimited',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line with spaces to single-line array which is space delimited',
+      before: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: [tag1 tag2 tag3 tag4]
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single-line space delimited',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line with spaces to single-line with spaces',
+      before: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string space delimited',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line array with spaces to single-line with spaces',
+      before: dedent`
+        ---
+        tags: [tag1 tag2 tag3 tag4]
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string space delimited',
+      },
+    },
+    {
+      testName: 'Convert tags from multi-line array with spaces to single string when 1 element is present',
+      before: dedent`
+        ---
+        tags:
+          - tag1
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: tag1
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string to single-line',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line with commas to single-line array when multiple elements present and option is single string to single-line',
+      before: dedent`
+        ---
+        tags: tag1, tag2, tag3, tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: [tag1, tag2, tag3, tag4]
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string to single-line',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line array with spaces to multi-line array when multiple elements present and option is single string to multi-line',
+      before: dedent`
+        ---
+        tags: tag1 tag2 tag3 tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags:
+          - tag1
+          - tag2
+          - tag3
+          - tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string to multi-line',
+      },
+    },
+    {
+      testName: 'Convert tags from single-line string to single-line string when there is only 1 element and the style is single string to multi-line',
+      before: dedent`
+        ---
+        tags: tag1, tag2, tag3, tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags:
+          - tag1
+          - tag2
+          - tag3
+          - tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string to multi-line',
+      },
+    },
+  ],
+});

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -717,5 +717,43 @@ ruleTest({
         ---
       `,
     },
+    {
+      testName: 'An empty multi-line array does not get modified when linted and it is supposed to be a multi-line array',
+      before: dedent`
+        ---
+        speakers:
+          - 
+        ---
+      `,
+      after: dedent`
+        ---
+        speakers:
+          - 
+        ---
+      `,
+      options: {
+        forceMultiLineArrayStyle: ['speakers'],
+      },
+    },
+    {
+      testName: 'A multi-line array with mixed empty and non-empty values should have empty values removed',
+      before: dedent`
+        ---
+        speakers:
+          - 
+          - speaker1
+          - 
+        ---
+      `,
+      after: dedent`
+        ---
+        speakers:
+          - speaker1
+        ---
+      `,
+      options: {
+        forceMultiLineArrayStyle: ['speakers'],
+      },
+    },
   ],
 });

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -755,5 +755,18 @@ ruleTest({
         forceMultiLineArrayStyle: ['speakers'],
       },
     },
+    {
+      testName: 'A single-line array with an empty value at the end should have the empty value removed',
+      before: dedent`
+        ---
+        speakers: [speaker1, ]
+        ---
+      `,
+      after: dedent`
+        ---
+        speakers: [speaker1]
+        ---
+      `,
+    },
   ],
 });

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -690,12 +690,12 @@ ruleTest({
       testName: 'Trying to format aliases to a single-line separated by spaces when it is has an empty string will result in an empty single-line',
       before: dedent`
         ---
-        tags: 
+        aliases: 
         ---
       `,
       after: dedent`
         ---
-        tags: []
+        aliases: []
         ---
       `,
       options: {

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -5,6 +5,7 @@ import {ruleTest} from './common';
 ruleTest({
   RuleBuilderClass: FormatYamlArray,
   testCases: [
+    // tags
     {
       testName: 'Convert tags from single-line with spaces to multi-line array',
       before: dedent`
@@ -178,5 +179,161 @@ ruleTest({
         tagArrayStyle: 'single string to multi-line',
       },
     },
+    {
+      testName: 'Formatting yaml tags does nothing when disabled',
+      before: dedent`
+        ---
+        tags: tag1, tag2, tag3, tag4
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: tag1, tag2, tag3, tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string to multi-line',
+        formatTagKey: false,
+      },
+    },
+
+    // aliases
+    {
+      testName: 'Convert aliases from single-line to multi-line array',
+      before: dedent`
+        ---
+        aliases: [title1, title2, title3]
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - title1
+          - title2
+          - title3
+        ---
+      `,
+      options: {
+        aliasArrayStyle: 'multi-line',
+      },
+    },
+    {
+      testName: 'Convert aliases from multi-line to single string which is comma delimited',
+      before: dedent`
+        ---
+        aliases:
+          - title1
+          - title2
+          - title3
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: title1, title2, title3
+        ---
+      `,
+      options: {
+        aliasArrayStyle: 'single string comma delimited',
+      },
+    },
+    {
+      testName: 'Convert multi-line to single string when there is 1 element and the style is single string to single-line',
+      before: dedent`
+        ---
+        aliases:
+          - title
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: title
+        ---
+      `,
+      options: {
+        aliasArrayStyle: 'single string to single-line',
+      },
+    },
+    {
+      testName: 'Convert multi-line to single string when there is 1 element and the style is single string to multi-line',
+      before: dedent`
+        ---
+        aliases:
+          - title
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: title
+        ---
+      `,
+      options: {
+        aliasArrayStyle: 'single string to multi-line',
+      },
+    },
+    {
+      testName: 'Convert single-line to multi-line string when there is more than 1 element and the style is single string to multi-line',
+      before: dedent`
+        ---
+        aliases: [title, other title]
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - title
+          - other title
+        ---
+      `,
+      options: {
+        aliasArrayStyle: 'single string to multi-line',
+      },
+    },
+    {
+      testName: 'Convert multi-line to single-line when there is more than 1 element and the style is single string to single-line',
+      before: dedent`
+        ---
+        aliases:
+          - title
+          - other title
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: [title, other title]
+        ---
+      `,
+      options: {
+        aliasArrayStyle: 'single string to single-line',
+      },
+    },
+    {
+      testName: 'Formatting aliases does nothing when disabled',
+      before: dedent`
+        ---
+        aliases:
+          - title
+          - other title
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - title
+          - other title
+        ---
+      `,
+      options: {
+        aliasArrayStyle: 'single string to single-line',
+        formatAliasKey: false,
+      },
+    },
+
+    // default array style
+
+    // force single-line
+
+    // force multi-line
+
+    // combinations
   ],
 });

--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -329,11 +329,378 @@ ruleTest({
     },
 
     // default array style
+    {
+      testName: 'Convert multi-line to single-line for regular yaml arrays',
+      before: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      after: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'single-line',
+      },
+    },
+    {
+      testName: 'Convert single-line to multi-line for regular yaml arrays',
+      before: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      after: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'multi-line',
+      },
+    },
+    {
+      testName: 'Regular yaml array formatting does nothing when disabled',
+      before: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      after: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'multi-line',
+        formatArrayKeys: false,
+      },
+    },
+    {
+      testName: 'Regular yaml array formatting does nothing when key is present in list for forcing to be single-line',
+      before: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      after: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'multi-line',
+        forceSingleLineArrayStyle: ['key'],
+      },
+    },
+    {
+      testName: 'Regular yaml array formatting does nothing when key is present in list for forcing to be multi-line',
+      before: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      after: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'single-line',
+        forceMultiLineArrayStyle: ['key'],
+      },
+    },
+    {
+      testName: 'Regular yaml array formatting does nothing to tags and aliases',
+      before: dedent`
+        ---
+        aliases: [title1, other title]
+        tags: [tag1, tag2, tag3]
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: [title1, other title]
+        tags: [tag1, tag2, tag3]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'multi-line',
+      },
+    },
 
     // force single-line
+    {
+      testName: 'Forcing single-line on a multi-line array results in a single-line array',
+      before: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      after: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'multi-line',
+        forceSingleLineArrayStyle: ['key'],
+      },
+    },
+    {
+      testName: 'Forcing single-line on a key that is not present just ignores the value',
+      before: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      after: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'multi-line',
+        forceSingleLineArrayStyle: ['key1'],
+      },
+    },
+    {
+      testName: 'Forcing single-line on a value that is a single string will result in a single-line',
+      before: dedent`
+        ---
+        key: text here
+        ---
+      `,
+      after: dedent`
+        ---
+        key: [text here]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'multi-line',
+        forceSingleLineArrayStyle: ['key'],
+      },
+    },
 
     // force multi-line
+    {
+      testName: 'Forcing multi-line on a single-line array results in a multi-line array',
+      before: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      after: dedent`
+        ---
+        key:
+          - val1
+          - other val
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'single-line',
+        forceMultiLineArrayStyle: ['key'],
+      },
+    },
+    {
+      testName: 'Forcing multi-line on a key that does not exist results in it being ignored',
+      before: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      after: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'single-line',
+        forceMultiLineArrayStyle: ['key1'],
+      },
+    },
+    {
+      testName: 'Forcing multi-line on a key that does not exist results in it being ignored',
+      before: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      after: dedent`
+        ---
+        key: [val1, other val]
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'single-line',
+        forceMultiLineArrayStyle: ['key1'],
+      },
+    },
+    {
+      testName: 'Forcing multi-line on a key that has a single string will result in a multi-line',
+      before: dedent`
+        ---
+        key: here is some text
+        ---
+      `,
+      after: dedent`
+        ---
+        key:
+          - here is some text
+        ---
+      `,
+      options: {
+        defaultArrayStyle: 'single-line',
+        forceMultiLineArrayStyle: ['key'],
+      },
+    },
 
-    // combinations
+    // edge cases
+    {
+      testName: 'Forcing multi-line on a key that has no value will result in an empty multi-line array',
+      before: dedent`
+        ---
+        key: 
+        ---
+      `,
+      after: dedent`
+        ---
+        key:
+          - 
+        ---
+      `,
+      options: {
+        forceMultiLineArrayStyle: ['key'],
+      },
+    },
+    {
+      testName: 'Forcing single-line on a key that has no value will result in an empty single-line array',
+      before: dedent`
+        ---
+        key: 
+        ---
+      `,
+      after: dedent`
+        ---
+        key: []
+        ---
+      `,
+      options: {
+        forceSingleLineArrayStyle: ['key'],
+      },
+    },
+    {
+      testName: 'Trying to format tags to a single string when it is has an empty single-line will result in an empty single string',
+      before: dedent`
+        ---
+        tags: []
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: 
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string to single-line',
+      },
+    },
+    {
+      testName: 'Trying to format tags to a multi-line when it is has an empty single-line will result in an empty multi-line',
+      before: dedent`
+        ---
+        tags: []
+        ---
+      `,
+      after: dedent`
+        ---
+        tags:
+          - 
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'multi-line',
+      },
+    },
+    {
+      testName: 'Trying to format tags to a single string separated by commas when it is has an empty single-line will result in an empty string',
+      before: dedent`
+        ---
+        tags: []
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: 
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string comma delimited',
+      },
+    },
+    {
+      testName: 'Trying to format tags to a single string separated by spaces when it is has an empty single-line will result in an empty string',
+      before: dedent`
+        ---
+        tags: []
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: 
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single string space delimited',
+      },
+    },
+    {
+      testName: 'Trying to format tags to a single-line separated by spaces when it is has an empty single-line will result in an empty single-line',
+      before: dedent`
+        ---
+        tags: []
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: []
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single-line space delimited',
+      },
+    },
+    {
+      testName: 'Trying to format aliases to a single-line separated by spaces when it is has an empty string will result in an empty single-line',
+      before: dedent`
+        ---
+        tags: 
+        ---
+      `,
+      after: dedent`
+        ---
+        tags: []
+        ---
+      `,
+      options: {
+        tagArrayStyle: 'single-line space delimited',
+      },
+    },
   ],
 });

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -235,9 +235,13 @@ aliases: Title 1, Title2
 test: this is a value
 ---
 
-# Note
+# Notes:
 
 Nesting yaml arrays may result in unexpected results.
+
+Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
+
+Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
 ``````
 
 After:
@@ -251,9 +255,13 @@ aliases:
 test: [this is a value]
 ---
 
-# Note
+# Notes:
 
 Nesting yaml arrays may result in unexpected results.
+
+Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
+
+Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
 ``````
 Example: Format tags as a single string with space delimiters, ignore aliases, and format regular yaml arrays as single-line arrays
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -239,8 +239,6 @@ test: this is a value
 
 Nesting yaml arrays may result in unexpected results.
 
-Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
-
 Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
 ``````
 
@@ -258,8 +256,6 @@ test: [this is a value]
 # Notes:
 
 Nesting yaml arrays may result in unexpected results.
-
-Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
 
 Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
 ``````

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -186,6 +186,99 @@ tags:
 ---
 ``````
 
+### Format Yaml Array
+
+Alias: `format-yaml-array`
+
+Allows for the formatting of regular yaml arrays as either multi-line or single-line and `tags` and `aliases` are allowed to have some Obsidian specific yaml formats. Note that single string to single-line goes from a single string entry to a single-line array if more than 1 entry is present. The same is true for single string to multi-line except it becomes a multi-line array.
+
+Options:
+- Yaml aliases section style: The style of the yaml aliases section
+	- Default: `single-line`
+	- `multi-line`: ```aliases:\n  - Title```
+	- `single-line`: ```aliases: [Title]```
+	- `single string comma delimited`: ```aliases: Title, Other Title```
+	- `single string to single-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a single-line array.
+	- `single string to multi-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a multi-line array.
+- Format yaml aliases section: Turns on formatting for the yaml aliases section
+	- Default: `true`
+- Yaml tags section style: The style of the yaml tags section
+	- Default: `single-line`
+	- `multi-line`: ```tags:\n  - tag1```
+	- `single-line`: ```tags: [tag1]```
+	- `single string to single-line`: Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.
+	- `single string to multi-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.
+	- `single-line space delimited`: ```tags: [tag1 tag2]```
+	- `single string space delimited`: ```tags: tag1 tag2```
+	- `single string comma delimited`: ```tags: tag1, tag2```
+- Default yaml array section style: The style of other yaml arrays that are not `tags`, `aliases` or  in `Force key values to be single-line arrays` and `Force key values to be multi-line arrays`
+	- Default: `single-line`
+	- `multi-line`: ```key:\n  - value```
+	- `single-line`: ```key: [value]```
+- Format yaml array sections: Turns on formatting for regular yaml arrays
+	- Default: `true`
+- Force key values to be single-line arrays: Forces the yaml array for the new line separated keys to be in single-line format (leave empty to disable this option)
+	- Default: ``
+- Force key values to be multi-line arrays: Forces the yaml array for the new line separated keys to be in multi-line format (leave empty to disable this option)
+	- Default: ``
+
+Example: Format tags as a single-line array delimited by spaces and aliases as a multi-line array and format the key `test` to be a single-line array
+
+Before:
+
+``````markdown
+---
+tags:
+  - computer
+  - research
+aliases: Title 1, Title2
+test: this is a value
+---
+
+# Note
+
+Nesting yaml arrays may result in unexpected results.
+``````
+
+After:
+
+``````markdown
+---
+tags: [computer, research]
+aliases:
+  - Title 1
+  - Title2
+test: [this is a value]
+---
+
+# Note
+
+Nesting yaml arrays may result in unexpected results.
+``````
+Example: Format tags as a single string with space delimiters, ignore aliases, and format regular yaml arrays as single-line arrays
+
+Before:
+
+``````markdown
+---
+aliases: Typescript
+types:
+  - thought provoking
+  - peer reviewed
+tags: [computer, science, trajectory]
+---
+``````
+
+After:
+
+``````markdown
+---
+aliases: Typescript
+types: [thought provoking, peer reviewed]
+tags: computer science trajectory
+---
+``````
+
 ### Insert YAML attributes
 
 Alias: `insert-yaml-attributes`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js --environment BUILD:production && terser main.js --compress toplevel=true,passes=2 --ecma 2016 --comments \"/(GENERATED|Copyright|license)/\" --output main.js",
     "test": "jest",
+    "test-suite": "jest -t \"$1\"",
     "docs": "node docs.js",
     "compile": "npm run build && npm run docs && npm run lint && npm run test",
     "lint": "eslint . --ext .ts --fix"

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,7 +248,6 @@ export default class LinterPlugin extends Plugin {
     // escape YAML where possible before parsing yaml
     [newText] = EscapeYamlSpecialCharacters.applyIfEnabled(newText, this.settings, disabledRules);
 
-
     const modifiedAtTime = moment(file.stat.mtime, this.momentLocale).format();
     const createdAtTime = moment(file.stat.ctime, this.momentLocale).format();
 

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -1,0 +1,430 @@
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder} from './rule-builder';
+import dedent from 'ts-dedent';
+import {formatYAML, loadYAML, setYamlSection, toSingleLineArrayYamlString} from '../utils/yaml';
+
+/**
+ * new Rule(
+    'Format YAML Arrays',
+    '',
+    RuleType.YAML,
+    (text: string, options = {}) => {
+      const yaml = text.match(yamlRegex);
+      if (!yaml) {
+        return text;
+      }
+
+      const yamlKeysToRemove: string[] = options['YAML Keys to Remove'].split('\n');
+
+      let yamlText = yaml[1];
+      for (const key of yamlKeysToRemove) {
+        let actualKey = key.trim();
+        if (actualKey.endsWith(':')) {
+          actualKey = actualKey.substring(0, actualKey.length - 1);
+        }
+
+        yamlText = removeYamlSection(yamlText, actualKey);
+      }
+
+
+      return text.replace(yaml[1], yamlText);
+    },
+    [
+      new Example(
+          'Removes the values specified in `YAML Keys to Remove` = "status:\nkeywords\ndate"',
+          dedent`
+        ---
+        language: Typescript
+        type: programming
+        tags: computer
+        keywords:
+          - keyword1
+          - keyword2
+        status: WIP
+        date: 02/15/2022
+        ---
+
+        # Header Context
+
+        Text
+        `,
+          dedent`
+        ---
+        language: Typescript
+        type: programming
+        tags: computer
+        ---
+
+        # Header Context
+
+        Text
+        `,
+          {'YAML Keys to Remove': 'status:\nkeywords\ndate'},
+      ),
+    ],
+    [
+      new DropdownOption(
+          'YAML aliases section style',
+          'The style of the aliases YAML section',
+          'Multi-line array',
+          [
+            new DropdownRecord(
+                'Multi-line array',
+                '```aliases:\\n  - Title```',
+            ),
+            new DropdownRecord(
+                'Single-line array',
+                '```aliases: [Title]```',
+            ),
+            new DropdownRecord(
+                'Single string that expands to multi-line array if needed',
+                '```aliases: Title```',
+            ),
+            new DropdownRecord(
+                'Single string that expands to single-line array if needed',
+                '```aliases: Title```',
+            ),
+          ],
+      ),
+      new DropdownOption(
+          'YAML tags section style',
+          'The style of the tags YAML section',
+          'Multi-line array',
+          [
+            new DropdownRecord(
+                'Multi-line array',
+                '```tags:\\n  - tag```',
+            ),
+            new DropdownRecord(
+                'Single-line array',
+                '```tags: [tag]```',
+            ),
+            new DropdownRecord(
+                'Single string that expands to multi-line array if needed',
+                '```tags: tag```',
+            ),
+            new DropdownRecord(
+                'Single string that expands to single-line array if needed',
+                '```tags: tag```',
+            ),
+          ],
+      ),
+      new DropdownOption(
+          'Default YAML array section style',
+          'The style to use for any YAML array except `tags` and `aliases`',
+          'Multi-line array',
+          [
+            new DropdownRecord(
+                'Multi-line array',
+                '```key:\\n  - value```',
+            ),
+            new DropdownRecord(
+                'Single-line array',
+                '```key: [value]```',
+            ),
+          ],
+      ),
+      new TextAreaOption('Force Single-line Array for YAML Keys', 'The yaml keys to make sure that they are single-line arrays', ''),
+      new TextAreaOption('Force Multi-line Array for YAML Keys', 'The yaml keys to make sure that they are multi-line arrays', ''),
+    ],
+),
+ */
+
+type TagSpecificYamlArrayFormats = 'single string space delimited' | 'single string comma delimited' | 'single-line space delimited';
+
+type SpecialYamlArrayFormats = 'single string to single-line' | 'single string to multi-line';
+
+type NormalYamlArrayFormats = 'single-line' | 'multi-line';
+
+class FormatYamlArrayOptions implements Options {
+  aliasArrayStyle?: NormalYamlArrayFormats | SpecialYamlArrayFormats = 'single-line';
+  formatAliasKey?: boolean = true;
+  tagArrayStyle?: TagSpecificYamlArrayFormats | NormalYamlArrayFormats | SpecialYamlArrayFormats = 'single-line';
+  formatTagKey?: boolean = true;
+  defaultArrayStyle?: NormalYamlArrayFormats = 'single-line';
+  formatArrayKeys?: boolean = true;
+  forceSingleLineArrayStyle?: string[] = [];
+  forceMultiLineArrayStyle?: string[] = [];
+}
+
+@RuleBuilder.register
+export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
+  get OptionsClass(): new () => FormatYamlArrayOptions {
+    return FormatYamlArrayOptions;
+  }
+  get name(): string {
+    return 'Format YAML Array';
+  }
+  get description(): string {
+    return 'Allows for the formatting of arrays to either be multi-line or single-line arrays with `tags` and `aliases` getting more options';
+  }
+  get type(): RuleType {
+    return RuleType.YAML;
+  }
+  apply(text: string, options: FormatYamlArrayOptions): string {
+    return formatYAML(text, (text: string) => {
+      const obsidianTagKey = 'tags';
+      const obsidianAliasKey = 'aliases';
+
+      const yaml = loadYAML(text.replace('---\n', '').replace('\n---', ''));
+      if (!yaml) {
+        return text;
+      }
+
+      const formatYamlArrayValue = function(value: string | string[], format: NormalYamlArrayFormats | SpecialYamlArrayFormats | TagSpecificYamlArrayFormats): string {
+        if (typeof value === 'string') {
+          value = [value];
+        }
+
+        switch (format) {
+          case 'single-line':
+            return ' ' + toSingleLineArrayYamlString(value);
+          case 'multi-line':
+            return '\n  - ' + value.join('\n  - ');
+          case 'single string to single-line':
+            if (value.length === 1) {
+              return ' ' + value[0];
+            }
+
+            return ' ' + toSingleLineArrayYamlString(value);
+          case 'single string to multi-line':
+            if (value.length === 1) {
+              return ' ' + value[0];
+            }
+
+            return '\n  - ' + value.join('\n  - ');
+          case 'single string space delimited':
+            if (value.length === 1) {
+              return ' ' + value[0];
+            }
+            return ' ' +value.join(' ');
+          case 'single string comma delimited':
+            if (value.length === 1) {
+              return ' ' + value[0];
+            }
+            return ' ' + value.join(', ');
+          case 'single-line space delimited':
+            if (value.length === 1) {
+              return ' ' + value[0];
+            }
+
+            return ' ' + toSingleLineArrayYamlString(value).replaceAll(', ', ' ');
+        }
+      };
+
+      const convertTagValueToStringOrStringArray = function(value: string | string[]): string[] {
+        if (typeof value === 'string') {
+          if (value.includes(',')) {
+            return value.split(', ');
+          }
+
+          return value.split(' ');
+        }
+
+        return value;
+      };
+
+      if (options.formatAliasKey && Object.keys(yaml).includes(obsidianAliasKey)) {
+        text = setYamlSection(text, obsidianAliasKey, formatYamlArrayValue(yaml[obsidianAliasKey], options.aliasArrayStyle) );
+      }
+
+      if (options.formatAliasKey && Object.keys(yaml).includes(obsidianTagKey)) {
+        text = setYamlSection(text, obsidianTagKey, formatYamlArrayValue(convertTagValueToStringOrStringArray(yaml[obsidianTagKey]), options.tagArrayStyle));
+      }
+
+
+      if (options.formatArrayKeys) {
+        const keysToIgnore = [obsidianAliasKey, obsidianTagKey, ...options.forceMultiLineArrayStyle, ...options.forceSingleLineArrayStyle];
+
+        for (const key of Object.keys(yaml)) {
+          // skip non-arrays and already accounted for keys
+          if (keysToIgnore.includes(key) || !(typeof yaml[key] !== 'string' && yaml[key] as string[])) {
+            continue;
+          }
+
+          text = setYamlSection(text, key, formatYamlArrayValue(yaml[key], options.defaultArrayStyle));
+        }
+      }
+
+      for (const singleLineArrayKey of options.forceSingleLineArrayStyle) {
+        if (!Object.keys(yaml).includes(singleLineArrayKey)) {
+          continue;
+        }
+
+        text = setYamlSection(text, singleLineArrayKey, formatYamlArrayValue(yaml[singleLineArrayKey], 'single-line'));
+      }
+
+      for (const multiLineArrayKey of options.forceMultiLineArrayStyle) {
+        if (!Object.keys(yaml).includes(multiLineArrayKey)) {
+          continue;
+        }
+
+        text = setYamlSection(text, multiLineArrayKey, formatYamlArrayValue(yaml[multiLineArrayKey], 'multi-line'));
+      }
+
+      return text;
+    });
+  }
+  get exampleBuilders(): ExampleBuilder<FormatYamlArrayOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Test example',
+        before: dedent`
+          ---
+          language: Typescript
+          type: programming
+          tags: computer
+          ---
+
+          # Header Context
+
+          Text
+        `,
+        after: dedent`
+          ---
+          language: Typescript
+          type: programming
+          tags: [computer]
+          ---
+
+          # Header Context
+
+          Text
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Test example2',
+        before: dedent`
+          ---
+          language: Typescript
+          type: programming
+          tags: computer, science, trajectory
+          ---
+
+          # Header Context
+
+          Text
+        `,
+        after: dedent`
+          ---
+          language: Typescript
+          type: programming
+          tags: [computer, science, trajectory]
+          ---
+
+          # Header Context
+
+          Text
+        `,
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<FormatYamlArrayOptions>[] {
+    return [
+      new DropdownOptionBuilder({
+        OptionsClass: FormatYamlArrayOptions,
+        name: 'Yaml aliases section style',
+        description: 'The style of the aliases yaml section',
+        optionsKey: 'aliasArrayStyle',
+        records: [
+          {
+            value: 'multi-line',
+            description: '```aliases:\\n  - Title```',
+          },
+          {
+            value: 'single-line',
+            description: '```aliases: [Title]```',
+          },
+          {
+            value: 'single string to single-line',
+            description: '```aliases: Title```',
+          },
+          {
+            value: 'single string to multi-line',
+            description: '```aliases: Title```',
+          },
+        ],
+      }),
+      new BooleanOptionBuilder({
+        OptionsClass: FormatYamlArrayOptions,
+        name: 'Format yaml aliases section',
+        description: 'Turns on formatting for yaml aliases section',
+        optionsKey: 'formatAliasKey',
+      }),
+      new DropdownOptionBuilder({
+        OptionsClass: FormatYamlArrayOptions,
+        name: 'Yaml aliases section style',
+        description: 'The style of the aliases yaml section',
+        optionsKey: 'tagArrayStyle',
+        records: [
+          {
+            value: 'multi-line',
+            description: '```tags:\\n  - tag1```',
+          },
+          {
+            value: 'single-line',
+            description: '```tags: [tag1]```',
+          },
+          {
+            value: 'single string to single-line',
+            description: '```tags: tag1```',
+          },
+          {
+            value: 'single string to multi-line',
+            description: '```tags: tag1```',
+          },
+          {
+            value: 'single-line space delimited',
+            description: '```tags: [tag1 tag2]```',
+          },
+          {
+            value: 'single string space delimited',
+            description: '```tags: tag1 tag2```',
+          },
+          {
+            value: 'single string comma delimited',
+            description: '```tags: tag1, tag2```',
+          },
+        ],
+      }),
+      new DropdownOptionBuilder({
+        OptionsClass: FormatYamlArrayOptions,
+        name: 'Default yaml array section style',
+        description: 'The style of the aliases yaml section',
+        optionsKey: 'defaultArrayStyle',
+        records: [
+          {
+            value: 'multi-line',
+            description: '```key:\\n  - value```',
+          },
+          {
+            value: 'single-line',
+            description: '```key: [value]```',
+          },
+        ],
+      }),
+      new BooleanOptionBuilder({
+        OptionsClass: FormatYamlArrayOptions,
+        name: 'Format yaml array sections',
+        description: 'Turns on formatting for yaml arrays section',
+        optionsKey: 'formatArrayKeys',
+      }),
+      new TextAreaOptionBuilder({
+        OptionsClass: FormatYamlArrayOptions,
+        name: 'Force Key Values to Be Single-Line Arrays',
+        description: 'Forces the yaml array for the new line separated keys to be in single-line format',
+        optionsKey: 'forceSingleLineArrayStyle',
+      }),
+      new TextAreaOptionBuilder({
+        OptionsClass: FormatYamlArrayOptions,
+        name: 'Force Key Values to Be Multi-Line Arrays',
+        description: 'Forces the yaml array for the new line separated keys to be in multi-line format',
+        optionsKey: 'forceMultiLineArrayStyle',
+      }),
+      /**
+       *
+  formatTagKey: boolean = true;
+       */
+    ];
+  }
+}

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -101,9 +101,13 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           test: this is a value
           ---
           ${''}
-          # Note
+          # Notes:
           ${''}
           Nesting yaml arrays may result in unexpected results.
+          ${''}
+          Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
+          ${''}
+          Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
         `,
         after: dedent`
           ---

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -118,9 +118,13 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           test: [this is a value]
           ---
           ${''}
-          # Note
+          # Notes:
           ${''}
           Nesting yaml arrays may result in unexpected results.
+          ${''}
+          Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
+          ${''}
+          Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
         `,
         options: {
           aliasArrayStyle: 'multi-line',

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -10,6 +10,7 @@ import {convertAliasValueToStringOrStringArray,
   NormalYamlArrayFormats,
   setYamlSection,
   SpecialYamlArrayFormats,
+  splitValueIfSingleOrMultilineArray,
   TagSpecificYamlArrayFormats} from '../utils/yaml';
 
 class FormatYamlArrayOptions implements Options {
@@ -41,43 +42,6 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
     return formatYAML(text, (text: string) => {
       const obsidianTagKey = 'tags';
       const obsidianAliasKey = 'aliases';
-
-      const splitValueIfSingleOrMultilineArray = function(value: string): string | string[] {
-        if (value == null || value.length === 0) {
-          return null;
-        }
-
-        value = value.trimEnd();
-        if (value.startsWith('[')) {
-          value = value.substring(1);
-
-          if (value.endsWith(']')) {
-            value = value.substring(0, value.length - 1);
-          }
-
-          // accounts for an empty single line array which can then be converted as needed later on
-          if (value.length === 0) {
-            return null;
-          }
-
-          const arrayItems = value.split(', ');
-
-          return arrayItems.length > 1 ? arrayItems : arrayItems[0].split(',');
-        }
-
-        if (value.includes('\n')) {
-          const arrayItems = value.split(/\s*\n\s*-\s*/);
-          arrayItems.splice(0, 1);
-
-          if (arrayItems.length === 1 && arrayItems[0] === '') {
-            return null;
-          }
-
-          return arrayItems;
-        }
-
-        return value;
-      };
 
       const yaml = loadYAML(text.replace('---\n', '').replace('\n---', ''));
       if (!yaml) {

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -51,33 +51,52 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
 
         switch (format) {
           case 'single-line':
+            if (value == null || value.length === 0) {
+              return ' []';
+            }
+
             return ' ' + toSingleLineArrayYamlString(value);
           case 'multi-line':
+            if (value == null || value.length === 0) {
+              return '\n  - ';
+            }
             return '\n  - ' + value.join('\n  - ');
           case 'single string to single-line':
-            if (value.length === 1) {
+            if (value == null || value.length === 0) {
+              return ' ';
+            } else if (value.length === 1) {
               return ' ' + value[0];
             }
 
             return ' ' + toSingleLineArrayYamlString(value);
           case 'single string to multi-line':
-            if (value.length === 1) {
+            if (value == null || value.length === 0) {
+              return ' ';
+            } else if (value.length === 1) {
               return ' ' + value[0];
             }
 
             return '\n  - ' + value.join('\n  - ');
           case 'single string space delimited':
-            if (value.length === 1) {
+            if (value == null || value.length === 0) {
+              return ' ';
+            } else if (value.length === 1) {
               return ' ' + value[0];
             }
+
             return ' ' +value.join(' ');
           case 'single string comma delimited':
-            if (value.length === 1) {
+            if (value == null || value.length === 0) {
+              return ' ';
+            } else if (value.length === 1) {
               return ' ' + value[0];
             }
+
             return ' ' + value.join(', ');
           case 'single-line space delimited':
-            if (value.length === 1) {
+            if (value == null || value.length === 0) {
+              return ' []';
+            } else if (value.length === 1) {
               return ' ' + value[0];
             }
 
@@ -297,10 +316,6 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         description: 'Forces the yaml array for the new line separated keys to be in multi-line format',
         optionsKey: 'forceMultiLineArrayStyle',
       }),
-      /**
-       *
-  formatTagKey: boolean = true;
-       */
     ];
   }
 }

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -195,7 +195,6 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           Nesting yaml arrays may result in unexpected results.
         `,
         options: {
-          tagArrayStyle: 'single-line',
           aliasArrayStyle: 'multi-line',
           forceSingleLineArrayStyle: ['test'],
         },
@@ -215,7 +214,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           ---
           aliases: Typescript
           types: [thought provoking, peer reviewed]
-          tags: computer, science, trajectory
+          tags: computer science trajectory
           ---
         `,
         options: {

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -141,7 +141,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         `,
         options: {
           formatAliasKey: false,
-          tagArrayStyle: 'single-line space delimited',
+          tagArrayStyle: 'single string space delimited',
         },
       }),
     ];
@@ -168,11 +168,11 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           },
           {
             value: 'single string to single-line',
-            description: '```aliases: Title```',
+            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a single-line array.',
           },
           {
             value: 'single string to multi-line',
-            description: '```aliases: Title```',
+            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a multi-line array.',
           },
         ],
       }),
@@ -198,11 +198,11 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           },
           {
             value: 'single string to single-line',
-            description: '```tags: tag1```',
+            description: 'Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.',
           },
           {
             value: 'single string to multi-line',
-            description: '```tags: tag1```',
+            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.',
           },
           {
             value: 'single-line space delimited',

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -105,8 +105,6 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           ${''}
           Nesting yaml arrays may result in unexpected results.
           ${''}
-          Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
-          ${''}
           Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
         `,
         after: dedent`
@@ -121,8 +119,6 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           # Notes:
           ${''}
           Nesting yaml arrays may result in unexpected results.
-          ${''}
-          Arrays that can be treated as strings like an array of integers might accidentally get caught up in the formatting.
           ${''}
           Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
         `,

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -1,13 +1,15 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
-import {formatYAML, loadYAML, setYamlSection, toSingleLineArrayYamlString} from '../utils/yaml';
-
-type TagSpecificYamlArrayFormats = 'single string space delimited' | 'single-line space delimited';
-
-type SpecialYamlArrayFormats = 'single string to single-line' | 'single string to multi-line' | 'single string comma delimited';
-
-type NormalYamlArrayFormats = 'single-line' | 'multi-line';
+import {convertAliasValueToStringOrStringArray,
+  convertTagValueToStringOrStringArray,
+  formatYAML,
+  formatYamlArrayValue,
+  loadYAML,
+  NormalYamlArrayFormats,
+  setYamlSection,
+  SpecialYamlArrayFormats,
+  TagSpecificYamlArrayFormats} from '../utils/yaml';
 
 class FormatYamlArrayOptions implements Options {
   aliasArrayStyle?: NormalYamlArrayFormats | SpecialYamlArrayFormats = 'single-line';
@@ -43,86 +45,6 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
       if (!yaml) {
         return text;
       }
-
-      const formatYamlArrayValue = function(value: string | string[], format: NormalYamlArrayFormats | SpecialYamlArrayFormats | TagSpecificYamlArrayFormats): string {
-        if (typeof value === 'string') {
-          value = [value];
-        }
-
-        switch (format) {
-          case 'single-line':
-            if (value == null || value.length === 0) {
-              return ' []';
-            }
-
-            return ' ' + toSingleLineArrayYamlString(value);
-          case 'multi-line':
-            if (value == null || value.length === 0) {
-              return '\n  - ';
-            }
-            return '\n  - ' + value.join('\n  - ');
-          case 'single string to single-line':
-            if (value == null || value.length === 0) {
-              return ' ';
-            } else if (value.length === 1) {
-              return ' ' + value[0];
-            }
-
-            return ' ' + toSingleLineArrayYamlString(value);
-          case 'single string to multi-line':
-            if (value == null || value.length === 0) {
-              return ' ';
-            } else if (value.length === 1) {
-              return ' ' + value[0];
-            }
-
-            return '\n  - ' + value.join('\n  - ');
-          case 'single string space delimited':
-            if (value == null || value.length === 0) {
-              return ' ';
-            } else if (value.length === 1) {
-              return ' ' + value[0];
-            }
-
-            return ' ' +value.join(' ');
-          case 'single string comma delimited':
-            if (value == null || value.length === 0) {
-              return ' ';
-            } else if (value.length === 1) {
-              return ' ' + value[0];
-            }
-
-            return ' ' + value.join(', ');
-          case 'single-line space delimited':
-            if (value == null || value.length === 0) {
-              return ' []';
-            } else if (value.length === 1) {
-              return ' ' + value[0];
-            }
-
-            return ' ' + toSingleLineArrayYamlString(value).replaceAll(', ', ' ');
-        }
-      };
-
-      const convertTagValueToStringOrStringArray = function(value: string | string[]): string[] {
-        if (typeof value === 'string') {
-          if (value.includes(',')) {
-            return value.split(', ');
-          }
-
-          return value.split(' ');
-        }
-
-        return value;
-      };
-
-      const convertAliasValueToStringOrStringArray = function(value: string | string[]): string[] {
-        if (typeof value === 'string') {
-          return value.split(', ');
-        }
-
-        return value;
-      };
 
       if (options.formatAliasKey && Object.keys(yaml).includes(obsidianAliasKey)) {
         text = setYamlSection(text, obsidianAliasKey, formatYamlArrayValue(convertAliasValueToStringOrStringArray(yaml[obsidianAliasKey]), options.aliasArrayStyle) );

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -1,4 +1,4 @@
-import {obsidianMultilineCommentRegex, tagRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns} from './regex';
+import {obsidianMultilineCommentRegex, tagRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns, genericLinkRegex} from './regex';
 import {getPositions, MDAstTypes} from './mdast';
 import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
@@ -140,7 +140,7 @@ function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): Ign
 
     const regularLink = text.substring(position.start.offset, position.end.offset);
     // skip links that are not in markdown format
-    if (!regularLink.includes('[')) {
+    if (!regularLink.match(genericLinkRegex)) {
       continue;
     }
 

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -2,7 +2,7 @@ import {visit} from 'unist-util-visit';
 import type {Position} from 'unist';
 import type {Root} from 'mdast';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
-import {escapeRegExp} from './regex';
+import {escapeRegExp, genericLinkRegex} from './regex';
 import {remark} from 'remark';
 import remarkGfm from 'remark-gfm';
 
@@ -277,7 +277,7 @@ export function removeSpacesInLinkText(text: string): string {
   for (const position of positions) {
     const regularLink = text.substring(position.start.offset, position.end.offset);
     // skip links that are not are not in markdown format
-    if (!regularLink.includes('[')) {
+    if (!regularLink.match(genericLinkRegex)) {
       continue;
     }
 

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -9,6 +9,7 @@ export const tildeBlockRegexTemplate = fencedRegexTemplate.replaceAll('X', '~');
 export const indentedBlockRegex = '^((\t|( {4})).*\n)+';
 export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeBlockRegexTemplate}|${indentedBlockRegex}`, 'gm');
 export const wikiLinkRegex = /(!?)(\[{2}[^[\n\]]*\]{2})/g;
+export const genericLinkRegex = /^!?\[.*\](.*)$/;
 export const tagRegex = /#[^\s#]{1,}/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -34,7 +34,7 @@ export function toSingleLineArrayYamlString<T>(arr: T[]): string {
 }
 
 function getYamlSectionRegExp(rawKey: string): RegExp {
-  return new RegExp(`(?<=^|\\n)${rawKey}:[ \\t]*(\\S.*|(?:\\n {2}\\S.*)*)\\n`);
+  return new RegExp(`(?<=^|\\n)${rawKey}:[ \\t]*(\\S.*|(?:\\n *- \\S.*)*)\\n`);
 }
 
 export function setYamlSection(yaml: string, rawKey: string, rawValue: string): string {
@@ -82,6 +82,12 @@ export type SpecialYamlArrayFormats = 'single string to single-line' | 'single s
 
 export type NormalYamlArrayFormats = 'single-line' | 'multi-line';
 
+/**
+ * Formats the yaml array value passed in with the specified format.
+ * @param {string | string[]} value The value(s) that will be used as the parts of the array that is assumed to already be broken down into the appropriate format to be put in the array.
+ * @param {NormalYamlArrayFormats | SpecialYamlArrayFormats | TagSpecificYamlArrayFormats} format The format that the array should be converted into.
+ * @return {string} The formatted array in the specified yaml/obsidian yaml format.
+ */
 export function formatYamlArrayValue(value: string | string[], format: NormalYamlArrayFormats | SpecialYamlArrayFormats | TagSpecificYamlArrayFormats): string {
   if (typeof value === 'string') {
     value = [value];
@@ -142,6 +148,11 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
   }
 }
 
+/**
+ * Converts the tag string to the proper split up values based on whether or not it is already an array and if it has delimiters.
+ * @param {string | string[]} value The value that is already good to go or needs to be split on a comma or spaces.
+ * @return {string} The converted tag key value that should account for its obsidian formats.
+ */
 export function convertTagValueToStringOrStringArray(value: string | string[]): string[] {
   if (typeof value === 'string') {
     if (value.includes(',')) {
@@ -154,6 +165,11 @@ export function convertTagValueToStringOrStringArray(value: string | string[]): 
   return value;
 }
 
+/**
+ * Converts the alias over to the appropriate array items for formatting taking into account obsidian formats.
+ * @param {string | string[]} value The value of the aliases key that may need to be split into the appropriate parts.
+ * @return {string} The alias value converted to the appropriate array items for formatting.
+ */
 export function convertAliasValueToStringOrStringArray(value: string | string[]): string[] {
   if (typeof value === 'string') {
     return value.split(', ');

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -75,3 +75,89 @@ export function loadYAML(yaml_text: string): any {
 
   return parsed_yaml;
 }
+
+export type TagSpecificYamlArrayFormats = 'single string space delimited' | 'single-line space delimited';
+
+export type SpecialYamlArrayFormats = 'single string to single-line' | 'single string to multi-line' | 'single string comma delimited';
+
+export type NormalYamlArrayFormats = 'single-line' | 'multi-line';
+
+export function formatYamlArrayValue(value: string | string[], format: NormalYamlArrayFormats | SpecialYamlArrayFormats | TagSpecificYamlArrayFormats): string {
+  if (typeof value === 'string') {
+    value = [value];
+  }
+
+  switch (format) {
+    case 'single-line':
+      if (value == null || value.length === 0) {
+        return ' []';
+      }
+
+      return ' ' + toSingleLineArrayYamlString(value);
+    case 'multi-line':
+      if (value == null || value.length === 0) {
+        return '\n  - ';
+      }
+      return '\n  - ' + value.join('\n  - ');
+    case 'single string to single-line':
+      if (value == null || value.length === 0) {
+        return ' ';
+      } else if (value.length === 1) {
+        return ' ' + value[0];
+      }
+
+      return ' ' + toSingleLineArrayYamlString(value);
+    case 'single string to multi-line':
+      if (value == null || value.length === 0) {
+        return ' ';
+      } else if (value.length === 1) {
+        return ' ' + value[0];
+      }
+
+      return '\n  - ' + value.join('\n  - ');
+    case 'single string space delimited':
+      if (value == null || value.length === 0) {
+        return ' ';
+      } else if (value.length === 1) {
+        return ' ' + value[0];
+      }
+
+      return ' ' +value.join(' ');
+    case 'single string comma delimited':
+      if (value == null || value.length === 0) {
+        return ' ';
+      } else if (value.length === 1) {
+        return ' ' + value[0];
+      }
+
+      return ' ' + value.join(', ');
+    case 'single-line space delimited':
+      if (value == null || value.length === 0) {
+        return ' []';
+      } else if (value.length === 1) {
+        return ' ' + value[0];
+      }
+
+      return ' ' + toSingleLineArrayYamlString(value).replaceAll(', ', ' ');
+  }
+}
+
+export function convertTagValueToStringOrStringArray(value: string | string[]): string[] {
+  if (typeof value === 'string') {
+    if (value.includes(',')) {
+      return value.split(', ');
+    }
+
+    return value.split(' ');
+  }
+
+  return value;
+}
+
+export function convertAliasValueToStringOrStringArray(value: string | string[]): string[] {
+  if (typeof value === 'string') {
+    return value.split(', ');
+  }
+
+  return value;
+}

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -99,7 +99,7 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
         return ' []';
       }
 
-      return ' ' + toSingleLineArrayYamlString(value);
+      return ' ' + convertStringArrayToSingleLineArray(value);
     case 'multi-line':
       if (value == null || value.length === 0) {
         return '\n  - ';
@@ -112,7 +112,7 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
         return ' ' + value[0];
       }
 
-      return ' ' + toSingleLineArrayYamlString(value);
+      return ' ' + convertStringArrayToSingleLineArray(value);
     case 'single string to multi-line':
       if (value == null || value.length === 0) {
         return ' ';
@@ -144,8 +144,16 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
         return ' ' + value[0];
       }
 
-      return ' ' + toSingleLineArrayYamlString(value).replaceAll(', ', ' ');
+      return ' ' + convertStringArrayToSingleLineArray(value).replaceAll(', ', ' ');
   }
+}
+
+function convertStringArrayToSingleLineArray(arrayItems: string[]): string {
+  if (arrayItems == null || arrayItems.length === 0) {
+    return '[]';
+  }
+
+  return '[' + arrayItems.join(', ') + ']';
 }
 
 /**

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -179,9 +179,13 @@ export function splitValueIfSingleOrMultilineArray(value: string): string | stri
       return null;
     }
 
-    const arrayItems = value.split(', ');
+    let arrayItems = value.split(', ');
 
-    return arrayItems.length > 1 ? arrayItems : arrayItems[0].split(',');
+    arrayItems = arrayItems.length > 1 ? arrayItems : arrayItems[0].split(',');
+
+    return arrayItems.filter((el: string) => {
+      return el != '';
+    });
   }
 
   if (value.includes('\n')) {


### PR DESCRIPTION
Fixes #172 
Fixes #291
Fixes #182 

Changes Made:
- Added a rule to account for updating yaml array formats and forcing a regular string value to be a yaml array
- Added a bunch of tests to handle some possible test cases
- Added a couple of examples
- Added a fix for a bug where if a url had `[` in it, it was considered to be a regular markdown link which caused multiple `<` to be added at the start of the link when the rule for removing space around link text was active
