### PR TITLE
Make `linter-yaml-title-alias` Optional

### DIFF
--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -1,6 +1,7 @@
 import FormatYamlArray from '../src/rules/format-yaml-arrays';
 import dedent from 'ts-dedent';
 import {ruleTest} from './common';
+import {NormalArrayFormats, SpecialArrayFormats, TagSpecificArrayFormats} from '../src/utils/yaml';
 
 ruleTest({
   RuleBuilderClass: FormatYamlArray,
@@ -23,7 +24,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'multi-line',
+        tagArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
     {
@@ -39,7 +40,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single-line',
+        tagArrayStyle: NormalArrayFormats.SingleLine,
       },
     },
     {
@@ -55,7 +56,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string comma delimited',
+        tagArrayStyle: SpecialArrayFormats.SingleStringCommaDelimited,
       },
     },
     {
@@ -71,7 +72,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single-line space delimited',
+        tagArrayStyle: TagSpecificArrayFormats.SingleLineSpaceDelimited,
       },
     },
     {
@@ -87,7 +88,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string space delimited',
+        tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
       },
     },
     {
@@ -103,7 +104,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string space delimited',
+        tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
       },
     },
     {
@@ -120,7 +121,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string to single-line',
+        tagArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
       },
     },
     {
@@ -136,7 +137,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string to single-line',
+        tagArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
       },
     },
     {
@@ -156,7 +157,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string to multi-line',
+        tagArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -176,7 +177,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string to multi-line',
+        tagArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -192,7 +193,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string to multi-line',
+        tagArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         formatTagKey: false,
       },
     },
@@ -214,7 +215,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'multi-line',
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
     {
@@ -233,7 +234,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'single string comma delimited',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringCommaDelimited,
       },
     },
     {
@@ -250,7 +251,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'single string to single-line',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
       },
     },
     {
@@ -267,7 +268,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'single string to multi-line',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -285,7 +286,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'single string to multi-line',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -303,7 +304,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'single string to single-line',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
       },
     },
     {
@@ -323,7 +324,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'single string to single-line',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
         formatAliasKey: false,
       },
     },
@@ -344,7 +345,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'single-line',
+        defaultArrayStyle: NormalArrayFormats.SingleLine,
       },
     },
     {
@@ -362,7 +363,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'multi-line',
+        defaultArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
     {
@@ -378,7 +379,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'multi-line',
+        defaultArrayStyle: NormalArrayFormats.MultiLine,
         formatArrayKeys: false,
       },
     },
@@ -395,7 +396,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'multi-line',
+        defaultArrayStyle: NormalArrayFormats.MultiLine,
         forceSingleLineArrayStyle: ['key'],
       },
     },
@@ -416,7 +417,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'single-line',
+        defaultArrayStyle: NormalArrayFormats.SingleLine,
         forceMultiLineArrayStyle: ['key'],
       },
     },
@@ -435,7 +436,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'multi-line',
+        defaultArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
 
@@ -455,7 +456,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'multi-line',
+        defaultArrayStyle: NormalArrayFormats.MultiLine,
         forceSingleLineArrayStyle: ['key'],
       },
     },
@@ -476,7 +477,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'multi-line',
+        defaultArrayStyle: NormalArrayFormats.MultiLine,
         forceSingleLineArrayStyle: ['key1'],
       },
     },
@@ -493,7 +494,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'multi-line',
+        defaultArrayStyle: NormalArrayFormats.MultiLine,
         forceSingleLineArrayStyle: ['key'],
       },
     },
@@ -514,7 +515,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'single-line',
+        defaultArrayStyle: NormalArrayFormats.SingleLine,
         forceMultiLineArrayStyle: ['key'],
       },
     },
@@ -531,7 +532,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'single-line',
+        defaultArrayStyle: NormalArrayFormats.SingleLine,
         forceMultiLineArrayStyle: ['key1'],
       },
     },
@@ -548,7 +549,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'single-line',
+        defaultArrayStyle: NormalArrayFormats.SingleLine,
         forceMultiLineArrayStyle: ['key1'],
       },
     },
