### PR TITLE
Update Settings to Allow for the Collapsing of Tabs to Just Icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-linter",
-  "version": "1.4.4",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
-      "version": "1.4.4",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
@@ -14,9 +14,11 @@
         "diff-match-patch": "^1.0.5",
         "js-yaml": "^4.1.0",
         "loglevel": "^1.8.0",
+        "rehype-stringify": "^9.0.3",
         "remark": "^14.0.2",
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
+        "remark-rehype": "^10.1.0",
         "ts-dedent": "^2.2.0",
         "unified": "^10.1.2",
         "unified-lint-rule": "^2.1.0"
@@ -2496,6 +2498,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -3313,6 +3323,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/character-entities-legacy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-2.0.0.tgz",
@@ -3408,6 +3427,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4750,6 +4778,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz",
+      "integrity": "sha512-thjnlGAnwP8ef/GSO1Q8BfVk2gundnc2peGQqEg2kUt/IqesiGg/5mSwN2fE7nLzy61pg88NG6xV+UrGOrx9EA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.3.tgz",
+      "integrity": "sha512-/D/E5ymdPYhHpPkuTHOUkSatxr4w1ZKrZsG0Zv/3C2SRVT0JFJG53VS45AMrBtYk0wp5A7ksEhiC8QaOZM95+A==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "html-void-elements": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.2",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
+      "integrity": "sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -4761,6 +4832,15 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html-void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
+      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -5905,6 +5985,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/mdast-util-definitions": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.1.tgz",
+      "integrity": "sha512-rQ+Gv7mHttxHOBx2dkF4HWTg+EE+UR78ptQWDylzPKaQuVGdG4HIoY3SrS/pCp80nZ04greFvXbVFHT+uf0JVQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.1.tgz",
@@ -6048,6 +6142,26 @@
         "@types/mdast": "^3.0.0",
         "longest-streak": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.2.4.tgz",
+      "integrity": "sha512-a21xoxSef1l8VhHxS1Dnyioz6grrJkoaCUgGzMD/7dWHvboYX3VW53esRUfB5tgTyz4Yos1n25SPcj35dJqmAg==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-builder": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6580,9 +6694,9 @@
       }
     },
     "node_modules/micromark-util-sanitize-uri": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz",
-      "integrity": "sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
+      "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7212,6 +7326,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/property-information": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
+      "integrity": "sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -7395,6 +7518,20 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-stringify": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
+      "integrity": "sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-to-html": "^8.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
@@ -7447,6 +7584,21 @@
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
         "unified": "^10.0.0"
       },
       "funding": {
@@ -7660,6 +7812,15 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
+      "integrity": "sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -7745,6 +7906,28 @@
         "core-js": "^2.0.0",
         "traverse": "^0.6.6",
         "type-name": "^2.0.1"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities/node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -7900,6 +8083,15 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/trough": {
       "version": "2.0.2",
@@ -8100,10 +8292,43 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-builder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.0.tgz",
+      "integrity": "sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-generated": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.0.tgz",
+      "integrity": "sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
       "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.3.tgz",
+      "integrity": "sha512-p/5EMGIa1qwbXjA+QgcBXaPWjSnZfQ2Sc3yBEEfgPwsEmJd8Qh+DSk3LGnmOM4S1bY2C0AjmMnB8RuEYxpPwXQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -10247,6 +10472,14 @@
         "@types/node": "*"
       }
     },
+    "@types/hast": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -10832,6 +11065,11 @@
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.0.tgz",
       "integrity": "sha512-oHqMj3eAuJ77/P5PaIRcqk+C3hdfNwyCD2DAUcD5gyXkegAuF2USC40CEqPscDk4I8FRGMTojGJQkXDsN5QlJA=="
     },
+    "character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
+    },
     "character-entities-legacy": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-2.0.0.tgz",
@@ -10908,6 +11146,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "comma-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -11819,6 +12062,37 @@
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
+    "hast-util-is-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz",
+      "integrity": "sha512-thjnlGAnwP8ef/GSO1Q8BfVk2gundnc2peGQqEg2kUt/IqesiGg/5mSwN2fE7nLzy61pg88NG6xV+UrGOrx9EA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "hast-util-to-html": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.3.tgz",
+      "integrity": "sha512-/D/E5ymdPYhHpPkuTHOUkSatxr4w1ZKrZsG0Zv/3C2SRVT0JFJG53VS45AMrBtYk0wp5A7ksEhiC8QaOZM95+A==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "html-void-elements": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.2",
+        "unist-util-is": "^5.0.0"
+      }
+    },
+    "hast-util-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
+      "integrity": "sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg=="
+    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -11830,6 +12104,11 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "html-void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
+      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="
     },
     "human-signals": {
       "version": "2.1.0",
@@ -12678,6 +12957,16 @@
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.2.tgz",
       "integrity": "sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA=="
     },
+    "mdast-util-definitions": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.1.tgz",
+      "integrity": "sha512-rQ+Gv7mHttxHOBx2dkF4HWTg+EE+UR78ptQWDylzPKaQuVGdG4HIoY3SrS/pCp80nZ04greFvXbVFHT+uf0JVQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      }
+    },
     "mdast-util-find-and-replace": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.1.tgz",
@@ -12785,6 +13074,22 @@
         "@types/mdast": "^3.0.0",
         "longest-streak": "^3.0.0",
         "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-to-hast": {
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.2.4.tgz",
+      "integrity": "sha512-a21xoxSef1l8VhHxS1Dnyioz6grrJkoaCUgGzMD/7dWHvboYX3VW53esRUfB5tgTyz4Yos1n25SPcj35dJqmAg==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-builder": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
       }
     },
     "mdast-util-to-markdown": {
@@ -13100,9 +13405,9 @@
       }
     },
     "micromark-util-sanitize-uri": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz",
-      "integrity": "sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
+      "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
       "requires": {
         "micromark-util-character": "^1.0.0",
         "micromark-util-encode": "^1.0.0",
@@ -13574,6 +13879,11 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "property-information": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
+      "integrity": "sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w=="
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -13710,6 +14020,16 @@
         }
       }
     },
+    "rehype-stringify": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
+      "integrity": "sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-to-html": "^8.0.0",
+        "unified": "^10.0.0"
+      }
+    },
     "remark": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
@@ -13750,6 +14070,17 @@
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      }
+    },
+    "remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
         "unified": "^10.0.0"
       }
     },
@@ -13898,6 +14229,11 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
+    "space-separated-tokens": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
+      "integrity": "sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw=="
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -13974,6 +14310,22 @@
         "core-js": "^2.0.0",
         "traverse": "^0.6.6",
         "type-name": "^2.0.1"
+      }
+    },
+    "stringify-entities": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
+      "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
+      "requires": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "dependencies": {
+        "character-entities-legacy": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+          "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+        }
       }
     },
     "strip-ansi": {
@@ -14090,6 +14442,11 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
     },
     "trough": {
       "version": "2.0.2",
@@ -14221,10 +14578,31 @@
         "vfile": "^5.0.0"
       }
     },
