### PR TITLE
Format Ordered Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [convert-bullet-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-bullet-list-markers)
 - [emphasis-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#emphasis-style)
 - [no-bare-urls](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#no-bare-urls)
+- [ordered-list-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#ordered-list-style)
 - [proper-ellipsis](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#proper-ellipsis)
 - [remove-consecutive-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-consecutive-list-markers)
 - [remove-empty-list-markers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-empty-list-markers)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1363,6 +1363,140 @@ After:
 <https://gitlab.com>
 ``````
 
+### Ordered List Style
+
+Alias: `ordered-list-style`
+
+Makes sure that ordered lists follow the style specified.
+
+Options:
+- Number Style: The number style used to denote emphasized content
+	- Default: `ascending`
+	- `ascending`: Makes sure ordered list items are ascending (i.e. 1, 2, 3, etc.)
+	- `lazy`: Makes sure ordered list item indicators all are the number 1
+- Ordered List Indicator End Style: The number style used to denote emphasized content
+	- Default: `.`
+	- `.`: Makes sure ordered list items indicators end in '.'
+	- `)`: Makes sure ordered list item indicators end in ')'
+
+Example: Ordered lists have list items set to ascending numerical order when Number Style is `ascending`.
+
+Before:
+
+``````markdown
+1. Item 1
+2. Item 2
+4. Item 3
+
+Some text here
+
+1. Item 1
+1. Item 2
+1. Item 3
+``````
+
+After:
+
+``````markdown
+1. Item 1
+2. Item 2
+3. Item 3
+
+Some text here
+
+1. Item 1
+2. Item 2
+3. Item 3
+``````
+Example: Nested ordered lists have list items set to ascending numerical order when Number Style is `ascending`.
+
+Before:
+
+``````markdown
+1. Item 1
+2. Item 2
+  1. Subitem 1
+  5. Subitem 2
+  2. Subitem 3
+4. Item 3
+``````
+
+After:
+
+``````markdown
+1. Item 1
+2. Item 2
+  1. Subitem 1
+  2. Subitem 2
+  3. Subitem 3
+3. Item 3
+``````
+Example: Ordered list in blockquote has list items set to '1.' when Number Style is `lazy`.
+
+Before:
+
+``````markdown
+> 1. Item 1
+> 4. Item 2
+> > 1. Subitem 1
+> > 5. Subitem 2
+> > 2. Subitem 3
+``````
+
+After:
+
+``````markdown
+> 1. Item 1
+> 1. Item 2
+> > 1. Subitem 1
+> > 1. Subitem 2
+> > 1. Subitem 3
+``````
+Example: Ordered list in blockquote has list items set to ascending numerical order when Number Style is `ascending`.
+
+Before:
+
+``````markdown
+> 1. Item 1
+> 4. Item 2
+> > 1. Subitem 1
+> > 5. Subitem 2
+> > 2. Subitem 3
+``````
+
+After:
+
+``````markdown
+> 1. Item 1
+> 2. Item 2
+> > 1. Subitem 1
+> > 2. Subitem 2
+> > 3. Subitem 3
+``````
+Example: Nested ordered list has list items set to '1)' when Number Style is `lazy` and Ordered List Indicator End Style is `)`.
+
+Before:
+
+``````markdown
+1. Item 1
+2. Item 2
+  1. Subitem 1
+  5. Subitem 2
+  2. Subitem 3
+4. Item 3
+``````
+
+After:
+
+``````markdown
+1) Item 1
+1) Item 2
+  1) Subitem 1
+  1) Subitem 2
+  1) Subitem 3
+1) Item 3
+``````
+
 ### Proper Ellipsis
 
 Alias: `proper-ellipsis`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1370,14 +1370,14 @@ Alias: `ordered-list-style`
 Makes sure that ordered lists follow the style specified.
 
 Options:
