### PR TITLE
Move Tags to Yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [format-tags-in-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#format-tags-in-yaml)
 - [format-yaml-array](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#format-yaml-array)
 - [insert-yaml-attributes](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#insert-yaml-attributes)
+- [move-tags-to-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#move-tags-to-yaml)
 - [remove-yaml-keys](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-yaml-keys)
 - [yaml-key-sort](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#yaml-key-sort)
 - [yaml-timestamp](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#yaml-timestamp)

--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -1,0 +1,114 @@
+import MoveTagsToYaml from '../src/rules/move-tags-to-yaml';
+import {NormalArrayFormats, SpecialArrayFormats} from '../src/utils/yaml';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: MoveTagsToYaml,
+  testCases: [
+    {
+      testName: 'Nothing happens when there is no tag in the content of the text',
+      before: dedent`
+        # Title
+      `,
+      after: dedent`
+        # Title
+      `,
+    },
+    {
+      testName: 'Creates multi-line array tag when missing',
+      before: dedent`
+        #test
+      `,
+      after: dedent`
+        ---
+        tags:
+          - test
+        ---
+        #test
+      `,
+      options: {
+        tagArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+    {
+      testName: 'Creates single-line array tags when missing',
+      before: dedent`
+        #test
+      `,
+      after: dedent`
+        ---
+        tags: [test]
+        ---
+        #test
+      `,
+    },
+    {
+      testName: 'Creates single string tag when missing',
+      before: dedent`
+        #test
+      `,
+      after: dedent`
+        ---
+        tags: test
+        ---
+        #test
+      `,
+      options: {
+        tagArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
+      },
+    },
+    {
+      testName: 'Creates multi-line array tags when empty',
+      before: dedent`
+        ---
+        tags: ${''}
+        ---
+        #test
+      `,
+      after: dedent`
+        ---
+        tags:
+          - test
+        ---
+        #test
+      `,
+      options: {
+        tagArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+    {
+      testName: 'Creates single-line array tags when empty',
+      before: dedent`
+        ---
+        tags: ${''}
+        ---
+        #test
+      `,
+      after: dedent`
+        ---
+        tags: [test]
+        ---
+        #test
+      `,
+    },
+    {
+      testName: 'Nothing happens when the tags in the body are covered by the tags in the yaml already',
+      before: dedent`
+        ---
+        tags: test
+        ---
+        #test
+      `,
+      after: dedent`
+        ---
+        tags: test
+        ---
+        #test
+      `,
+      options: {
+        tagArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
+      },
+    },
+  ],
+});

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -347,6 +347,96 @@ animal: cat
 ---
 ``````
 
+### Move Tags to Yaml
+
+Alias: `move-tags-to-yaml`
+
+Move all tags to Yaml frontmatter of the document.
+
+Options:
+- Yaml tags section style: The style of the Yaml tags section
+	- Default: `single-line`
+	- `multi-line`: ```tags:\n  - tag1```
+	- `single-line`: ```tags: [tag1]```
+	- `single string to single-line`: Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.
+	- `single string to multi-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.
+	- `single-line space delimited`: ```tags: [tag1 tag2]```
+	- `single string space delimited`: ```tags: tag1 tag2```
+	- `single string comma delimited`: ```tags: tag1, tag2```
+- Remove the hashtag from tags in content body: Removes `#` from tags in content body after moving them to the Yaml frontmatter
+	- Default: `false`
+
+Example: Move tags from body to Yaml
+
+Before:
+
+``````markdown
+Text has to do with #test and #markdown
+
+#test content here
+```
+#ignored
+Code block content is ignored
+```
+
+This inline code `#ignored content`
+``````
+
+After:
+
+``````markdown
+---
+tags: [test, markdown]
+---
+Text has to do with #test and #markdown
+
+#test content here
+```
+#ignored
+Code block content is ignored
+```
+
+This inline code `#ignored content`
+``````
+Example: Move tags from body to Yaml with existing tags retains the already existing ones and only adds new ones
+
+Before:
+
+``````markdown
+---
+tags: [test, tag2]
+---
+Text has to do with #test and #markdown
+``````
+
+After:
+
+``````markdown
+---
+tags: [test, tag2, markdown]
+---
+Text has to do with #test and #markdown
+``````
+Example: Move tags to Yaml frontmatter and then remove hashtags in body content tags `Remove the hashtag from tags in content body = true` 
+
+Before:
+
+``````markdown
+---
+tags: [test, tag2]
+---
+Text has to do with #test and #markdown
+``````
+
+After:
+
+``````markdown
+---
+tags: [test, tag2, markdown]
+---
+Text has to do with test and markdown
+``````
+
 ### Remove YAML Keys
 
 Alias: `remove-yaml-keys`

--- a/src/rules/move-tags-to-yaml.ts
+++ b/src/rules/move-tags-to-yaml.ts
@@ -1,0 +1,197 @@
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {tagRegex} from '../utils/regex';
+import {
+  convertTagValueToStringOrStringArray,
+  getYamlSectionValue,
+  setYamlSection,
+  splitValueIfSingleOrMultilineArray,
+  formatYamlArrayValue,
+  initYAML,
+  formatYAML,
+  OBSIDIAN_TAG_KEY,
+  NormalArrayFormats,
+  SpecialArrayFormats,
+  TagSpecificArrayFormats,
+} from '../utils/yaml';
+
+class MoveTagsToYamlOptions implements Options {
+  tagArrayStyle? : TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
+  removeHashtagsFromTagsInBody?: boolean = false;
+}
+
+@RuleBuilder.register
+export default class MoveTagsToYaml extends RuleBuilder<MoveTagsToYamlOptions> {
+  get OptionsClass(): new () => MoveTagsToYamlOptions {
+    return MoveTagsToYamlOptions;
+  }
+  get name(): string {
+    return 'Move Tags to Yaml';
+  }
+  get description(): string {
+    return 'Move all tags to Yaml frontmatter of the document.';
+  }
+  get type(): RuleType {
+    return RuleType.YAML;
+  }
+  apply(text: string, options: MoveTagsToYamlOptions): string {
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math], text, (text) => {
+      const tags = text.match(tagRegex);
+      if (!tags) {
+        return text;
+      }
+
+      text = initYAML(text);
+      text = formatYAML(text, (text: string) => {
+        text = text.replace('---\n', '').replace('---', '');
+
+        let tagValue = convertTagValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(getYamlSectionValue(text, OBSIDIAN_TAG_KEY)));
+        const existingTags = new Set<string>();
+        if (typeof tagValue === 'string') {
+          existingTags.add(tagValue);
+          tagValue = [tagValue];
+        } else if (tagValue != undefined) {
+          for (const tag of tagValue) {
+            existingTags.add(tag);
+          }
+        } else {
+          tagValue = [];
+        }
+
+        for (const tag of tags) {
+          const tagContent = tag.trim().substring(1);
+          if (!existingTags.has(tagContent)) {
+            existingTags.add(tagContent);
+            tagValue.push(tagContent);
+          }
+        }
+
+        const newYaml = setYamlSection(text, OBSIDIAN_TAG_KEY, formatYamlArrayValue(tagValue, options.tagArrayStyle));
+
+        return `---\n${newYaml}---`;
+      });
+
+      if (options.removeHashtagsFromTagsInBody) {
+        text = text.replace(tagRegex, (tag: string) => {
+          const hashtagIndex = tag.indexOf('#');
+          return tag.substring(0, hashtagIndex) + tag.substring(hashtagIndex+1);
+        });
+      }
+
+      return text;
+    });
+  }
+  get exampleBuilders(): ExampleBuilder<MoveTagsToYamlOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Move tags from body to Yaml',
+        before: dedent`
+          Text has to do with #test and #markdown
+          ${''}
+          #test content here
+          \`\`\`
+          #ignored
+          Code block content is ignored
+          \`\`\`
+          ${''}
+          This inline code \`#ignored content\`
+        `,
+        after: dedent`
+          ---
+          tags: [test, markdown]
+          ---
+          Text has to do with #test and #markdown
+          ${''}
+          #test content here
+          \`\`\`
+          #ignored
+          Code block content is ignored
+          \`\`\`
+          ${''}
+          This inline code \`#ignored content\`
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Move tags from body to Yaml with existing tags retains the already existing ones and only adds new ones',
+        before: dedent`
+          ---
+          tags: [test, tag2]
+          ---
+          Text has to do with #test and #markdown
+        `,
+        after: dedent`
+          ---
+          tags: [test, tag2, markdown]
+          ---
+          Text has to do with #test and #markdown
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Move tags to Yaml frontmatter and then remove hashtags in body content tags `Remove the hashtag from tags in content body = true` ',
+        before: dedent`
+          ---
+          tags: [test, tag2]
+          ---
+          Text has to do with #test and #markdown
+        `,
+        after: dedent`
+          ---
+          tags: [test, tag2, markdown]
+          ---
+          Text has to do with test and markdown
+        `,
+        options: {
+          removeHashtagsFromTagsInBody: true,
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<MoveTagsToYamlOptions>[] {
+    return [
+      new DropdownOptionBuilder({
+        OptionsClass: MoveTagsToYamlOptions,
+        name: 'Yaml tags section style',
+        description: 'The style of the Yaml tags section',
+        optionsKey: 'tagArrayStyle',
+        records: [
+          {
+            value: NormalArrayFormats.MultiLine as TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats,
+            description: '```tags:\\n  - tag1```',
+          },
+          {
+            value: NormalArrayFormats.SingleLine,
+            description: '```tags: [tag1]```',
+          },
+          {
+            value: SpecialArrayFormats.SingleStringToSingleLine,
+            description: 'Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.',
+          },
+          {
+            value: SpecialArrayFormats.SingleStringToMultiLine,
+            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.',
+          },
+          {
+            value: TagSpecificArrayFormats.SingleLineSpaceDelimited,
+            description: '```tags: [tag1 tag2]```',
+          },
+          {
+            value: TagSpecificArrayFormats.SingleStringSpaceDelimited,
+            description: '```tags: tag1 tag2```',
+          },
+          {
+            value: SpecialArrayFormats.SingleStringCommaDelimited,
+            description: '```tags: tag1, tag2```',
+          },
+        ],
+      }),
+      new BooleanOptionBuilder({
+        OptionsClass: MoveTagsToYamlOptions,
+        name: 'Remove the hashtag from tags in content body',
+        description: 'Removes `#` from tags in content body after moving them to the Yaml frontmatter',
+        optionsKey: 'removeHashtagsFromTagsInBody',
+      }),
+    ];
+  }
+}


### PR DESCRIPTION
Fixes #246 

Changes Made:
- Added a rule that can copy tags from the body of the text to the the yaml frontmatter and even remove the hashtag in the tag bodies if the user so chooses
- Added UTs to verify that certain functionality works
- Added docs for the new rule