+    "unist-builder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.0.tgz",
+      "integrity": "sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-generated": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.0.tgz",
+      "integrity": "sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw=="
+    },
     "unist-util-is": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
       "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+    },
+    "unist-util-position": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.3.tgz",
+      "integrity": "sha512-p/5EMGIa1qwbXjA+QgcBXaPWjSnZfQ2Sc3yBEEfgPwsEmJd8Qh+DSk3LGnmOM4S1bY2C0AjmMnB8RuEYxpPwXQ==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
     },
     "unist-util-stringify-position": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,11 @@
     "diff-match-patch": "^1.0.5",
     "js-yaml": "^4.1.0",
     "loglevel": "^1.8.0",
+    "rehype-stringify": "^9.0.3",
     "remark": "^14.0.2",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
+    "remark-rehype": "^10.1.0",
     "ts-dedent": "^2.2.0",
     "unified": "^10.1.2",
     "unified-lint-rule": "^2.1.0"

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,185 +1,83 @@
 // icon sources
-const lintFileSVG = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   fill="currentColor"
-   viewBox="0 0 100 100"
-   width="100"
-   height="100"
-   version="1.1"
-   id="svg3235"
-   xml:space="preserve"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><defs
-     id="defs3239" /><path
-     d="M 5,2 V 99.648562 H 96.607328 V 28.733947 L 95.891646,28.070574 65.35587,2.597036 64.560667,2 Z m 5.089296,4.2455896 h 50.89296 V 31.719127 H 91.518032 V 95.402972 H 10.089296 Z M 66.071552,9.2971072 87.860101,27.473538 H 66.071552 Z"
-     id="path3233"
-     style="stroke-width:2.32417" /><g
-     transform="matrix(0.15232206,0,0,0.14054685,49.142307,65.828276)"
-     id="g3717">
-    <g
-   style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   transform="matrix(3.89,0,0,3.89,-175.05,-175.05)"
-   id="g3715">
-    <path
-   d="m 89.161,11.093 c -0.109,-0.329 -0.381,-0.578 -0.719,-0.658 -0.334,-0.078 -0.692,0.02 -0.937,0.266 l -7.189,7.189 c -1.096,1.096 -2.553,1.7 -4.104,1.7 -1.55,0 -3.007,-0.603 -4.104,-1.699 -2.262,-2.263 -2.262,-5.944 0,-8.207 L 79.297,2.495 C 79.542,2.25 79.643,1.895 79.563,1.558 79.484,1.221 79.234,0.949 78.905,0.839 73.042,-1.106 66.689,0.39 62.335,4.745 57.872,9.207 56.419,15.794 58.543,21.693 L 21.693,58.544 C 15.796,56.42 9.208,57.874 4.745,62.336 0.39,66.691 -1.107,73.04 0.838,78.906 c 0.109,0.329 0.381,0.579 0.719,0.658 0.335,0.081 0.692,-0.021 0.937,-0.266 l 7.189,-7.189 c 2.261,-2.263 5.943,-2.263 8.207,0 1.096,1.096 1.699,2.553 1.699,4.104 0,1.551 -0.603,3.007 -1.7,4.104 L 10.7,87.506 c -0.245,0.245 -0.346,0.599 -0.266,0.937 0.08,0.338 0.329,0.609 0.658,0.719 1.7,0.563 3.44,0.839 5.16,0.839 4.218,0 8.317,-1.652 11.41,-4.745 4.463,-4.463 5.917,-11.049 3.793,-16.948 L 68.306,31.457 c 5.9,2.123 12.485,0.671 16.948,-3.793 4.357,-4.355 5.853,-10.705 3.907,-16.571 z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path3709" />
-    <path
-   d="M 72.088,57.275 C 71.911,57.098 71.675,56.995 71.426,56.983 67.964,56.828 64.348,55.107 61.503,52.262 59.761,50.519 58.438,48.48 57.64,46.365 L 46.517,57.488 c 2.115,0.799 4.154,2.121 5.897,3.863 2.845,2.846 4.565,6.462 4.721,9.923 0.012,0.249 0.115,0.485 0.292,0.662 l 14.876,14.876 c 2.021,2.021 4.676,3.031 7.33,3.031 2.655,0 5.311,-1.01 7.331,-3.031 4.041,-4.042 4.041,-10.619 0,-14.661 z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path3711" />
-    <path
-   d="m 5.351,14.171 c 0.123,0.219 0.324,0.384 0.563,0.462 l 5.82,1.89 23.869,23.869 4.638,-4.638 L 16.372,11.885 14.481,6.065 C 14.403,5.826 14.238,5.625 14.019,5.502 L 4.714,0.279 C 4.323,0.06 3.834,0.128 3.518,0.444 L 0.293,3.668 C -0.024,3.985 -0.091,4.474 0.128,4.864 Z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path3713" />
-</g>
-</g></svg>`;
+const lintFileSVG = `<svg fill="currentColor" viewBox="0 0 100 100" width="100" height="100" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+   <path d="M5 2v97.649h91.607V28.734l-.715-.663L65.356 2.597 64.56 2Zm5.09 4.246h50.892v25.473h30.536v63.684H10.089Zm55.982 3.051L87.86 27.474H66.072Z" style="stroke-width:2.32417"/>
+   <g style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" stroke-linecap="round">
+      <path d="M89.161 11.093a1 1 0 0 0-1.656-.392l-7.189 7.189a5.765 5.765 0 0 1-4.104 1.7 5.768 5.768 0 0 1-4.104-1.699 5.811 5.811 0 0 1 0-8.207l7.189-7.189a1 1 0 0 0-.392-1.656C73.042-1.106 66.689.39 62.335 4.745a16.177 16.177 0 0 0-3.792 16.948l-36.85 36.851a16.18 16.18 0 0 0-16.948 3.792C.39 66.691-1.107 73.04.838 78.906a.998.998 0 0 0 1.656.392l7.189-7.189a5.81 5.81 0 0 1 8.207 0 5.764 5.764 0 0 1 1.699 4.104 5.763 5.763 0 0 1-1.7 4.104L10.7 87.506a.999.999 0 0 0 .392 1.656c1.7.563 3.44.839 5.16.839 4.218 0 8.317-1.652 11.41-4.745a16.177 16.177 0 0 0 3.793-16.948l36.851-36.851a16.177 16.177 0 0 0 16.948-3.793c4.357-4.355 5.853-10.705 3.907-16.571z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(.59252 0 0 .54674 22.478 41.225)"/>
+      <path d="M72.088 57.275a1.003 1.003 0 0 0-.662-.292c-3.462-.155-7.078-1.876-9.923-4.721-1.742-1.743-3.065-3.782-3.863-5.897L46.517 57.488c2.115.799 4.154 2.121 5.897 3.863 2.845 2.846 4.565 6.462 4.721 9.923.012.249.115.485.292.662l14.876 14.876a10.334 10.334 0 0 0 7.33 3.031c2.655 0 5.311-1.01 7.331-3.031 4.041-4.042 4.041-10.619 0-14.661zM5.351 14.171c.123.219.324.384.563.462l5.82 1.89 23.869 23.869 4.638-4.638-23.869-23.869-1.891-5.82a1.003 1.003 0 0 0-.462-.563L4.714.279a1 1 0 0 0-1.196.165L.293 3.668a1 1 0 0 0-.165 1.196Z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(.59252 0 0 .54674 22.478 41.225)"/>
+   </g>
+</svg>`;
 
-const lintFolderSVG = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   version="1.1"
-   width="100"
-   height="100"
-   viewBox="0 0 100 100"
-   xml:space="preserve"
-   id="svg3874"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-<defs
-   id="defs3862" />
+const lintFolderSVG = `<svg width="100" height="100" viewBox="0 0 100 100" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+   <g style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" stroke-linecap="round">
+      <path d="M89.161 11.093a1 1 0 0 0-1.656-.392l-7.189 7.189a5.765 5.765 0 0 1-4.104 1.7 5.768 5.768 0 0 1-4.104-1.699 5.811 5.811 0 0 1 0-8.207l7.189-7.189a1 1 0 0 0-.392-1.656C73.042-1.106 66.689.39 62.335 4.745a16.177 16.177 0 0 0-3.792 16.948l-36.85 36.851a16.18 16.18 0 0 0-16.948 3.792C.39 66.691-1.107 73.04.838 78.906a.998.998 0 0 0 1.656.392l7.189-7.189a5.81 5.81 0 0 1 8.207 0 5.764 5.764 0 0 1 1.699 4.104 5.763 5.763 0 0 1-1.7 4.104L10.7 87.506a.999.999 0 0 0 .392 1.656c1.7.563 3.44.839 5.16.839 4.218 0 8.317-1.652 11.41-4.745a16.177 16.177 0 0 0 3.793-16.948l36.851-36.851a16.177 16.177 0 0 0 16.948-3.793c4.357-4.355 5.853-10.705 3.907-16.571z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(.57187 0 0 .39802 28.922 50.846)"/>
+      <path d="M72.088 57.275a1.003 1.003 0 0 0-.662-.292c-3.462-.155-7.078-1.876-9.923-4.721-1.742-1.743-3.065-3.782-3.863-5.897L46.517 57.488c2.115.799 4.154 2.121 5.897 3.863 2.845 2.846 4.565 6.462 4.721 9.923.012.249.115.485.292.662l14.876 14.876a10.334 10.334 0 0 0 7.33 3.031c2.655 0 5.311-1.01 7.331-3.031 4.041-4.042 4.041-10.619 0-14.661zM5.351 14.171c.123.219.324.384.563.462l5.82 1.89 23.869 23.869 4.638-4.638-23.869-23.869-1.891-5.82a1.003 1.003 0 0 0-.462-.563L4.714.279a1 1 0 0 0-1.196.165L.293 3.668a1 1 0 0 0-.165 1.196Z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(.57187 0 0 .39802 28.922 50.846)"/>
+   </g>
+   <g style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none">
+      <path d="M89.234 35.526a3.794 3.794 0 0 0-3.065-1.536H74.085v-8.511a5.187 5.187 0 0 0-5.181-5.181H44.128a2.196 2.196 0 0 1-1.542-.639l-7.588-7.588a5.144 5.144 0 0 0-3.664-1.518H5.181A5.188 5.188 0 0 0 0 15.735v59.569a4.147 4.147 0 0 0 4.142 4.143h70.075c2.389 0 4.245-1.737 5.093-4.753l10.531-35.792c.344-1.17.124-2.4-.607-3.376zM4.142 76.446c-.63 0-1.142-.513-1.142-1.143V15.735c0-1.203.978-2.181 2.181-2.181h26.154c.574 0 1.136.233 1.542.639l7.588 7.588a5.144 5.144 0 0 0 3.664 1.518h24.776c1.202 0 2.181.978 2.181 2.181v8.511h-50.05a5.292 5.292 0 0 0-5.065 3.817L5.342 74.893c-.442 1.553-.954 1.553-1.2 1.553Zm82.821-38.392-10.537 35.81c-.331 1.179-.983 2.582-2.222 2.582H7.985c.086-.227.167-.469.241-.729l10.629-37.083a2.278 2.278 0 0 1 2.181-1.644h65.133c.36 0 .57.208.663.333a.813.813 0 0 1 .131.731z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(1.06512 0 0 1.385 3.167 -10.742)"/>
+   </g>
+</svg>`;
 
-<g
-   transform="matrix(0.14701218,0,0,0.10231871,54.655987,68.756842)"
-   id="g3940">
-    <g
-   style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   transform="matrix(3.89,0,0,3.89,-175.05,-175.05)"
-   id="g3938">
-    <path
-   d="m 89.161,11.093 c -0.109,-0.329 -0.381,-0.578 -0.719,-0.658 -0.334,-0.078 -0.692,0.02 -0.937,0.266 l -7.189,7.189 c -1.096,1.096 -2.553,1.7 -4.104,1.7 -1.55,0 -3.007,-0.603 -4.104,-1.699 -2.262,-2.263 -2.262,-5.944 0,-8.207 L 79.297,2.495 C 79.542,2.25 79.643,1.895 79.563,1.558 79.484,1.221 79.234,0.949 78.905,0.839 73.042,-1.106 66.689,0.39 62.335,4.745 57.872,9.207 56.419,15.794 58.543,21.693 L 21.693,58.544 C 15.796,56.42 9.208,57.874 4.745,62.336 0.39,66.691 -1.107,73.04 0.838,78.906 c 0.109,0.329 0.381,0.579 0.719,0.658 0.335,0.081 0.692,-0.021 0.937,-0.266 l 7.189,-7.189 c 2.261,-2.263 5.943,-2.263 8.207,0 1.096,1.096 1.699,2.553 1.699,4.104 0,1.551 -0.603,3.007 -1.7,4.104 L 10.7,87.506 c -0.245,0.245 -0.346,0.599 -0.266,0.937 0.08,0.338 0.329,0.609 0.658,0.719 1.7,0.563 3.44,0.839 5.16,0.839 4.218,0 8.317,-1.652 11.41,-4.745 4.463,-4.463 5.917,-11.049 3.793,-16.948 L 68.306,31.457 c 5.9,2.123 12.485,0.671 16.948,-3.793 4.357,-4.355 5.853,-10.705 3.907,-16.571 z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path3932" />
-    <path
-   d="M 72.088,57.275 C 71.911,57.098 71.675,56.995 71.426,56.983 67.964,56.828 64.348,55.107 61.503,52.262 59.761,50.519 58.438,48.48 57.64,46.365 L 46.517,57.488 c 2.115,0.799 4.154,2.121 5.897,3.863 2.845,2.846 4.565,6.462 4.721,9.923 0.012,0.249 0.115,0.485 0.292,0.662 l 14.876,14.876 c 2.021,2.021 4.676,3.031 7.33,3.031 2.655,0 5.311,-1.01 7.331,-3.031 4.041,-4.042 4.041,-10.619 0,-14.661 z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path3934" />
-    <path
-   d="m 5.351,14.171 c 0.123,0.219 0.324,0.384 0.563,0.462 l 5.82,1.89 23.869,23.869 4.638,-4.638 L 16.372,11.885 14.481,6.065 C 14.403,5.826 14.238,5.625 14.019,5.502 L 4.714,0.279 C 4.323,0.06 3.834,0.128 3.518,0.444 L 0.293,3.668 C -0.024,3.985 -0.091,4.474 0.128,4.864 Z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path3936" />
-</g>
-</g><g
-   transform="matrix(0.27381202,0,0,0.35603928,51.097404,51.582597)"
-   id="g4147">
-    <g
-   style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   transform="matrix(3.89,0,0,3.89,-175.05,-175.05)"
-   id="g4145">
-    <path
-   d="M 89.234,35.526 C 88.505,34.55 87.387,33.99 86.169,33.99 H 74.085 v -8.511 c 0,-2.856 -2.324,-5.181 -5.181,-5.181 H 44.128 c -0.574,0 -1.136,-0.233 -1.542,-0.639 L 34.998,12.071 C 34.02,11.092 32.719,10.553 31.334,10.553 H 5.181 C 2.324,10.554 0,12.878 0,15.735 v 49.459 7.593 2.517 c 0,2.284 1.858,4.143 4.142,4.143 h 70.042 c 0.011,0 0.021,0 0.033,0 2.389,0 4.245,-1.737 5.093,-4.753 L 89.841,38.902 c 0.344,-1.17 0.124,-2.4 -0.607,-3.376 z M 4.142,76.446 C 3.512,76.446 3,75.933 3,75.303 V 72.786 65.193 15.735 c 0,-1.203 0.978,-2.181 2.181,-2.181 h 26.154 c 0.574,0 1.136,0.233 1.542,0.639 l 7.588,7.588 c 0.978,0.979 2.279,1.518 3.664,1.518 h 24.776 c 1.202,0 2.181,0.978 2.181,2.181 v 8.511 h -50.05 c -2.338,0 -4.421,1.57 -5.065,3.817 L 5.342,74.893 C 4.9,76.446 4.388,76.446 4.142,76.446 Z M 86.963,38.054 76.426,73.864 c -0.331,1.179 -0.983,2.582 -2.222,2.582 -0.003,0 -0.007,0 -0.011,0 H 7.985 C 8.071,76.219 8.152,75.977 8.226,75.717 L 18.855,38.634 c 0.277,-0.968 1.174,-1.644 2.181,-1.644 h 65.133 c 0.36,0 0.57,0.208 0.663,0.333 0.093,0.124 0.233,0.384 0.131,0.731 z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path4143" />
-</g>
-</g></svg>`;
+const lintVaultSVG = `<svg width="100" height="100" viewBox="0 0 100 100" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+   <g style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(1.07096 0 0 1.20147 1.964 -4.212)">
+      <path d="M90 84.505H0V5.495h90zm-86-4h82V9.495H4Z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"/>
+      <path d="M90 32.695H0v-27.2h90zm-86-4h82v-19.2H4Z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"/>
+      <rect x="9.58" y="17.09" rx="0" ry="0" width="3.07" height="4" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"/>
+      <rect x="16.45" y="17.09" rx="0" ry="0" width="3.07" height="4" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"/>
+      <rect x="23.31" y="17.09" rx="0" ry="0" width="3.07" height="4" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"/>
+      <rect x="36.55" y="17.09" rx="0" ry="0" width="43.88" height="4" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"/>
+   </g>
+   <g style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" stroke-linecap="round">
+      <path d="M89.161 11.093a1 1 0 0 0-1.656-.392l-7.189 7.189a5.765 5.765 0 0 1-4.104 1.7 5.768 5.768 0 0 1-4.104-1.699 5.811 5.811 0 0 1 0-8.207l7.189-7.189a1 1 0 0 0-.392-1.656C73.042-1.106 66.689.39 62.335 4.745a16.177 16.177 0 0 0-3.792 16.948l-36.85 36.851a16.18 16.18 0 0 0-16.948 3.792C.39 66.691-1.107 73.04.838 78.906a.998.998 0 0 0 1.656.392l7.189-7.189a5.81 5.81 0 0 1 8.207 0 5.764 5.764 0 0 1 1.699 4.104 5.763 5.763 0 0 1-1.7 4.104L10.7 87.506a.999.999 0 0 0 .392 1.656c1.7.563 3.44.839 5.16.839 4.218 0 8.317-1.652 11.41-4.745a16.177 16.177 0 0 0 3.793-16.948l36.851-36.851a16.177 16.177 0 0 0 16.948-3.793c4.357-4.355 5.853-10.705 3.907-16.571z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(.66714 0 0 .51336 18.867 41.049)"/>
+      <path d="M72.088 57.275a1.003 1.003 0 0 0-.662-.292c-3.462-.155-7.078-1.876-9.923-4.721-1.742-1.743-3.065-3.782-3.863-5.897L46.517 57.488c2.115.799 4.154 2.121 5.897 3.863 2.845 2.846 4.565 6.462 4.721 9.923.012.249.115.485.292.662l14.876 14.876a10.334 10.334 0 0 0 7.33 3.031c2.655 0 5.311-1.01 7.331-3.031 4.041-4.042 4.041-10.619 0-14.661zM5.351 14.171c.123.219.324.384.563.462l5.82 1.89 23.869 23.869 4.638-4.638-23.869-23.869-1.891-5.82a1.003 1.003 0 0 0-.462-.563L4.714.279a1 1 0 0 0-1.196.165L.293 3.668a1 1 0 0 0-.165 1.196Z" style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none" transform="matrix(.66714 0 0 .51336 18.867 41.049)"/>
+   </g>
+</svg>`;
 
