### PR TITLE
Allow for Dictionary Value Retrieval for Yaml Key Sort

### DIFF
--- a/__tests__/yaml-key-sort.test.ts
+++ b/__tests__/yaml-key-sort.test.ts
@@ -40,5 +40,31 @@ ruleTest({
         yamlTimestampDateModifiedEnabled: true,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/415
+      testName: 'Sort works with dictionary Yaml value',
+      before: dedent`
+        ---
+        test_key: "Hello"
+        dictionary:
+          abc: "abc"
+          def: "def"
+        tags: 
+          - Test
+        ---
+      `,
+      after: dedent`
+        ---
+        dictionary:
+          abc: "abc"
+          def: "def"
+        tags:
+          - Test
+        test_key: "Hello"
+        ---
+      `,
+      options: {
+        yamlSortOrderForOtherKeys: 'Ascending Alphabetical',
+      },
+    },
   ],
 });

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -38,7 +38,7 @@ export function toSingleLineArrayYamlString<T>(arr: T[]): string {
 }
 
 function getYamlSectionRegExp(rawKey: string): RegExp {
-  return new RegExp(`${rawKey}:[ \\t]*(\\S.*|(?:(?:\\n *- \\S.*)|((?:\\n *- *))*)*)\\n`);
+  return new RegExp(`${rawKey}:[ \\t]*(\\S.*|(?:(?:\\n *- \\S.*)|((?:\\n *- *))*|(\\n([ \\t]+[^\\n]*))*)*)\\n`);
 }
 
 export function setYamlSection(yaml: string, rawKey: string, rawValue: string): string {


### PR DESCRIPTION
Fixes #415 

Changes Made:
- Updated the regex for getting yaml to allow for getting dictionary values back (hopefully other nesting levels as well)
- Added a UT for the reported scenario