### PR TITLE
Handle Chinese Characters Having Spaces Added in Inline Code

### DIFF
--- a/__tests__/space-between-chinese-and-english-or-numbers.test.ts
+++ b/__tests__/space-between-chinese-and-english-or-numbers.test.ts
@@ -15,5 +15,45 @@ ruleTest({
         这是一个数学公式 $f(x)=x^2$ 这是一个数学公式
       `,
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/378
+      testName: 'Make sure that inline code blocks are not affected',
+      before: dedent`
+        \`test\`
+        \`test_case\`
+        \`test_case_here\`
+        \`test*case\`
+        \`test*case*here\`
+        \`测试\`
+        \`测试_一下\`
+        \`测试_一下_吧\`
+        \`测试-几个-才行\`
+        \`测试*一下\`
+        \`测试*一下*你们\`
+        \`测试一下**你们**所有人\`
+        \`测试this case\`
+        \`测试_this_case\`
+        \`this_测试-还*可以\`
+        \`filepath = './知识_巴别图书馆.md'\`
+      `,
+      after: dedent`
+        \`test\`
+        \`test_case\`
+        \`test_case_here\`
+        \`test*case\`
+        \`test*case*here\`
+        \`测试\`
+        \`测试_一下\`
+        \`测试_一下_吧\`
+        \`测试-几个-才行\`
+        \`测试*一下\`
+        \`测试*一下*你们\`
+        \`测试一下**你们**所有人\`
+        \`测试this case\`
+        \`测试_this_case\`
+        \`this_测试-还*可以\`
+        \`filepath = './知识_巴别图书馆.md'\`
+      `,
+    },
   ],
 });

--- a/src/rules/space-between-chinese-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-and-english-or-numbers.ts
@@ -28,7 +28,7 @@ export default class SpaceBetweenChineseAndEnglishOrNumbers extends RuleBuilder<
       return text.replace(head, '$1 $3').replace(tail, '$1 $3');
     };
 
-    let newText = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.image, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.italics, IgnoreTypes.bold], text, addSpaceAroundChineseAndEnglish);
+    let newText = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.yaml, IgnoreTypes.image, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.italics, IgnoreTypes.bold], text, addSpaceAroundChineseAndEnglish);
 
     newText = updateItalicsText(newText, addSpaceAroundChineseAndEnglish);
 

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -11,6 +11,7 @@ export type IgnoreType = {replaceAction: MDAstTypes | RegExp | IgnoreFunction, p
 export const IgnoreTypes: Record<string, IgnoreType> = {
   // mdast node types
   code: {replaceAction: MDAstTypes.Code, placeholder: '{CODE_BLOCK_PLACEHOLDER}'},
+  inlineCode: {replaceAction: MDAstTypes.InlineCode, placeholder: '{INLINE_CODE_BLOCK_PLACEHOLDER}'},
   image: {replaceAction: MDAstTypes.Image, placeholder: '{IMAGE_PLACEHOLDER}'},
   thematicBreak: {replaceAction: MDAstTypes.HorizontalRule, placeholder: '{HORIZONTAL_RULE_PLACEHOLDER}'},
   italics: {replaceAction: MDAstTypes.Italics, placeholder: '{ITALICS_PLACEHOLDER}'},
@@ -25,7 +26,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   obsidianMultiLineComments: {replaceAction: obsidianMultilineCommentRegex, placeholder: '{OBSIDIAN_COMMENT_PLACEHOLDER}'},
   // custom functions
   link: {replaceAction: replaceMarkdownLinks, placeholder: '{REGULAR_LINK_PLACEHOLDER}'},
-};
+} as const;
 
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
   let setOfPlaceholders: {placeholder: string, replacedValues: string[]}[] = [];

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -15,6 +15,7 @@ export enum MDAstTypes {
   Bold = 'strong',
   ListItem = 'listItem',
   Code = 'code',
+  InlineCode = 'inlineCode',
   Table = 'table',
   Image = 'image',
   List = 'list',


### PR DESCRIPTION
Fixes #378

Changes Made:
- Added test to account for the bug
- Added inline code to the list of ignored types
- Added mdast and ignore types for inline code
- Made sure that the `IgnoreTypes` was converted over to an immutable object with immutable properties