-const lintVaultSVG = `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   version="1.1"
-   width="100"
-   height="100"
-   viewBox="0 0 100 100"
-   xml:space="preserve"
-   id="svg4286"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-<defs
-   id="defs4268" />
-<g
-   transform="matrix(0.27531192,0,0,0.3088608,50.157353,49.85424)"
-   id="g4284">
-    <g
-   style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   transform="matrix(3.89,0,0,3.89,-175.05,-175.05)"
-   id="g4282">
-    <path
-   d="M 90,84.505 H 0 V 5.495 h 90 z m -86,-4 H 86 V 9.495 H 4 Z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path4270" />
-    <path
-   d="M 90,32.695 H 0 v -27.2 h 90 z m -86,-4 H 86 V 9.495 H 4 Z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path4272" />
-    <rect
-   x="9.5799999"
-   y="17.09"
-   rx="0"
-   ry="0"
-   width="3.0699999"
-   height="4"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   id="rect4274" />
-    <rect
-   x="16.450001"
-   y="17.09"
-   rx="0"
-   ry="0"
-   width="3.0699999"
-   height="4"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   id="rect4276" />
-    <rect
-   x="23.309999"
-   y="17.09"
-   rx="0"
-   ry="0"
-   width="3.0699999"
-   height="4"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   id="rect4278" />
-    <rect
-   x="36.549999"
-   y="17.09"
-   rx="0"
-   ry="0"
-   width="43.880001"
-   height="4"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   id="rect4280" />
-</g>
-</g>
-<g
-   transform="matrix(0.17149846,0,0,0.13197486,48.887861,64.150509)"
-   id="g4352">
-    <g
-   style="opacity:1;fill:none;fill-rule:nonzero;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   transform="matrix(3.89,0,0,3.89,-175.05,-175.05)"
-   id="g4350">
-    <path
-   d="m 89.161,11.093 c -0.109,-0.329 -0.381,-0.578 -0.719,-0.658 -0.334,-0.078 -0.692,0.02 -0.937,0.266 l -7.189,7.189 c -1.096,1.096 -2.553,1.7 -4.104,1.7 -1.55,0 -3.007,-0.603 -4.104,-1.699 -2.262,-2.263 -2.262,-5.944 0,-8.207 L 79.297,2.495 C 79.542,2.25 79.643,1.895 79.563,1.558 79.484,1.221 79.234,0.949 78.905,0.839 73.042,-1.106 66.689,0.39 62.335,4.745 57.872,9.207 56.419,15.794 58.543,21.693 L 21.693,58.544 C 15.796,56.42 9.208,57.874 4.745,62.336 0.39,66.691 -1.107,73.04 0.838,78.906 c 0.109,0.329 0.381,0.579 0.719,0.658 0.335,0.081 0.692,-0.021 0.937,-0.266 l 7.189,-7.189 c 2.261,-2.263 5.943,-2.263 8.207,0 1.096,1.096 1.699,2.553 1.699,4.104 0,1.551 -0.603,3.007 -1.7,4.104 L 10.7,87.506 c -0.245,0.245 -0.346,0.599 -0.266,0.937 0.08,0.338 0.329,0.609 0.658,0.719 1.7,0.563 3.44,0.839 5.16,0.839 4.218,0 8.317,-1.652 11.41,-4.745 4.463,-4.463 5.917,-11.049 3.793,-16.948 L 68.306,31.457 c 5.9,2.123 12.485,0.671 16.948,-3.793 4.357,-4.355 5.853,-10.705 3.907,-16.571 z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path4344" />
-    <path
-   d="M 72.088,57.275 C 71.911,57.098 71.675,56.995 71.426,56.983 67.964,56.828 64.348,55.107 61.503,52.262 59.761,50.519 58.438,48.48 57.64,46.365 L 46.517,57.488 c 2.115,0.799 4.154,2.121 5.897,3.863 2.845,2.846 4.565,6.462 4.721,9.923 0.012,0.249 0.115,0.485 0.292,0.662 l 14.876,14.876 c 2.021,2.021 4.676,3.031 7.33,3.031 2.655,0 5.311,-1.01 7.331,-3.031 4.041,-4.042 4.041,-10.619 0,-14.661 z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path4346" />
-    <path
-   d="m 5.351,14.171 c 0.123,0.219 0.324,0.384 0.563,0.462 l 5.82,1.89 23.869,23.869 4.638,-4.638 L 16.372,11.885 14.481,6.065 C 14.403,5.826 14.238,5.625 14.019,5.502 L 4.714,0.279 C 4.323,0.06 3.834,0.128 3.518,0.444 L 0.293,3.668 C -0.024,3.985 -0.091,4.474 0.128,4.864 Z"
-   style="opacity:1;fill:currentColor;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none"
-   stroke-linecap="round"
-   id="path4348" />
-</g>
-</g></svg>`;
+// copied SVG info
+
+// https://icon-sets.iconify.design/codicon/whitespace/
+const whitespaceSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+   <path fill="currentColor" d="M75 12.5V6.25H40.625a21.875 21.875 0 0 0 0 43.75H50v31.25h-6.25v6.25H75v-6.25h-6.25V12.5H75zM50 43.75h-9.375a15.625 15.625 0 1 1 0-31.25H50v31.25zm12.5 37.5h-6.25V12.5h6.25v68.75z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/fluent/math-formula-20-filled/
+const mathSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 125 125">
+   <path fill="currentColor" d="M55.719 22.131c1.812-.25 2.956-.213 3.831-.037a9.375 9.375 0 0 1 3.038 1.3 4.688 4.688 0 1 0 4.825-8.037 18.606 18.606 0 0 0-6.025-2.45c-2.244-.45-4.525-.406-7.05-.044l-.112.013c-5 .838-8.919 3.419-11.594 7.262-2.581 3.725-3.831 8.375-4.188 13.281a4.688 4.688 0 0 0-.006.331v.05l-.006.15-.019.519-.081 1.688c-.063 1.387-.169 3.25-.287 5.45l-.031.581H30a4.688 4.688 0 0 0 0 9.375h7.469l-.356 6.05a2608.581 2608.581 0 0 1-1.794 28.263c-.669 8.025-1.375 13.362-6.419 16.313-2.519 1.431-6.369 1.344-10.563-.75a4.688 4.688 0 0 0-4.188 8.375c5.794 2.906 13.188 4.069 19.419.506l.037-.019c9.581-5.594 10.425-15.937 11-22.912l.063-.75v-.031c.369-4.8 1.406-21.625 2.188-35.044h11.269a4.688 4.688 0 0 0 0-9.375H47.4c.231-4.175.388-7.225.406-8.225.287-3.788 1.219-6.594 2.525-8.475 1.231-1.769 2.919-2.938 5.388-3.356Zm49.156 42.125a4.688 4.688 0 1 0-6.625-6.631L82.131 73.738a226.175 226.175 0 0 1-4.75-8.463l-.456-.725c-.956-1.531-2.381-3.819-4.112-5.419a10.056 10.056 0 0 0-4.6-2.519 9.662 9.662 0 0 0-5.981.631 4.688 4.688 0 0 0-.875.494l-.206.137a11.125 11.125 0 0 0-1.769 1.456c-.281.294-.563.625-.825.931l-.137.163-1.025 1.188a4.688 4.688 0 0 0 7.087 6.144l1.081-1.263.131-.156c.263-.313.363-.425.419-.481l.075-.056c.063.037.144.106.256.213.356.325.781.844 1.325 1.644a48.75 48.75 0 0 1 1.05 1.619l.55.875c.756 1.469 3.063 5.606 5.912 10.438L57.625 98.25a4.688 4.688 0 1 0 6.625 6.625l16.637-16.631a240.988 240.988 0 0 1 5.1 9.069l.313.544c.813 1.381 2.188 3.731 4 5.45 1.125 1.069 2.637 2.125 4.581 2.637a10.038 10.038 0 0 0 6.6-.6c2.225-1.113 3.6-2.55 5.025-4.869a4.688 4.688 0 0 0-8-4.894 5.95 5.95 0 0 1-.787 1.1.938.938 0 0 1-.2.156 1.163 1.163 0 0 1-.206.037h-.044s-.044-.013-.125-.063a2.419 2.419 0 0 1-.394-.313 9.156 9.156 0 0 1-1.269-1.606 37.587 37.587 0 0 1-.988-1.613l-.375-.644a289.688 289.688 0 0 0-6.381-11.244l17.137-17.144ZM66.25 65.768Zm-.013 0h.013Z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/fluent/slide-text-20-regular/
+const contentSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100px" height="100px" preserveAspectRatio="xMidYMid meet" viewBox="0 0 125 125">
+   <path fill="currentColor" d="M34.375 43.75a3.125 3.125 0 0 0 0 6.25h25a3.125 3.125 0 0 0 0 -6.25h-25Zm0 15.625a3.125 3.125 0 0 0 0 6.25h43.75a3.125 3.125 0 0 0 0 -6.25h-43.75Zm-3.125 18.75a3.125 3.125 0 0 1 3.125 -3.125h31.25a3.125 3.125 0 0 1 0 6.25h-31.25a3.125 3.125 0 0 1 -3.125 -3.125ZM28.125 25A15.625 15.625 0 0 0 12.5 40.625v43.75A15.625 15.625 0 0 0 28.125 100h68.75a15.625 15.625 0 0 0 15.625 -15.625v-43.75A15.625 15.625 0 0 0 96.875 25h-68.75ZM18.75 40.625A9.375 9.375 0 0 1 28.125 31.25h68.75A9.375 9.375 0 0 1 106.25 40.625v43.75a9.375 9.375 0 0 1 -9.375 9.375h-68.75A9.375 9.375 0 0 1 18.75 84.375v-43.75Z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/fluent/clipboard-text-ltr-20-regular/
+const pasteSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 125 125">
+   <path fill="currentColor" d="M40.625 50a3.125 3.125 0 0 0 0 6.25h43.75a3.125 3.125 0 0 0 0-6.25h-43.75ZM37.5 71.875a3.125 3.125 0 0 1 3.125-3.125h18.75a3.125 3.125 0 0 1 0 6.25h-18.75a3.125 3.125 0 0 1-3.125-3.125ZM40.625 87.5a3.125 3.125 0 0 0 0 6.25h31.25a3.125 3.125 0 0 0 0-6.25h-31.25Zm12.5-75a9.375 9.375 0 0 0-8.844 6.25h-9.906A9.375 9.375 0 0 0 25 28.125v75a9.375 9.375 0 0 0 9.375 9.375h56.25a9.375 9.375 0 0 0 9.375-9.375v-75a9.375 9.375 0 0 0-9.375-9.375h-9.906a9.375 9.375 0 0 0-8.844-6.25h-18.75Zm18.75 6.25a3.125 3.125 0 0 1 0 6.25h-18.75a3.125 3.125 0 0 1 0-6.25h18.75ZM34.375 25h9.906a9.375 9.375 0 0 0 8.844 6.25h18.75A9.375 9.375 0 0 0 80.719 25h9.906a3.125 3.125 0 0 1 3.125 3.125v75a3.125 3.125 0 0 1-3.125 3.125h-56.25a3.125 3.125 0 0 1-3.125-3.125v-75A3.125 3.125 0 0 1 34.375 25Z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/fluent/book-add-20-regular/
+const addBookSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 125 125">
+   <path fill="currentColor" d="M87.5 18.75h-50A6.25 6.25 0 0 0 31.25 25v68.75h25.138a34.375 34.375 0 0 0 1.156 6.25H31.25a6.25 6.25 0 0 0 6.25 6.25H60a34.63 34.63 0 0 0 4.106 6.25H37.5A12.5 12.5 0 0 1 25 100V25a12.5 12.5 0 0 1 12.5-12.5h50A12.5 12.5 0 0 1 100 25v32.544a34.25 34.25 0 0 0-6.25-1.156V25a6.25 6.25 0 0 0-6.25-6.25Zm-50 12.5v6.25a6.25 6.25 0 0 0 6.25 6.25h37.5a6.25 6.25 0 0 0 6.25-6.25v-6.25A6.25 6.25 0 0 0 81.25 25h-37.5a6.25 6.25 0 0 0-6.25 6.25Zm6.25 0h37.5v6.25h-37.5v-6.25Zm75 59.375a28.125 28.125 0 1 1-56.25 0 28.125 28.125 0 0 1 56.25 0Zm-25-12.5a3.125 3.125 0 0 0-6.25 0V87.5h-9.375a3.125 3.125 0 0 0 0 6.25H87.5v9.375a3.125 3.125 0 0 0 6.25 0V93.75h9.375a3.125 3.125 0 0 0 0-6.25H93.75v-9.375Z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/fluent/text-header-1-20-filled/
+const headingSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 125 125">
+   <path fill="currentColor" d="M103.581 23.894a4.688 4.688 0 0 0-6.613 3.313c-1.594 7.112-8.175 16.3-16.756 22.019a4.688 4.688 0 1 0 5.2 7.8 54.806 54.806 0 0 0 11.463-10.338v50.187a4.688 4.688 0 0 0 9.375 0v-68.65a4.688 4.688 0 0 0-2.669-4.331Zm-81.706 4.231a4.688 4.688 0 1 0-9.375 0v68.75a4.688 4.688 0 0 0 9.375 0v-31.25h31.25v31.25a4.688 4.688 0 0 0 9.375 0v-68.75a4.688 4.688 0 1 0-9.375 0V56.25h-31.25V28.125Z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/fluent/text-footnote-20-filled/
+const footerSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 125 125">
+   <path fill="currentColor" d="M108.187 18.75a4.688 4.688 0 0 1 4.313 4.675v34.388a4.688 4.688 0 0 1-9.375 0V38.206a27.531 27.531 0 0 1-1.944 1.431 4.688 4.688 0 0 1-5.2-7.806c3.85-2.563 6.644-6.638 7.25-9.406a4.669 4.669 0 0 1 4.956-3.675ZM63.75 94.188a4.913 4.913 0 0 1-1.25-3.413V41.294a5.188 5.188 0 0 1 1.325-3.606l.025-.025a4.75 4.75 0 0 1 3.519-1.463 4.625 4.625 0 0 1 3.5 1.475c.938.994 1.375 2.244 1.375 3.625v14.669a15.53 15.53 0 0 1 3.006-2.288l.013-.006c2.481-1.438 5.25-2.15 8.275-2.15 5.438 0 9.925 2.063 13.3 6.162 3.356 4.075 4.956 9.412 4.956 15.862 0 6.469-1.6 11.819-4.956 15.9-3.381 4.081-7.906 6.125-13.419 6.125-3.081 0-5.894-.706-8.388-2.156h-.006a15.619 15.619 0 0 1-3.094-2.375 4.656 4.656 0 0 1-4.787 4.525 4.519 4.519 0 0 1-3.375-1.356l-.019-.025Zm11.313-11c1.862 2.325 4.181 3.438 7.062 3.438 3.05 0 5.344-1.106 7.062-3.313 1.75-2.275 2.712-5.475 2.712-9.763 0-4.263-.963-7.456-2.719-9.738-1.719-2.231-4.013-3.344-7.056-3.344-2.875 0-5.194 1.125-7.062 3.475-1.856 2.344-2.856 5.5-2.856 9.606 0 4.125 1 7.294 2.85 9.638Zm-64.125 7.543c0 1.319.531 2.469 1.519 3.344l.043.05a5.5 5.5 0 0 0 3.562 1.194 5 5 0 0 0 3.081-.975 5.731 5.731 0 0 0 1.875-2.694l4.662-12.662h20.462l4.694 12.662a5.719 5.719 0 0 0 1.875 2.688 5 5 0 0 0 3.087.981 5.375 5.375 0 0 0 3.55-1.213 4.313 4.313 0 0 0 1.581-3.375c0-.775-.219-1.625-.537-2.469L41.954 40.224a6.888 6.888 0 0 0-2.288-3.163 6.037 6.037 0 0 0-3.65-1.125c-1.4 0-2.688.344-3.781 1.125a6.8 6.8 0 0 0-2.362 3.206l-18.4 47.994a7.125 7.125 0 0 0-.537 2.469ZM42.987 70h-14.1l7.051-19.35 7.05 19.356Z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/file-icons/yaml-alt4/
+const yamlSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100px" height="100px" preserveAspectRatio="xMidYMid meet" viewBox="0 0 3200 3200">
+   <path fill="currentColor" d="m1473.706 130.869l-573.844 860.463v545.469H548.138v-545.469L0 130.869h395.313l348.55 554.038l351.406 -554.038h378.438zm590.631 1093.281H1427.706l-129.481 312.65H1016.313l596.125 -1405.931h288.356l571.938 1405.931h-301.225l-107.175 -312.65zm-105.75 -279.588l-195.162 -515.938l-217.731 515.938h412.887zM548.131 1691.187v1377.938h295.644V2118.638l309.406 638.875h232.713l319.975 -661.331v972.663h283.619V1691.187h-387.25l-343.606 623.163l-327.25 -623.163h-383.25zM3200 2770H2472.737V1691.187h-301.225v1372.013H3200v-293.188z"/>
+</svg>`;
+
+// https://icon-sets.iconify.design/fluent/settings-20-regular/
+const settingsSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+   <path fill="currentColor" d="M9.55 36.915a42.455 42.455 0 0 1 8.9-15.4 2.5 2.5 0 0 1 2.7-.675l9.59 3.43a5 5 0 0 0 6.6-3.81l1.83-10.03a2.5 2.5 0 0 1 1.94-2 42.66 42.66 0 0 1 17.775 0 2.5 2.5 0 0 1 1.935 2l1.835 10.03a5 5 0 0 0 6.6 3.81l9.59-3.43a2.5 2.5 0 0 1 2.7.68 42.455 42.455 0 0 1 8.9 15.395 2.5 2.5 0 0 1-.76 2.675l-7.775 6.6a5 5 0 0 0 0 7.62l7.775 6.6a2.5 2.5 0 0 1 .76 2.675 42.455 42.455 0 0 1-8.9 15.4 2.5 2.5 0 0 1-2.7.675l-9.59-3.43a5 5 0 0 0-6.6 3.81L60.82 89.575a2.5 2.5 0 0 1-1.935 1.995 42.65 42.65 0 0 1-17.775 0 2.5 2.5 0 0 1-1.94-2l-1.825-10.03a5 5 0 0 0-6.6-3.81l-9.595 3.43a2.5 2.5 0 0 1-2.7-.68 42.45 42.45 0 0 1-8.9-15.395 2.5 2.5 0 0 1 .765-2.675l7.77-6.6a5 5 0 0 0 0-7.62l-7.77-6.6a2.5 2.5 0 0 1-.765-2.675Zm5.305-.03 6.47 5.49a10 10 0 0 1 0 15.25l-6.475 5.49a37.45 37.45 0 0 0 6.225 10.76l7.98-2.85a10 10 0 0 1 13.2 7.625l1.525 8.34a37.78 37.78 0 0 0 12.425 0l1.525-8.35a9.99 9.99 0 0 1 13.2-7.62l7.985 2.855a37.46 37.46 0 0 0 6.225-10.76l-6.47-5.49a9.99 9.99 0 0 1 0-15.25l6.47-5.49a37.455 37.455 0 0 0-6.225-10.76l-7.98 2.85a10 10 0 0 1-13.2-7.62l-1.53-8.345a37.775 37.775 0 0 0-12.425 0l-1.52 8.345a10 10 0 0 1-13.205 7.625l-7.98-2.855a37.455 37.455 0 0 0-6.225 10.76ZM37.5 50a12.5 12.5 0 1 1 25 0 12.5 12.5 0 0 1-25 0Zm5 0a7.5 7.5 0 1 0 15 0 7.5 7.5 0 0 0-15 0Z"/>
+</svg>`;
 
 // exported SVG info
 
