### PR TITLE
fixed the issue with subsets being grabbed by regex for yaml value re…

### DIFF
--- a/__tests__/remove-yaml-keys.test.ts
+++ b/__tests__/remove-yaml-keys.test.ts
@@ -1,0 +1,40 @@
+import RemoveYamlKeys from '../src/rules/remove-yaml-keys';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: RemoveYamlKeys,
+  testCases: [
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/426
+      testName: 'Make sure that removing keys only works on the entire key not just a part',
+      before: dedent`
+        ---
+        type: 
+        status: 
+        tags: 
+        aliases: 
+        cssclass: 
+        publish: false
+        date created: 2022-09-27 18:41
+        date modified: 2022-09-27 18:44
+        ---
+      `,
+      after: dedent`
+        ---
+        type: 
+        status: 
+        tags: 
+        aliases: 
+        cssclass: 
+        publish: false
+        date created: 2022-09-27 18:41
+        date modified: 2022-09-27 18:44
+        ---
+      `,
+      options: {
+        yamlKeysToRemove: ['created'],
+      },
+    },
+  ],
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,13 +32,13 @@
 @media screen and (max-width: 1325px) {
   .linter-navigation-item.linter-desktop {
 		max-width: 32px;
-	}
+  }
 }
 
 @media screen and (max-width: 800px) {
   .linter-navigation-item.linter-mobile {
 		max-width: 32px;
-	}
+  }
 }
 
 .linter-navigation-item-icon {

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -38,15 +38,15 @@ export function toSingleLineArrayYamlString<T>(arr: T[]): string {
 }
 
 function getYamlSectionRegExp(rawKey: string): RegExp {
-  return new RegExp(`${rawKey}:[ \\t]*(\\S.*|(?:(?:\\n *- \\S.*)|((?:\\n *- *))*|(\\n([ \\t]+[^\\n]*))*)*)\\n`);
+  return new RegExp(`^([\\t ]*)${rawKey}:[ \\t]*(\\S.*|(?:(?:\\n *- \\S.*)|((?:\\n *- *))*|(\\n([ \\t]+[^\\n]*))*)*)\\n`, 'm');
 }
 
 export function setYamlSection(yaml: string, rawKey: string, rawValue: string): string {
   const yamlSectionEscaped = `${rawKey}:${rawValue}\n`;
   let isReplaced = false;
-  let result = yaml.replace(getYamlSectionRegExp(rawKey), () => {
+  let result = yaml.replace(getYamlSectionRegExp(rawKey), (_, $1: string) => {
     isReplaced = true;
-    return yamlSectionEscaped;
+    return $1 + yamlSectionEscaped;
   });
   if (!isReplaced) {
     result = `${yaml}${yamlSectionEscaped}`;
@@ -56,7 +56,7 @@ export function setYamlSection(yaml: string, rawKey: string, rawValue: string): 
 
 export function getYamlSectionValue(yaml: string, rawKey: string): string | null {
   const match = yaml.match(getYamlSectionRegExp(rawKey));
-  const result = match == null ? null : match[1];
+  const result = match == null ? null : match[2];
   return result;
 }
 


### PR DESCRIPTION
Fixes #426 

The problem was that the regex was not multi-line and it was assuming that the text to match on could start anywhere. This led to the problem of having a partial match on yaml key removal which then let 'date created' get moved onto the same line after the first time it ran.

Changes Made:
- Made sure that yaml values were grabbed from the start of the line making sure to account for that in replace statements
- Added a UT for the scenario in question