-- Number Style: The number style used to denote emphasized content
+- Number Style: The number style used in ordered list indicators
 	- Default: `ascending`
 	- `ascending`: Makes sure ordered list items are ascending (i.e. 1, 2, 3, etc.)
 	- `lazy`: Makes sure ordered list item indicators all are the number 1
-- Ordered List Indicator End Style: The number style used to denote emphasized content
+- Ordered List Indicator End Style: The ending character of an ordered list indicator
 	- Default: `.`
-	- `.`: Makes sure ordered list items indicators end in '.'
-	- `)`: Makes sure ordered list item indicators end in ')'
+	- `.`: Makes sure ordered list items indicators end in '.' (i.e `1.`)
+	- `)`: Makes sure ordered list item indicators end in ')' (i.e. `1)`)
 
 Example: Ordered lists have list items set to ascending numerical order when Number Style is `ascending`.
 

--- a/src/rules/ordered-list-style.ts
+++ b/src/rules/ordered-list-style.ts
@@ -1,0 +1,176 @@
+import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {OrderListItemEndOfIndicatorStyles, OrderListItemStyles, updateOrderedListItemIndicators} from '../utils/mdast';
+
+
+class OrderedListStyleOptions implements Options {
+  numberStyle?: OrderListItemStyles = OrderListItemStyles.Ascending;
+  listEndStyle?: OrderListItemEndOfIndicatorStyles = OrderListItemEndOfIndicatorStyles.Period;
+}
+
+@RuleBuilder.register
+export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOptions> {
+  get OptionsClass(): new () => OrderedListStyleOptions {
+    return OrderedListStyleOptions;
+  }
+  get name(): string {
+    return 'Ordered List Style';
+  }
+  get description(): string {
+    return 'Makes sure that ordered lists follow the style specified.';
+  }
+  get type(): RuleType {
+    return RuleType.CONTENT;
+  }
+  apply(text: string, options: OrderedListStyleOptions): string {
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.tag], text, (text) => {
+      return updateOrderedListItemIndicators(text, options.numberStyle, options.listEndStyle);
+    });
+  }
+  get exampleBuilders(): ExampleBuilder<OrderedListStyleOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Ordered lists have list items set to ascending numerical order when Number Style is `ascending`.',
+        before: dedent`
+          1. Item 1
+          2. Item 2
+          4. Item 3
+          ${''}
+          Some text here
+          ${''}
+          1. Item 1
+          1. Item 2
+          1. Item 3
+        `,
+        after: dedent`
+          1. Item 1
+          2. Item 2
+          3. Item 3
+          ${''}
+          Some text here
+          ${''}
+          1. Item 1
+          2. Item 2
+          3. Item 3
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Nested ordered lists have list items set to ascending numerical order when Number Style is `ascending`.',
+        before: dedent`
+          1. Item 1
+          2. Item 2
+            1. Subitem 1
+            5. Subitem 2
+            2. Subitem 3
+          4. Item 3
+        `,
+        after: dedent`
+          1. Item 1
+          2. Item 2
+            1. Subitem 1
+            2. Subitem 2
+            3. Subitem 3
+          3. Item 3
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Ordered list in blockquote has list items set to \'1.\' when Number Style is `lazy`.',
+        before: dedent`
+          > 1. Item 1
+          > 4. Item 2
+          > > 1. Subitem 1
+          > > 5. Subitem 2
+          > > 2. Subitem 3
+        `,
+        after: dedent`
+          > 1. Item 1
+          > 1. Item 2
+          > > 1. Subitem 1
+          > > 1. Subitem 2
+          > > 1. Subitem 3
+        `,
+        options: {
+          numberStyle: OrderListItemStyles.Lazy,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Ordered list in blockquote has list items set to ascending numerical order when Number Style is `ascending`.',
+        before: dedent`
+          > 1. Item 1
+          > 4. Item 2
+          > > 1. Subitem 1
+          > > 5. Subitem 2
+          > > 2. Subitem 3
+        `,
+        after: dedent`
+          > 1. Item 1
+          > 2. Item 2
+          > > 1. Subitem 1
+          > > 2. Subitem 2
+          > > 3. Subitem 3
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Nested ordered list has list items set to \'1)\' when Number Style is `lazy` and Ordered List Indicator End Style is `)`.',
+        before: dedent`
+          1. Item 1
+          2. Item 2
+            1. Subitem 1
+            5. Subitem 2
+            2. Subitem 3
+          4. Item 3
+        `,
+        after: dedent`
+          1) Item 1
+          1) Item 2
+            1) Subitem 1
+            1) Subitem 2
+            1) Subitem 3
+          1) Item 3
+        `,
+        options: {
+          listEndStyle: OrderListItemEndOfIndicatorStyles.Parenthesis,
+          numberStyle: OrderListItemStyles.Lazy,
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<OrderedListStyleOptions>[] {
+    return [
+      new DropdownOptionBuilder<OrderedListStyleOptions, OrderListItemStyles>({
+        OptionsClass: OrderedListStyleOptions,
+        name: 'Number Style',
+        description: 'The number style used to denote emphasized content',
+        optionsKey: 'numberStyle',
+        records: [
+          {
+            value: OrderListItemStyles.Ascending,
+            description: 'Makes sure ordered list items are ascending (i.e. 1, 2, 3, etc.)',
+          },
+          {
+            value: OrderListItemStyles.Lazy,
+            description: 'Makes sure ordered list item indicators all are the number 1',
+          },
+        ],
+      }),
+      new DropdownOptionBuilder<OrderedListStyleOptions, OrderListItemEndOfIndicatorStyles>({
+        OptionsClass: OrderedListStyleOptions,
+        name: 'Ordered List Indicator End Style',
+        description: 'The number style used to denote emphasized content',
+        optionsKey: 'listEndStyle',
+        records: [
+          {
+            value: OrderListItemEndOfIndicatorStyles.Period,
+            description: 'Makes sure ordered list items indicators end in \'.\'',
+          },
+          {
+            value: OrderListItemEndOfIndicatorStyles.Parenthesis,
+            description: 'Makes sure ordered list item indicators end in \')\'',
+          },
+        ],
+      }),
+    ];
+  }
+}

--- a/src/rules/ordered-list-style.ts
+++ b/src/rules/ordered-list-style.ts
@@ -142,7 +142,7 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
       new DropdownOptionBuilder<OrderedListStyleOptions, OrderListItemStyles>({
         OptionsClass: OrderedListStyleOptions,
         name: 'Number Style',
-        description: 'The number style used to denote emphasized content',
+        description: 'The number style used in ordered list indicators',
         optionsKey: 'numberStyle',
         records: [
           {
@@ -158,16 +158,16 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
       new DropdownOptionBuilder<OrderedListStyleOptions, OrderListItemEndOfIndicatorStyles>({
         OptionsClass: OrderedListStyleOptions,
         name: 'Ordered List Indicator End Style',
-        description: 'The number style used to denote emphasized content',
+        description: 'The ending character of an ordered list indicator',
         optionsKey: 'listEndStyle',
         records: [
           {
             value: OrderListItemEndOfIndicatorStyles.Period,
-            description: 'Makes sure ordered list items indicators end in \'.\'',
+            description: 'Makes sure ordered list items indicators end in \'.\' (i.e `1.`)',
           },
           {
             value: OrderListItemEndOfIndicatorStyles.Parenthesis,
-            description: 'Makes sure ordered list item indicators end in \')\'',
+            description: 'Makes sure ordered list item indicators end in \')\' (i.e. `1)`)',
           },
         ],
       }),


### PR DESCRIPTION
Fixes #153 

Changes Made:
- Made sure that you can update the number value of ordered lists to either be ascending or to be `1`.
- Made sure that you can have the end of the ordered list indicator/marker be either `.` or `)`
- Added examples including nesting in blockquotes