### PR TITLE
Ignore Math Blocks for Chinese Spacing with English Characters or Numbers

### DIFF
--- a/__tests__/space-between-chinese-and-english-or-numbers.test.ts
+++ b/__tests__/space-between-chinese-and-english-or-numbers.test.ts
@@ -55,5 +55,19 @@ ruleTest({
         \`filepath = './知识_巴别图书馆.md'\`
       `,
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/407
+      testName: 'Make sure that inline math blocks are not affected',
+      before: dedent`
+        # Title Here
+
+        $M0 = 现金$
+      `,
+      after: dedent`
+        # Title Here
+
+        $M0 = 现金$
+      `,
+    },
   ],
 });

--- a/src/rules/space-between-chinese-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-and-english-or-numbers.ts
@@ -28,7 +28,7 @@ export default class SpaceBetweenChineseAndEnglishOrNumbers extends RuleBuilder<
       return text.replace(head, '$1 $3').replace(tail, '$1 $3');
     };
 
-    let newText = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.yaml, IgnoreTypes.image, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.italics, IgnoreTypes.bold], text, addSpaceAroundChineseAndEnglish);
+    let newText = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.yaml, IgnoreTypes.image, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.italics, IgnoreTypes.bold, IgnoreTypes.math, IgnoreTypes.inlineMath], text, addSpaceAroundChineseAndEnglish);
 
     newText = updateItalicsText(newText, addSpaceAroundChineseAndEnglish);
 


### PR DESCRIPTION
Fixes #407 

Changes Made:
- Added inline math and regular math to the ignore types for the Chinese spacing rule
- Added a UT to verify the fix and hopefully make sure we do not come across this issue again