### PR TITLE
Update Logic to Allow UI to Properly Display Links in Setting Options Name or Description

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -507,7 +507,7 @@ Options:
 	- Default: `true`
 - Date Modified Key: Which YAML key to use for modification date
 	- Default: `date modified`
-- Format: Date format
+- Format: Moment date format to use (see [Moment format options](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/))
 	- Default: `dddd, MMMM Do YYYY, h:mm:ss a`
 
 Example: Adds a header with the date.
@@ -2563,7 +2563,7 @@ After:
 
 Alias: `space-between-chinese-and-english-or-numbers`
 
-Ensures that Chinese and English or numbers are separated by a single space. Follow this [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)
+Ensures that Chinese and English or numbers are separated by a single space. Follows these [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)
 
 
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,6 +1,7 @@
 import {Setting} from 'obsidian';
 import LinterPlugin from './main';
 import {LinterSettings} from './rules';
+import {convertRegularMarkdownLinksToHTMLLinks} from './utils/mdast';
 
 /** Class representing an option of a rule */
 
@@ -50,6 +51,7 @@ export class BooleanOption extends Option {
           });
         });
 
+    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -71,6 +73,7 @@ export class TextOption extends Option {
           });
         });
 
+    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -92,6 +95,7 @@ export class TextAreaOption extends Option {
           });
         });
 
+    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -114,6 +118,7 @@ export class MomentFormatOption extends Option {
           });
         });
 
+    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -158,7 +163,13 @@ export class DropdownOption extends Option {
           });
         });
 
+    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
+}
+
+function makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting: Setting) {
+  setting.nameEl.innerHTML = convertRegularMarkdownLinksToHTMLLinks(setting.nameEl.innerHTML);
+  setting.descEl.innerHTML = convertRegularMarkdownLinksToHTMLLinks(setting.descEl.innerHTML);
 }

--- a/src/rules/space-between-chinese-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-and-english-or-numbers.ts
@@ -16,7 +16,7 @@ export default class SpaceBetweenChineseAndEnglishOrNumbers extends RuleBuilder<
     return 'Space between Chinese and English or numbers';
   }
   get description(): string {
-    return 'Ensures that Chinese and English or numbers are separated by a single space. Follow this [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)';
+    return 'Ensures that Chinese and English or numbers are separated by a single space. Follows these [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)';
   }
   get type(): RuleType {
     return RuleType.SPACING;

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -241,7 +241,7 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
       new MomentFormatOptionBuilder({
         OptionsClass: YamlTimestampOptions,
         name: 'Format',
-        description: 'Date format',
+        description: 'Moment date format to use (see [Moment format options](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/))',
         optionsKey: 'format',
       }),
     ];

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -290,7 +290,7 @@ export function removeSpacesInLinkText(text: string): string {
       continue;
     }
 
-    const endLinkTextPosition = regularLink.lastIndexOf(']');
+    const endLinkTextPosition = regularLink.indexOf(']');
     const newLink = regularLink.substring(0, 1) + regularLink.substring(1, endLinkTextPosition).trim() + regularLink.substring(endLinkTextPosition);
     text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, newLink);
   }
@@ -444,6 +444,28 @@ export function ensureEmptyLinesAroundTables(text: string): string {
   const positions: Position[] = getPositions(MDAstTypes.Table, text);
   for (const position of positions) {
     text = makeSureContentHasEmptyLinesAddedBeforeAndAfter(text, position.start.offset, position.end.offset);
+  }
+
+  return text;
+}
+
+export function convertRegularMarkdownLinksToHTMLLinks(text: string): string {
+  const positions: Position[] = getPositions(MDAstTypes.Link, text);
+
+  for (const position of positions) {
+    if (position == null) {
+      continue;
+    }
+
+    const regularLink = text.substring(position.start.offset, position.end.offset);
+    // skip links that are not are not in markdown format
+    if (!regularLink.match(genericLinkRegex)) {
+      continue;
+    }
+
+    const endLinkTextPosition = regularLink.indexOf(']');
+    const htmlLink = '<a href="' + regularLink.substring(endLinkTextPosition+2, regularLink.length - 1)+ '">' + regularLink.substring(1, endLinkTextPosition) + '</a>';
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, htmlLink);
   }
 
   return text;


### PR DESCRIPTION
Fixes #391 

I found an issue when working on a change for #391. The issue was that the UI was not properly displaying links if they were in markdown format. They also do not display if passed in as html, but that is a separate issue that the linter does not need to address for its logic at this time.

Changes Made:
- Added a link reference to the Moment format page for the format for yaml timestamp
- Also updated grammar around the Chinese and English or number space rule
- Made sure to convert the inner HTML for the setting option name or description to an anchor tag
- Also made sure regular markdown only looked for the first index of `[` as it was still setup to work for wiki links