@@ -566,7 +567,7 @@ ruleTest({
         ---
       `,
       options: {
-        defaultArrayStyle: 'single-line',
+        defaultArrayStyle: NormalArrayFormats.SingleLine,
         forceMultiLineArrayStyle: ['key'],
       },
     },
@@ -618,7 +619,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string to single-line',
+        tagArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
       },
     },
     {
@@ -635,7 +636,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'multi-line',
+        tagArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
     {
@@ -651,7 +652,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string comma delimited',
+        tagArrayStyle: SpecialArrayFormats.SingleStringCommaDelimited,
       },
     },
     {
@@ -667,7 +668,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single string space delimited',
+        tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
       },
     },
     {
@@ -683,7 +684,7 @@ ruleTest({
         ---
       `,
       options: {
-        tagArrayStyle: 'single-line space delimited',
+        tagArrayStyle: TagSpecificArrayFormats.SingleLineSpaceDelimited,
       },
     },
     {
@@ -699,7 +700,7 @@ ruleTest({
         ---
       `,
       options: {
-        aliasArrayStyle: 'single-line',
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
       },
     },
     {

--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -20,6 +20,22 @@ ruleTest({
       `,
     },
     {
+      testName: 'Creates multi-line array aliases when missing without helper key',
+      before: dedent`
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Title
+        ---
+        # Title
+      `,
+      options: {
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    {
       testName: 'Creates single-line array aliases when missing',
       before: dedent`
         # Title
@@ -33,6 +49,22 @@ ruleTest({
       `,
       options: {
         yamlAliasesSectionStyle: 'Single-line array',
+      },
+    },
+    {
+      testName: 'Creates single-line array aliases when missing without helper key',
+      before: dedent`
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases: [Title]
+        ---
+        # Title
+      `,
+      options: {
+        yamlAliasesSectionStyle: 'Single-line array',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
     {
@@ -52,6 +84,22 @@ ruleTest({
       },
     },
     {
+      testName: 'Creates single string alias when missing without helper key',
+      before: dedent`
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases: Title
+        ---
+        # Title
+      `,
+      options: {
+        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    {
       testName: 'Creates multi-line array aliases when empty',
       before: dedent`
         ---
@@ -67,6 +115,25 @@ ruleTest({
         ---
         # Title
       `,
+    },
+    {
+      testName: 'Creates multi-line array aliases when empty without helper key',
+      before: dedent`
+        ---
+        aliases: ${''}
+        ---
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Title
+        ---
+        # Title
+      `,
+      options: {
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
     },
     {
       testName: 'Creates single-line array aliases when empty',
@@ -88,6 +155,25 @@ ruleTest({
       },
     },
     {
+      testName: 'Creates single-line array aliases when empty without helper key',
+      before: dedent`
+        ---
+        aliases: ${''}
+        ---
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases: [Title]
+        ---
+        # Title
+      `,
+      options: {
+        yamlAliasesSectionStyle: 'Single-line array',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    {
       testName: 'Creates single string alias when empty',
       before: dedent`
         ---
@@ -104,6 +190,25 @@ ruleTest({
       `,
       options: {
         yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+      },
+    },
+    {
+      testName: 'Creates single string alias when empty without helper key',
+      before: dedent`
+        ---
+        aliases: ${''}
+        ---
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases: Title
+        ---
+        # Title
+      `,
+      options: {
+        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
     {
@@ -128,6 +233,31 @@ ruleTest({
         ---
         # Title
       `,
+    },
+    {
+      testName: 'Adds new value as first alias in multi-line array when there is no helper key and it is not on',
+      before: dedent`
+        ---
+        aliases:
+          - alias1
+          - alias2
+          - alias3
+        ---
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Title
+          - alias1
+          - alias2
+          - alias3
+        ---
+        # Title
+      `,
+      options: {
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
     },
     {
       testName: 'Adds before first alias in multi-line array',
@@ -186,6 +316,24 @@ ruleTest({
       `,
     },
     {
+      testName: 'Adds before first alias in single-line array without helper key',
+      before: dedent`
+        ---
+        aliases: [alias1, alias2, alias3]
+        ---
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases: [Title, alias1, alias2, alias3]
+        ---
+        # Title
+      `,
+      options: {
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    {
       testName: 'Updates single string alias',
       before: dedent`
         ---
@@ -224,6 +372,27 @@ ruleTest({
       },
     },
     {
+      testName: 'Changes single string aliases to multi-line array when adding without helper key',
+      before: dedent`
+        ---
+        aliases: other alias
+        ---
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Title
+          - other alias
+        ---
+        # Title
+      `,
+      options: {
+        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    {
       testName: 'Changes single string aliases to single-line array when adding',
       before: dedent`
         ---
@@ -240,6 +409,25 @@ ruleTest({
       `,
       options: {
         yamlAliasesSectionStyle: 'Single string that expands to single-line array if needed',
+      },
+    },
+    {
+      testName: 'Changes single string aliases to single-line array when adding without helper key',
+      before: dedent`
+        ---
+        aliases: other alias
+        ---
+        # Title
+      `,
+      after: dedent`
+        ---
+        aliases: [Title, other alias]
+        ---
+        # Title
+      `,
+      options: {
+        yamlAliasesSectionStyle: 'Single string that expands to single-line array if needed',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
     {
@@ -447,6 +635,29 @@ ruleTest({
       },
     },
     {
+      testName: 'Adds alias that matches the filename for multi-line array style aliases section without helper key',
+      before: dedent`
+        ---
+        aliases:
+          - alias1
+        ---
+        # Filename
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Filename
+          - alias1
+        ---
+        # Filename
+      `,
+      options: {
+        keepAliasThatMatchesTheFilename: true,
+        fileName: 'Filename',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    {
       testName: 'Adds alias that matches the filename for single-line array style aliases section',
       before: dedent`
         ---
@@ -464,6 +675,26 @@ ruleTest({
       options: {
         keepAliasThatMatchesTheFilename: true,
         fileName: 'Filename',
+      },
+    },
+    {
+      testName: 'Adds alias that matches the filename for single-line array style aliases section without helper key',
+      before: dedent`
+        ---
+        aliases: [alias1]
+        ---
+        # Filename
+      `,
+      after: dedent`
+        ---
+        aliases: [Filename, alias1]
+        ---
+        # Filename
+      `,
+      options: {
+        keepAliasThatMatchesTheFilename: true,
+        fileName: 'Filename',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
     {
@@ -487,6 +718,29 @@ ruleTest({
         keepAliasThatMatchesTheFilename: true,
         fileName: 'Filename',
         yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+      },
+    },
+    {
+      testName: 'Adds alias that matches the filename for single string style aliases section',
+      before: dedent`
+        ---
+        aliases: alias1
+        ---
+        # Filename
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Filename
+          - alias1
+        ---
+        # Filename
+      `,
+      options: {
+        keepAliasThatMatchesTheFilename: true,
+        fileName: 'Filename',
+        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
     {

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -655,7 +655,7 @@ Alias: `yaml-title-alias`
 Inserts the title of the file into the YAML frontmatter's aliases section. Gets the title from the first H1 or filename.
 
 Options:
-- YAML aliases section style: The style of the aliases YAML section
+- YAML aliases section style: The style of the aliases YAML section. It is recommended that the value here matches the aliases format for format YAML arrays if in use.
 	- Default: `Multi-line array`
 	- `Multi-line array`: ```aliases:\n  - Title```
 	- `Single-line array`: ```aliases: [Title]```
@@ -665,6 +665,8 @@ Options:
 	- Default: `true`
 - Keep alias that matches the filename: Such aliases are usually redundant
 	- Default: `false`
+- Use the YAML key `linter-yaml-title-alias` to help with filename and heading changes: If set, when the first H1 heading changes or filename if first H1 is not present changes, then the old alias stored in this key will be replaced with the new value instead of just inserting a new entry in the aliases array
+	- Default: `true`
 
 Example: Adds a header with the title from heading.
 
@@ -684,6 +686,23 @@ linter-yaml-title-alias: Obsidian
 ---
 # Obsidian
 ``````
+Example: Adds a header with the title from heading without YAML key when the use of the YAML key is set to false.
+
+Before:
+
+``````markdown
+# Obsidian
+``````
+
+After:
+
+``````markdown
+---
+aliases:
+  - Obsidian
+---
+# Obsidian
+``````
 Example: Adds a header with the title.
 
 Before:
@@ -698,6 +717,48 @@ After:
 ---
 aliases:
   - Filename
+linter-yaml-title-alias: Filename
+---
+
+``````
+Example: Adds a header with the title without YAML key when the use of the YAML key is set to false.
+
+Before:
+
+``````markdown
+
+``````
+
+After:
+
+``````markdown
+---
+aliases:
+  - Filename
+---
+
+``````
+Example: Replaces old filename with new filename when no header is present and filename is different than the old one listed in `linter-yaml-title-alias`.
+
+Before:
+
+``````markdown
+---
+aliases:
+  - Old Filename
+  - Alias 2
+linter-yaml-title-alias: Old Filename
+---
+
+``````
+
+After:
+
+``````markdown
+---
+aliases:
+  - Filename
+  - Alias 2
 linter-yaml-title-alias: Filename
 ---
 

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -7,18 +7,18 @@ import {convertAliasValueToStringOrStringArray,
   formatYamlArrayValue,
   getYamlSectionValue,
   loadYAML,
-  NormalYamlArrayFormats,
+  NormalArrayFormats,
   setYamlSection,
-  SpecialYamlArrayFormats,
+  SpecialArrayFormats,
   splitValueIfSingleOrMultilineArray,
-  TagSpecificYamlArrayFormats} from '../utils/yaml';
+  TagSpecificArrayFormats} from '../utils/yaml';
 
 class FormatYamlArrayOptions implements Options {
-  aliasArrayStyle?: NormalYamlArrayFormats | SpecialYamlArrayFormats = 'single-line';
+  aliasArrayStyle?: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
   formatAliasKey?: boolean = true;
-  tagArrayStyle?: TagSpecificYamlArrayFormats | NormalYamlArrayFormats | SpecialYamlArrayFormats = 'single-line';
+  tagArrayStyle?: TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
   formatTagKey?: boolean = true;
-  defaultArrayStyle?: NormalYamlArrayFormats = 'single-line';
+  defaultArrayStyle?: NormalArrayFormats = NormalArrayFormats.SingleLine;
   formatArrayKeys?: boolean = true;
   forceSingleLineArrayStyle?: string[] = [];
   forceMultiLineArrayStyle?: string[] = [];
@@ -79,7 +79,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           continue;
         }
 
-        text = setYamlSection(text, singleLineArrayKey, formatYamlArrayValue(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, singleLineArrayKey)), 'single-line'));
+        text = setYamlSection(text, singleLineArrayKey, formatYamlArrayValue(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, singleLineArrayKey)), NormalArrayFormats.SingleLine));
       }
 
       for (const multiLineArrayKey of options.forceMultiLineArrayStyle) {
@@ -87,7 +87,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           continue;
         }
 
-        text = setYamlSection(text, multiLineArrayKey, formatYamlArrayValue(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, multiLineArrayKey)), 'multi-line'));
+        text = setYamlSection(text, multiLineArrayKey, formatYamlArrayValue(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, multiLineArrayKey)), NormalArrayFormats.MultiLine));
       }
 
       return text;
@@ -128,7 +128,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
           Multi-line arrays will have empty values removed only leaving one if it is completely empty. The same is not true for single-line arrays as that is invalid yaml unless it comes as the last entry in the array.
         `,
         options: {
-          aliasArrayStyle: 'multi-line',
+          aliasArrayStyle: NormalArrayFormats.MultiLine,
           forceSingleLineArrayStyle: ['test'],
         },
       }),
@@ -152,7 +152,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         `,
         options: {
           formatAliasKey: false,
-          tagArrayStyle: 'single string space delimited',
+          tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
         },
       }),
     ];
@@ -165,24 +165,24 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         description: 'The style of the yaml aliases section',
         optionsKey: 'aliasArrayStyle',
         records: [
-          {
-            value: 'multi-line',
+          { // as types is needed to allow for the proper types as options otherwise it assumes it has to be the specific enum value
+            value: NormalArrayFormats.MultiLine as NormalArrayFormats | SpecialArrayFormats,
             description: '```aliases:\\n  - Title```',
           },
           {
-            value: 'single-line',
+            value: NormalArrayFormats.SingleLine,
             description: '```aliases: [Title]```',
           },
           {
-            value: 'single string comma delimited',
+            value: SpecialArrayFormats.SingleStringCommaDelimited,
             description: '```aliases: Title, Other Title```',
           },
           {
-            value: 'single string to single-line',
+            value: SpecialArrayFormats.SingleStringToSingleLine,
             description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a single-line array.',
           },
           {
-            value: 'single string to multi-line',
+            value: SpecialArrayFormats.SingleStringToMultiLine,
             description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a multi-line array.',
           },
         ],
@@ -200,31 +200,31 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         optionsKey: 'tagArrayStyle',
         records: [
           {
-            value: 'multi-line',
+            value: NormalArrayFormats.MultiLine as TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats,
             description: '```tags:\\n  - tag1```',
           },
           {
-            value: 'single-line',
+            value: NormalArrayFormats.SingleLine,
             description: '```tags: [tag1]```',
           },
           {
-            value: 'single string to single-line',
+            value: SpecialArrayFormats.SingleStringToSingleLine,
             description: 'Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.',
           },
           {
-            value: 'single string to multi-line',
+            value: SpecialArrayFormats.SingleStringToMultiLine,
             description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.',
           },
           {
-            value: 'single-line space delimited',
+            value: TagSpecificArrayFormats.SingleLineSpaceDelimited,
             description: '```tags: [tag1 tag2]```',
           },
           {
-            value: 'single string space delimited',
+            value: TagSpecificArrayFormats.SingleStringSpaceDelimited,
             description: '```tags: tag1 tag2```',
           },
           {
-            value: 'single string comma delimited',
+            value: SpecialArrayFormats.SingleStringCommaDelimited,
             description: '```tags: tag1, tag2```',
           },
         ],
@@ -242,11 +242,11 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         optionsKey: 'defaultArrayStyle',
         records: [
           {
-            value: 'multi-line',
+            value: NormalArrayFormats.MultiLine as NormalArrayFormats,
             description: '```key:\\n  - value```',
           },
           {
-            value: 'single-line',
+            value: NormalArrayFormats.SingleLine,
             description: '```key: [value]```',
           },
         ],

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -8,6 +8,8 @@ import {convertAliasValueToStringOrStringArray,
   getYamlSectionValue,
   loadYAML,
   NormalArrayFormats,
+  OBSIDIAN_ALIASES_KEY,
+  OBSIDIAN_TAG_KEY,
   setYamlSection,
   SpecialArrayFormats,
   splitValueIfSingleOrMultilineArray,
@@ -40,9 +42,6 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
   }
   apply(text: string, options: FormatYamlArrayOptions): string {
     return formatYAML(text, (text: string) => {
-      const obsidianTagKey = 'tags';
-      const obsidianAliasKey = 'aliases';
-
       const yaml = loadYAML(text.replace('---\n', '').replace('\n---', ''));
       if (!yaml) {
         return text;
@@ -53,16 +52,16 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         return date && Object.prototype.toString.call(date) === '[object Date]' && !isNaN(date);
       };
 
-      if (options.formatAliasKey && Object.keys(yaml).includes(obsidianAliasKey)) {
-        text = setYamlSection(text, obsidianAliasKey, formatYamlArrayValue(convertAliasValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, obsidianAliasKey))), options.aliasArrayStyle));
+      if (options.formatAliasKey && Object.keys(yaml).includes(OBSIDIAN_ALIASES_KEY)) {
+        text = setYamlSection(text, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(convertAliasValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, OBSIDIAN_ALIASES_KEY))), options.aliasArrayStyle));
       }
 
-      if (options.formatTagKey && Object.keys(yaml).includes(obsidianTagKey)) {
-        text = setYamlSection(text, obsidianTagKey, formatYamlArrayValue(convertTagValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, obsidianTagKey))), options.tagArrayStyle));
+      if (options.formatTagKey && Object.keys(yaml).includes(OBSIDIAN_TAG_KEY)) {
+        text = setYamlSection(text, OBSIDIAN_TAG_KEY, formatYamlArrayValue(convertTagValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, OBSIDIAN_TAG_KEY))), options.tagArrayStyle));
       }
 
       if (options.formatArrayKeys) {
-        const keysToIgnore = [obsidianAliasKey, obsidianTagKey, ...options.forceMultiLineArrayStyle, ...options.forceSingleLineArrayStyle];
+        const keysToIgnore = [OBSIDIAN_ALIASES_KEY, OBSIDIAN_TAG_KEY, ...options.forceMultiLineArrayStyle, ...options.forceSingleLineArrayStyle];
 
         for (const key of Object.keys(yaml)) {
           // skip non-arrays and already accounted for keys

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {getYamlSectionValue, initYAML, loadYAML, removeYamlSection, setYamlSection, toSingleLineArrayYamlString, toYamlString} from '../utils/yaml';
+import {convertAliasValueToStringOrStringArray, formatYamlArrayValue, getYamlSectionValue, initYAML, LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEY, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray, toYamlString} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {yamlRegex} from '../utils/regex';
 
@@ -10,12 +10,6 @@ type YamlAliasesSectionStyle =
   'Single-line array' |
   'Single string that expands to multi-line array if needed' |
   'Single string that expands to single-line array if needed';
-
-type YamlAliasesSectionResultStyle =
-  'Remove' |
-  'Multi-line array' |
-  'Single-line array' |
-  'Single string';
 
 class YamlTitleAliasOptions implements Options {
   yamlAliasesSectionStyle?: YamlAliasesSectionStyle = 'Multi-line array';
@@ -42,9 +36,6 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     return RuleType.YAML;
   }
   apply(text: string, options: YamlTitleAliasOptions): string {
-    const ALIASES_YAML_SECTION_NAME = 'aliases';
-    const LINTER_ALIASES_HELPER_NAME = 'linter-yaml-title-alias';
-
     text = initYAML(text);
     let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
       const result = text.match(/^#\s+(.*)/m);
@@ -55,190 +46,120 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     });
     title = title || options.fileName;
 
-    let requiresChanges = true;
     let previousTitle: string = null;
-    let yaml = text.match(yamlRegex)[1];
+    const yaml = text.match(yamlRegex)[1];
+
     const shouldRemoveTitleAlias = !options.keepAliasThatMatchesTheFilename && title === options.fileName;
-
     if (options.useYamlKeyToKeepTrackOfOldFilenameOrHeading) {
-      previousTitle = loadYAML(getYamlSectionValue(yaml, LINTER_ALIASES_HELPER_NAME));
-
-      if (previousTitle === title && !shouldRemoveTitleAlias) {
-        requiresChanges = false;
-      }
+      previousTitle = loadYAML(getYamlSectionValue(yaml, LINTER_ALIASES_HELPER_KEY));
     }
 
-    if (previousTitle === null && shouldRemoveTitleAlias) {
-      requiresChanges = false;
-    }
+    let newYaml = yaml.replace('---\n', '').replace('\n---', '');
+    const parsedYaml = loadYAML(yaml);
 
-    if (!requiresChanges && options.preserveExistingAliasesSectionStyle) {
-      return text;
-    }
+    previousTitle = loadYAML(getYamlSectionValue(yaml, LINTER_ALIASES_HELPER_KEY));
 
-    let aliasesValue = getYamlSectionValue(yaml, ALIASES_YAML_SECTION_NAME);
-
-    if (!aliasesValue) {
-      if (shouldRemoveTitleAlias) {
-        return text;
-      }
-
-      let emptyValue;
-      switch (options.yamlAliasesSectionStyle) {
-        case 'Multi-line array':
-          emptyValue = '\n  - \'\'';
-          break;
-        case 'Single-line array':
-          emptyValue = ' [\'\']';
-          break;
-        case 'Single string that expands to multi-line array if needed':
-        case 'Single string that expands to single-line array if needed':
-          emptyValue = ' \'\'';
-          break;
-        default:
-          throw new Error(`Unsupported setting 'YAML aliases section style': ${options.yamlAliasesSectionStyle}`);
-      }
-
-      let newYaml = yaml;
-      newYaml = setYamlSection(newYaml, ALIASES_YAML_SECTION_NAME, emptyValue);
-      if (options.useYamlKeyToKeepTrackOfOldFilenameOrHeading) {
-        newYaml = setYamlSection(newYaml, LINTER_ALIASES_HELPER_NAME, ' \'\'');
-      }
-
-      text = text.replace(`---\n${yaml}---`, `---\n${newYaml}---`);
-      yaml = newYaml;
-      aliasesValue = getYamlSectionValue(yaml, ALIASES_YAML_SECTION_NAME);
-      previousTitle = '';
-    }
-
-    const isMultiline = aliasesValue.includes('\n');
-    const parsedAliases = loadYAML(aliasesValue);
-    const isSingleString = !isMultiline && aliasesValue.match(/^\[.*\]/) === null;
-
-    let resultAliasesArray = isSingleString ? [parsedAliases] : [...parsedAliases];
-    const previousTitleIndex = resultAliasesArray.indexOf(previousTitle);
-    if (previousTitleIndex !== -1) {
-      if (shouldRemoveTitleAlias) {
-        resultAliasesArray.splice(previousTitleIndex, 1);
-      } else {
-        resultAliasesArray[previousTitleIndex] = title;
-      }
-    } else if (!shouldRemoveTitleAlias) {
-      resultAliasesArray = [title, ...resultAliasesArray];
-    }
-
-    if (!requiresChanges) {
-      switch (options.yamlAliasesSectionStyle) {
-        case 'Multi-line array':
-          if (isMultiline) {
-            return text;
-          }
-          break;
-        case 'Single-line array':
-          if (!isMultiline && !isSingleString) {
-            return text;
-          }
-          break;
-        case 'Single string that expands to multi-line array if needed':
-          if (isSingleString) {
-            return text;
-          }
-          if (isMultiline && resultAliasesArray.length > 1) {
-            return text;
-          }
-          break;
-        case 'Single string that expands to single-line array if needed':
-          if (isSingleString) {
-            return text;
-          }
-          if (!isMultiline && resultAliasesArray.length > 1) {
-            return text;
-          }
-          break;
-      }
-    }
-
-    let resultStyle: YamlAliasesSectionResultStyle;
-
-    if (resultAliasesArray.length === 0) {
-      resultStyle = 'Remove';
-    } else if (!options.preserveExistingAliasesSectionStyle) {
-      switch (options.yamlAliasesSectionStyle) {
-        case 'Multi-line array':
-          resultStyle = 'Multi-line array';
-          break;
-        case 'Single-line array':
-          resultStyle = 'Single-line array';
-          break;
-        case 'Single string that expands to multi-line array if needed':
-          if (resultAliasesArray.length === 1) {
-            resultStyle = 'Single string';
-          } else {
-            resultStyle = 'Multi-line array';
-          }
-          break;
-        case 'Single string that expands to single-line array if needed':
-          if (resultAliasesArray.length === 1) {
-            resultStyle = 'Single string';
-          } else {
-            resultStyle = 'Single-line array';
-          }
-          break;
-      }
-    } else if (isSingleString) {
-      if (resultAliasesArray.length === 1) {
-        resultStyle = 'Single string';
-      } else {
-        switch (options.yamlAliasesSectionStyle) {
-          case 'Multi-line array':
-          case 'Single string that expands to multi-line array if needed':
-            resultStyle = 'Multi-line array';
-            break;
-          case 'Single-line array':
-          case 'Single string that expands to single-line array if needed':
-            resultStyle = 'Single-line array';
-            break;
-        }
-      }
-    } else if (isMultiline) {
-      resultStyle = 'Multi-line array';
-    } else {
-      resultStyle = 'Single-line array';
-    }
-
-    let newAliasesYaml;
-
-    switch (resultStyle) {
-      case 'Remove':
-        break;
+    let newAliasStyle: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.MultiLine;
+    switch (options.yamlAliasesSectionStyle) {
       case 'Multi-line array':
-        newAliasesYaml = `\n${toYamlString(resultAliasesArray)}`.replace(/\n-/g, '\n  -');
+        newAliasStyle = NormalArrayFormats.MultiLine;
         break;
       case 'Single-line array':
-        newAliasesYaml = ` ${toSingleLineArrayYamlString(resultAliasesArray)}`;
+        newAliasStyle = NormalArrayFormats.SingleLine;
         break;
-      case 'Single string':
-        newAliasesYaml = resultAliasesArray.length === 0 ? '' : ` ${toYamlString(resultAliasesArray[0])}`;
+      case 'Single string that expands to multi-line array if needed':
+        newAliasStyle = SpecialArrayFormats.SingleStringToMultiLine;
+        break;
+      case 'Single string that expands to single-line array if needed':
+        newAliasStyle = SpecialArrayFormats.SingleStringToSingleLine;
         break;
       default:
-        throw new Error(`Unsupported resultStyle: ${resultStyle}`);
+        throw new Error(`Unsupported setting 'YAML aliases section style': ${options.yamlAliasesSectionStyle}`);
     }
 
-    let newYaml = yaml;
+    const getNewAliasValue = function(originalValue: string |string[], shouldRemoveTitle: boolean): string |string[] {
+      if (originalValue == null) {
+        return title;
+      }
 
-    if (resultStyle === 'Remove') {
-      newYaml = removeYamlSection(newYaml, ALIASES_YAML_SECTION_NAME);
+      if (typeof originalValue === 'string') {
+        if (shouldRemoveTitle) {
+          if (originalValue === title) {
+            originalValue = '';
+          }
+        } else if (previousTitle === originalValue) {
+          originalValue = title;
+        } else {
+          originalValue = [title, originalValue];
+        }
+      } else if (previousTitle !== null) {
+        const previousTitleIndex = originalValue.indexOf(previousTitle);
+        if (previousTitleIndex !== -1) {
+          if (shouldRemoveTitle) {
+            originalValue.splice(previousTitleIndex, 1);
+          } else {
+            originalValue[previousTitleIndex] = title;
+          }
+        }
+      } else {
+        const currentTitleIndex = originalValue.indexOf(title);
+        if (currentTitleIndex !== -1) {
+          if (shouldRemoveTitle) {
+            originalValue.splice(currentTitleIndex, 1);
+          }
+        } else if (!shouldRemoveTitle) {
+          originalValue = [title, ...originalValue];
+        }
+      }
+
+      if (originalValue === '' || originalValue.length === 0) {
+        return '';
+      }
+
+      return originalValue;
+    };
+
+    title = toYamlString(title);
+    if (Object.keys(parsedYaml).includes(OBSIDIAN_ALIASES_KEY)) {
+      const aliasesValue = getYamlSectionValue(newYaml, OBSIDIAN_ALIASES_KEY);
+      let currentAliasStyle: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.MultiLine;
+      const isEmpty = aliasesValue === '';
+      let isSingleString = false;
+      if (!aliasesValue.includes('\n')) {
+        if (aliasesValue.match(/^\[.*\]/) === null) {
+          // Note that the value here is just really a placeholder to indicate it is not single-line or multi-line
+          currentAliasStyle = SpecialArrayFormats.SingleStringToSingleLine;
+          isSingleString = true;
+        } else {
+          currentAliasStyle = NormalArrayFormats.SingleLine;
+        }
+      }
+
+      const currentAliasValue = convertAliasValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(aliasesValue));
+      const newAliasValue = getNewAliasValue(currentAliasValue, shouldRemoveTitleAlias);
+
+      if (newAliasValue === '') {
+        newYaml = removeYamlSection(newYaml, OBSIDIAN_ALIASES_KEY);
+      } else if (options.preserveExistingAliasesSectionStyle) {
+        if (!isEmpty && ((isSingleString && title == newAliasValue) || !isSingleString || currentAliasValue == newAliasValue)) {
+          newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, currentAliasStyle));
+        } else {
+          newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, newAliasStyle));
+        }
+      } else {
+        newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, newAliasStyle));
+      }
+    } else if (!shouldRemoveTitleAlias) {
+      newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(title, newAliasStyle));
+    }
+
+    if (!options.useYamlKeyToKeepTrackOfOldFilenameOrHeading || shouldRemoveTitleAlias) {
+      newYaml = removeYamlSection(newYaml, LINTER_ALIASES_HELPER_KEY);
     } else {
-      newYaml = setYamlSection(newYaml, ALIASES_YAML_SECTION_NAME, newAliasesYaml);
+      newYaml = setYamlSection(newYaml, LINTER_ALIASES_HELPER_KEY, ` ${title}`);
     }
 
-    if (shouldRemoveTitleAlias || !options.useYamlKeyToKeepTrackOfOldFilenameOrHeading) {
-      newYaml = removeYamlSection(newYaml, LINTER_ALIASES_HELPER_NAME);
-    } else {
-      newYaml = setYamlSection(newYaml, LINTER_ALIASES_HELPER_NAME, ` ${toYamlString(title)}`);
-    }
-
-    text = text.replace(yaml, newYaml);
+    text = text.replace(`---\n${yaml}---\n`, `---\n${newYaml}---\n`);
 
     return text;
   }
@@ -342,7 +263,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
       new DropdownOptionBuilder<YamlTitleAliasOptions, YamlAliasesSectionStyle>({
         OptionsClass: YamlTitleAliasOptions,
         name: 'YAML aliases section style',
-        description: 'The style of the aliases YAML section',
+        description: 'The style of the aliases YAML section. It is recommended that the value here matches the aliases format for format YAML arrays if in use.',
         optionsKey: 'yamlAliasesSectionStyle',
         records: [
           {

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,6 +1,9 @@
 import {load, dump} from 'js-yaml';
 import {escapeDollarSigns, yamlRegex} from './regex';
 
+export const OBSIDIAN_TAG_KEY = 'tags';
+export const OBSIDIAN_ALIASES_KEY = 'aliases';
+
 /**
  * Adds an empty YAML block to the text if it doesn't already have one.
  * @param {string} text - The text to process

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -3,6 +3,7 @@ import {escapeDollarSigns, yamlRegex} from './regex';
 
 export const OBSIDIAN_TAG_KEY = 'tags';
 export const OBSIDIAN_ALIASES_KEY = 'aliases';
+export const LINTER_ALIASES_HELPER_KEY = 'linter-yaml-title-alias';
 
 /**
  * Adds an empty YAML block to the text if it doesn't already have one.

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -76,36 +76,46 @@ export function loadYAML(yaml_text: string): any {
   return parsed_yaml;
 }
 
-export type TagSpecificYamlArrayFormats = 'single string space delimited' | 'single-line space delimited';
+export enum TagSpecificArrayFormats {
+  SingleStringSpaceDelimited = 'single string space delimited',
+  SingleLineSpaceDelimited = 'single-line space delimited',
+}
 
-export type SpecialYamlArrayFormats = 'single string to single-line' | 'single string to multi-line' | 'single string comma delimited';
+export enum SpecialArrayFormats {
+  SingleStringToSingleLine = 'single string to single-line',
+  SingleStringToMultiLine = 'single string to multi-line',
+  SingleStringCommaDelimited = 'single string comma delimited',
+}
 
-export type NormalYamlArrayFormats = 'single-line' | 'multi-line';
+export enum NormalArrayFormats {
+  SingleLine = 'single-line',
+  MultiLine = 'multi-line',
+}
 
 /**
  * Formats the yaml array value passed in with the specified format.
  * @param {string | string[]} value The value(s) that will be used as the parts of the array that is assumed to already be broken down into the appropriate format to be put in the array.
- * @param {NormalYamlArrayFormats | SpecialYamlArrayFormats | TagSpecificYamlArrayFormats} format The format that the array should be converted into.
+ * @param {NormalArrayFormats | SpecialArrayFormats | TagSpecificArrayFormats} format The format that the array should be converted into.
  * @return {string} The formatted array in the specified yaml/obsidian yaml format.
  */
-export function formatYamlArrayValue(value: string | string[], format: NormalYamlArrayFormats | SpecialYamlArrayFormats | TagSpecificYamlArrayFormats): string {
+export function formatYamlArrayValue(value: string | string[], format: NormalArrayFormats | SpecialArrayFormats | TagSpecificArrayFormats): string {
   if (typeof value === 'string') {
     value = [value];
   }
 
   switch (format) {
-    case 'single-line':
+    case NormalArrayFormats.SingleLine:
       if (value == null || value.length === 0) {
         return ' []';
       }
 
       return ' ' + convertStringArrayToSingleLineArray(value);
-    case 'multi-line':
+    case NormalArrayFormats.MultiLine:
       if (value == null || value.length === 0) {
         return '\n  - ';
       }
       return '\n  - ' + value.join('\n  - ');
-    case 'single string to single-line':
+    case SpecialArrayFormats.SingleStringToSingleLine:
       if (value == null || value.length === 0) {
         return ' ';
       } else if (value.length === 1) {
@@ -113,7 +123,7 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
       }
 
       return ' ' + convertStringArrayToSingleLineArray(value);
-    case 'single string to multi-line':
+    case SpecialArrayFormats.SingleStringToMultiLine:
       if (value == null || value.length === 0) {
         return ' ';
       } else if (value.length === 1) {
@@ -121,7 +131,7 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
       }
 
       return '\n  - ' + value.join('\n  - ');
-    case 'single string space delimited':
+    case TagSpecificArrayFormats.SingleStringSpaceDelimited:
       if (value == null || value.length === 0) {
         return ' ';
       } else if (value.length === 1) {
@@ -129,7 +139,7 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
       }
 
       return ' ' +value.join(' ');
-    case 'single string comma delimited':
+    case SpecialArrayFormats.SingleStringCommaDelimited:
       if (value == null || value.length === 0) {
         return ' ';
       } else if (value.length === 1) {
@@ -137,7 +147,7 @@ export function formatYamlArrayValue(value: string | string[], format: NormalYam
       }
 
       return ' ' + value.join(', ');
-    case 'single-line space delimited':
+    case TagSpecificArrayFormats.SingleLineSpaceDelimited:
       if (value == null || value.length === 0) {
         return ' []';
       } else if (value.length === 1) {


### PR DESCRIPTION
Fixes #404 

Changes Made:
- rewrote logic in the `yaml-title-alias` to allow the linter helper yaml key to be optional
- Added UTs for the new scenarios not having the yaml helper key
- Updated `format-yaml-arrays` and its tests to use an extracted enum instead of a custom type