### PR TITLE
Fix Issue with Some Date Formats Being Treated as Arrays

### DIFF
--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -768,5 +768,21 @@ ruleTest({
         ---
       `,
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/352
+      testName: 'Date stays the same',
+      before: dedent`
+        ---
+        date: 2022-08-14
+        tags: []
+        ---
+      `,
+      after: dedent`
+        ---
+        date: 2022-08-14
+        tags: []
+        ---
+      `,
+    },
   ],
 });

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -48,6 +48,11 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         return text;
       }
 
+      // https://stackoverflow.com/a/44198641
+      const isValidDate = function(date: any) {
+        return date && Object.prototype.toString.call(date) === '[object Date]' && !isNaN(date);
+      };
+
       if (options.formatAliasKey && Object.keys(yaml).includes(obsidianAliasKey)) {
         text = setYamlSection(text, obsidianAliasKey, formatYamlArrayValue(convertAliasValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, obsidianAliasKey))), options.aliasArrayStyle));
       }
@@ -61,7 +66,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
 
         for (const key of Object.keys(yaml)) {
           // skip non-arrays and already accounted for keys
-          if (keysToIgnore.includes(key) || !(typeof yaml[key] === 'object' && yaml[key] as string[])) {
+          if (keysToIgnore.includes(key) || !(typeof yaml[key] === 'object' && !isValidDate(yaml[key]) && yaml[key] as string[])) {
             continue;
           }
 


### PR DESCRIPTION
Fixes #352 

Changes Made:
- Added a UT to account for the scenario in question
- Added a check to make sure that the object in question for the yaml was not a date before going ahead and converting the value to the specified array format