### PR TITLE
Remove Positive Lookbehind to Support Most Browsers including Webkit Based Ones

### DIFF
--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -34,7 +34,7 @@ export function toSingleLineArrayYamlString<T>(arr: T[]): string {
 }
 
 function getYamlSectionRegExp(rawKey: string): RegExp {
-  return new RegExp(`(?<=^|\\n)${rawKey}:[ \\t]*(\\S.*|(?:(?:\\n *- \\S.*)|((?:\\n *- *))*)*)\\n`);
+  return new RegExp(`${rawKey}:[ \\t]*(\\S.*|(?:(?:\\n *- \\S.*)|((?:\\n *- *))*)*)\\n`);
 }
 
 export function setYamlSection(yaml: string, rawKey: string, rawValue: string): string {


### PR DESCRIPTION
Relates to #367 

Changes Made:
- Updated the regex for getting a yaml section since it was using a positive lookbehind which is not supported by Webkit from what I can tell. This causes it to fail on iOS (I believe). I am hoping this change will fix that.