@@ -187,4 +85,13 @@ export const iconInfo: Record<string, {id: string, source: string}> = {
   folder: {id: 'lint-folder', source: lintFolderSVG},
   file: {id: 'lint-file', source: lintFileSVG},
   vault: {id: 'lint-vault', source: lintVaultSVG},
-};
+  whitespace: {id: 'lint-whitespace', source: whitespaceSVG},
+  math: {id: 'lint-math', source: mathSVG},
+  content: {id: 'lint-content', source: contentSVG},
+  paste: {id: 'lint-paste', source: pasteSVG},
+  custom: {id: 'lint-custom', source: addBookSVG},
+  heading: {id: 'lint-heading', source: headingSVG},
+  footer: {id: 'lint-footer', source: footerSVG},
+  yaml: {id: 'lint-yaml', source: yamlSVG},
+  general: {id: 'lint-general', source: settingsSVG},
+} as const;

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,7 +1,7 @@
 import {Setting} from 'obsidian';
 import LinterPlugin from './main';
 import {LinterSettings} from './rules';
-import {convertRegularMarkdownLinksToHTMLLinks} from './utils/mdast';
+import {parseTextToHTMLWithoutOuterParagraph} from './utils/mdast';
 
 export type SearchOptionInfo = {name: string, description: string, options?: DropdownRecord[]}
 
