### PR TITLE
Fix Issue with Additional Angle Brackets Around URL When It Ends in `#some-text-here`

### DIFF
--- a/__tests__/no-bare-urls.test.ts
+++ b/__tests__/no-bare-urls.test.ts
@@ -17,5 +17,15 @@ ruleTest({
         ![image alt text](https://github.com/favicon.ico)
       `,
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/339
+      testName: 'Urls with a hashtag referring to header that are surrounded by `<` and `> should be left alone',
+      before: dedent`
+        <https://google.com#hashtag>
+      `,
+      after: dedent`
+        <https://google.com#hashtag>
+      `,
+    },
   ],
 });

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -578,7 +578,7 @@ modified: Wednesday, January 1st 2020, 4:00:00 pm
 
 Alias: `yaml-title`
 
-Inserts the title of the file into the YAML frontmatter. Gets the title from the first H1 or filename.
+Inserts the title of the file into the YAML frontmatter. Gets the title from the first H1 or filename if there is no H1.
 
 Options:
 - Title Key: Which YAML key to use for title
@@ -1252,6 +1252,23 @@ After:
 backticks around a url should stay the same, but only if the only contents of the backticks: `<https://github.com> some text here`
 single quotes around a url should stay the same, but only if the contents of the single quotes is the url: '<https://github.com> some text here'
 double quotes around a url should stay the same, but only if the contents of the double quotes is the url: "<https://github.com> some text here"
+``````
+Example: Multiple angle brackets at the start and or end of a url will be reduced down to 1
+
+Before:
+
+``````markdown
+<<https://github.com>
+<https://google.com>>
+<<https://gitlab.com>>
+``````
+
+After:
+
+``````markdown
+<https://github.com>
+<https://google.com>
+<https://gitlab.com>
 ``````
 
 ### Proper Ellipsis

--- a/src/rules/yaml-title.ts
+++ b/src/rules/yaml-title.ts
@@ -20,7 +20,7 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
     return 'YAML Title';
   }
   get description(): string {
-    return 'Inserts the title of the file into the YAML frontmatter. Gets the title from the first H1 or filename.';
+    return 'Inserts the title of the file into the YAML frontmatter. Gets the title from the first H1 or filename if there is no H1.';
   }
   get type(): RuleType {
     return RuleType.YAML;

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -10,7 +10,7 @@ export const indentedBlockRegex = '^((\t|( {4})).*\n)+';
 export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeBlockRegexTemplate}|${indentedBlockRegex}`, 'gm');
 export const wikiLinkRegex = /(!?)(\[{2}[^[\n\]]*\]{2})/g;
 export const genericLinkRegex = /^!?\[.*\](.*)$/;
-export const tagRegex = /#[^\s#]{1,}/g;
+export const tagRegex = /(?:\s|^)#[^\s#]{1,}/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 


### PR DESCRIPTION
Fixes #339 

Changes Made:
- Updated regex for tags to make sure they are only matched on if they start a line or follow some kind of whitespace
- Added logic to remove multiple angle brackets
- Added an example to show the addition in the logic
- Added a UT so we hopefully do not cause the same issue down the road