### PR TITLE
Fix Documentation for Yaml Key Sort

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -369,7 +369,7 @@ Text
 
 Alias: `yaml-key-sort`
 
-Sorts the YAML keys based on the order and priority specified. Note: removes blank lines as well.
+Sorts the YAML keys based on the order and priority specified. Note: may remove blank lines as well.
 
 Options:
 - YAML Key Priority Sort Order: The order in which to sort keys with one on each line where it sorts in the order found in the list

--- a/src/rules/yaml-key-sort.ts
+++ b/src/rules/yaml-key-sort.ts
@@ -31,7 +31,7 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
     return 'YAML Key Sort';
   }
   get description(): string {
-    return 'Sorts the YAML keys based on the order and priority specified. Note: removes blank lines as well.';
+    return 'Sorts the YAML keys based on the order and priority specified. Note: may remove blank lines as well.';
   }
   get type(): RuleType {
     return RuleType.YAML;


### PR DESCRIPTION
Fixes #397 

Changes Made:
- Updated yaml key sort description to specify that it may remove blank lines since it does not do so in all cases