@@ -44,8 +44,6 @@ export class BooleanOption extends Option {
 
   public display(containerEl: HTMLElement, settings: LinterSettings, plugin: LinterPlugin): void {
     const setting = new Setting(containerEl)
-        .setName(this.name)
-        .setDesc(this.description)
         .addToggle((toggle) => {
           toggle.setValue(settings.ruleConfigs[this.ruleName][this.name]);
           toggle.onChange((value) => {
@@ -55,7 +53,9 @@ export class BooleanOption extends Option {
           });
         });
 
-    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
+    setting.nameEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.name);
+    setting.descEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.description);
+
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -66,8 +66,6 @@ export class TextOption extends Option {
 
   public display(containerEl: HTMLElement, settings: LinterSettings, plugin: LinterPlugin): void {
     const setting = new Setting(containerEl)
-        .setName(this.name)
-        .setDesc(this.description)
         .addText((textbox) => {
           textbox.setValue(settings.ruleConfigs[this.ruleName][this.name]);
           textbox.onChange((value) => {
@@ -77,7 +75,9 @@ export class TextOption extends Option {
           });
         });
 
-    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
+    setting.nameEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.name);
+    setting.descEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.description);
+
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -88,8 +88,6 @@ export class TextAreaOption extends Option {
 
   public display(containerEl: HTMLElement, settings: LinterSettings, plugin: LinterPlugin): void {
     const setting = new Setting(containerEl)
-        .setName(this.name)
-        .setDesc(this.description)
         .addTextArea((textbox) => {
           textbox.setValue(settings.ruleConfigs[this.ruleName][this.name]);
           textbox.onChange((value) => {
@@ -99,7 +97,9 @@ export class TextAreaOption extends Option {
           });
         });
 
-    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
+    setting.nameEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.name);
+    setting.descEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.description);
+
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -110,8 +110,6 @@ export class MomentFormatOption extends Option {
 
   public display(containerEl: HTMLElement, settings: LinterSettings, plugin: LinterPlugin): void {
     const setting = new Setting(containerEl)
-        .setName(this.name)
-        .setDesc(this.description)
         .addMomentFormat((format) => {
           format.setValue(settings.ruleConfigs[this.ruleName][this.name]);
           format.setPlaceholder('dddd, MMMM Do YYYY, h:mm:ss a');
@@ -122,7 +120,9 @@ export class MomentFormatOption extends Option {
           });
         });
 
-    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
+    setting.nameEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.name);
+    setting.descEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.description);
+
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
@@ -150,8 +150,6 @@ export class DropdownOption extends Option {
 
   public display(containerEl: HTMLElement, settings: LinterSettings, plugin: LinterPlugin): void {
     const setting = new Setting(containerEl)
-        .setName(this.name)
-        .setDesc(this.description)
         .addDropdown((dropdown) => {
         // First, add all the available options
           for (const option of this.options) {
@@ -168,13 +166,10 @@ export class DropdownOption extends Option {
           });
         });
 
-    makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting);
+    setting.nameEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.name);
+    setting.descEl.innerHTML = parseTextToHTMLWithoutOuterParagraph(this.description);
+
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
   }
-}
-
-function makeSureSettingNameAndDescriptionHaveHTMlLinksInsteadOfMarkdownLinks(setting: Setting) {
-  setting.nameEl.innerHTML = convertRegularMarkdownLinksToHTMLLinks(setting.nameEl.innerHTML);
-  setting.descEl.innerHTML = convertRegularMarkdownLinksToHTMLLinks(setting.descEl.innerHTML);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,7 +12,7 @@
   font-size: 16px;
 
   display: flex;
-	flex-direction: row;
+  flex-direction: row;
   white-space: nowrap;
 
   padding: 4px 6px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,10 @@
   font-weight: bold;
   font-size: 16px;
 
+  display: flex;
+	flex-direction: row;
+  white-space: nowrap;
+
   padding: 4px 6px;
   align-items: center;
   gap: 4px;
@@ -25,6 +29,22 @@
   height: 32px;
 }
 
+@media screen and (max-width: 1325px) {
+  .linter-navigation-item.linter-desktop {
+		max-width: 32px;
+	}
+}
+
+@media screen and (max-width: 800px) {
+  .linter-navigation-item.linter-mobile {
+		max-width: 32px;
+	}
+}
+
+.linter-navigation-item-icon {
+  padding-top: 5px;
+}
+
 .linter-navigation-item:hover {
   border-color: var(--interactive-accent-hover);
   border-bottom: 0px;
@@ -34,7 +54,7 @@
   background-color: var(--interactive-accent) !important;
   color: var(--text-on-accent);
   padding: 4px 9px !important;
-  max-width: 200px;
+  max-width: 200px !important;
   border: 1px solid var(--background-modifier-border);
   border-radius: 8px 8px 2px 2px;
   border-bottom: 0px;
@@ -83,12 +103,6 @@
   padding-left: 2px;
   padding-right: 2px;
   border-bottom: 2px solid var(--background-modifier-border);
-}
-
-@media screen and (max-width: 680px) {
-  .linter-setting-header .linter-setting-tab-group {
-    justify-content: space-evenly;
-  }
 }
 
 .linter-setting-header .linter-tab-settings {

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -151,7 +151,7 @@ export class SettingTab extends PluginSettingTab {
   }
 
   generateCustomCommandSettings(tabName: string, containerEl: HTMLElement): void {
-    containerEl.createEl('h3', {text: 'Custom Commands'});
+    containerEl.createEl(Platform.isMobile ? 'h4' : 'h3', {text: 'Custom Commands'});
     const descriptionP1 = `Custom commands are Obsidian commands that get run after the linter is finished running its regular rules.
     This means that they do not run before the YAML timestamp logic runs, so they can cause YAML timestamp to be triggered on the next run of the linter.
     You may only select an Obsidian command once. **_Note that this currently only works on linting the current file._**`;
@@ -418,7 +418,7 @@ export class SettingTab extends PluginSettingTab {
   private createSearchZeroState(containerEl: HTMLElement) {
     this.searchZeroState = containerEl.createDiv();
     this.hideEl(this.searchZeroState);
-    this.searchZeroState.createEl('h2', {text: 'No settings match search'}).style.textAlign = 'center';
+    this.searchZeroState.createEl(Platform.isMobile ? 'h3' : 'h2', {text: 'No settings match search'}).style.textAlign = 'center';
   }
 
   private addSettingToMasterSettingsList(tabName: string, containerEl: HTMLDivElement, name: string = '', description: string = '', options: SearchOptionInfo[] = null, alias: string = null) {


### PR DESCRIPTION
Changes Made:
- Added `remark-rehype` to allow for converting between markdown and html for the settings page while removing the outer paragraph tags that were causing weird formatting
- Added new icons including a couple unused ones and refactored existing ones
- Updated logic to make sure that the name and description for rules would be properly converted to html
- Updated styles to better handle the changes to mobile tabs