### PR TITLE
Add Unordered List Item Indicator Style Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [remove-multiple-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-spaces)
 - [strong-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#strong-style)
 - [two-spaces-between-lines-with-content](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#two-spaces-between-lines-with-content)
+- [unordered-list-style](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#unordered-list-style)
 
 ### Spacing rules
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2086,6 +2086,121 @@ Even more content here
 
 ``````
 
+### Unordered List Style
+
+Alias: `unordered-list-style`
+
+Makes sure that unordered lists follow the style specified..
+
+Options:
+- List item style: The list item style to use in unordered lists
+	- Default: `-`
+	- `-`: Makes sure unordered list items use `-` as their indicator
+	- `*`: Makes sure unordered list items use `*` as their indicator
+	- `+`: Makes sure unordered list items use `+` as their indicator
+
+Example: Unordered lists have their indicator updated to `-` when `List item style = '-'`
+
+Before:
+
+``````markdown
+- Item 1
+  * Sublist 1 item 1
+  * Sublist 1 item 2
+* Item 2
+  + Sublist 2 item 1
+  + Sublist 2 item 2
++ Item 3
+  - Sublist 3 item 1
+  - Sublist 3 item 2
+
+See that the ordered list is ignored, but its sublist is not
+
+1. Item 1
+  - Sub item 1
+1. Item 2
+  * Sub item 2
+1. Item 3
+  + Sub item 3
+``````
+
+After:
+
+``````markdown
+- Item 1
+  - Sublist 1 item 1
+  - Sublist 1 item 2
+- Item 2
+  - Sublist 2 item 1
+  - Sublist 2 item 2
+- Item 3
+  - Sublist 3 item 1
+  - Sublist 3 item 2
+
+See that the ordered list is ignored, but its sublist is not
+
+1. Item 1
+  - Sub item 1
+1. Item 2
+  - Sub item 2
+1. Item 3
+  - Sub item 3
+``````
+Example: Unordered lists have their indicator updated to `*` when `List item style = '*'`
+
+Before:
+
+``````markdown
+- Item 1
+  * Sublist 1 item 1
+  * Sublist 1 item 2
+* Item 2
+  + Sublist 2 item 1
+  + Sublist 2 item 2
++ Item 3
+  - Sublist 3 item 1
+  - Sublist 3 item 2
+
+``````
+
+After:
+
+``````markdown
+* Item 1
+  * Sublist 1 item 1
+  * Sublist 1 item 2
+* Item 2
+  * Sublist 2 item 1
+  * Sublist 2 item 2
+* Item 3
+  * Sublist 3 item 1
+  * Sublist 3 item 2
+
+``````
+Example: Unordered list in blockquote has list item indicators set to `+` when `List item style = '-'`
+
+Before:
+
+``````markdown
+> - Item 1
+> + Item 2
+> > * Subitem 1
+> > + Subitem 2
+> >   - Sub sub item 1
+> > - Subitem 3
+``````
+
+After:
+
+``````markdown
+> + Item 1
+> + Item 2
+> > + Subitem 1
+> > + Subitem 2
+> >   + Sub sub item 1
+> > + Subitem 3
+``````
+
 ## Spacing
 ### Compact YAML
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2094,11 +2094,57 @@ Makes sure that unordered lists follow the style specified..
 
 Options:
 - List item style: The list item style to use in unordered lists
-	- Default: `-`
+	- Default: `consistent`
+	- `consistent`: Makes sure unordered list items use a consistent list item indicator in the file which will be based on the first list item found
 	- `-`: Makes sure unordered list items use `-` as their indicator
 	- `*`: Makes sure unordered list items use `*` as their indicator
 	- `+`: Makes sure unordered list items use `+` as their indicator
 
+Example: Unordered lists have their indicator updated to `*` when `List item style = 'consistent'` and `*` is the first unordered list indicator
+
+Before:
+
+``````markdown
+1. ordered item 1
+2. ordered item 2
+
+Checklists should be ignored
+- [ ] Checklist item 1
+- [x] completed item
+
+* Item 1
+  - Sublist 1 item 1
+  - Sublist 1 item 2
+- Item 2
+  + Sublist 2 item 1
+  + Sublist 2 item 2
++ Item 3
+  * Sublist 3 item 1
+  * Sublist 3 item 2
+
+``````
+
+After:
+
+``````markdown
+1. ordered item 1
+2. ordered item 2
+
+Checklists should be ignored
+- [ ] Checklist item 1
+- [x] completed item
+
+* Item 1
+  * Sublist 1 item 1
+  * Sublist 1 item 2
+* Item 2
+  * Sublist 2 item 1
+  * Sublist 2 item 2
+* Item 3
+  * Sublist 3 item 1
+  * Sublist 3 item 2
+
+``````
 Example: Unordered lists have their indicator updated to `-` when `List item style = '-'`
 
 Before:

--- a/src/rules/unordered-list-style.ts
+++ b/src/rules/unordered-list-style.ts
@@ -1,0 +1,154 @@
+import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {UnorderedListItemStyles, updateUnorderedListItemIndicators} from '../utils/mdast';
+
+
+class UnorderedListStyleOptions implements Options {
+  listStyle?: UnorderedListItemStyles = UnorderedListItemStyles.Dash;
+}
+
+@RuleBuilder.register
+export default class UnorderedListStyle extends RuleBuilder<UnorderedListStyleOptions> {
+  get OptionsClass(): new () => UnorderedListStyleOptions {
+    return UnorderedListStyleOptions;
+  }
+  get name(): string {
+    return 'Unordered List Style';
+  }
+  get description(): string {
+    return 'Makes sure that unordered lists follow the style specified..';
+  }
+  get type(): RuleType {
+    return RuleType.CONTENT;
+  }
+  apply(text: string, options: UnorderedListStyleOptions): string {
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.tag], text, (text) => {
+      return updateUnorderedListItemIndicators(text, options.listStyle);
+    });
+  }
+  get exampleBuilders(): ExampleBuilder<UnorderedListStyleOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Unordered lists have their indicator updated to `-` when `List item style = \'-\'`',
+        before: dedent`
+          - Item 1
+            * Sublist 1 item 1
+            * Sublist 1 item 2
+          * Item 2
+            + Sublist 2 item 1
+            + Sublist 2 item 2
+          + Item 3
+            - Sublist 3 item 1
+            - Sublist 3 item 2
+          ${''}
+          See that the ordered list is ignored, but its sublist is not
+          ${''}
+          1. Item 1
+            - Sub item 1
+          1. Item 2
+            * Sub item 2
+          1. Item 3
+            + Sub item 3
+        `,
+        after: dedent`
+          - Item 1
+            - Sublist 1 item 1
+            - Sublist 1 item 2
+          - Item 2
+            - Sublist 2 item 1
+            - Sublist 2 item 2
+          - Item 3
+            - Sublist 3 item 1
+            - Sublist 3 item 2
+          ${''}
+          See that the ordered list is ignored, but its sublist is not
+          ${''}
+          1. Item 1
+            - Sub item 1
+          1. Item 2
+            - Sub item 2
+          1. Item 3
+            - Sub item 3
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Unordered lists have their indicator updated to `*` when `List item style = \'*\'`',
+        before: dedent`
+          - Item 1
+            * Sublist 1 item 1
+            * Sublist 1 item 2
+          * Item 2
+            + Sublist 2 item 1
+            + Sublist 2 item 2
+          + Item 3
+            - Sublist 3 item 1
+            - Sublist 3 item 2
+          ${''}
+        `,
+        after: dedent`
+          * Item 1
+            * Sublist 1 item 1
+            * Sublist 1 item 2
+          * Item 2
+            * Sublist 2 item 1
+            * Sublist 2 item 2
+          * Item 3
+            * Sublist 3 item 1
+            * Sublist 3 item 2
+          ${''}
+        `,
+        options: {
+          listStyle: UnorderedListItemStyles.Asterisk,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Unordered list in blockquote has list item indicators set to `+` when `List item style = \'-\'`',
+        before: dedent`
+          > - Item 1
+          > + Item 2
+          > > * Subitem 1
+          > > + Subitem 2
+          > >   - Sub sub item 1
+          > > - Subitem 3
+        `,
+        after: dedent`
+          > + Item 1
+          > + Item 2
+          > > + Subitem 1
+          > > + Subitem 2
+          > >   + Sub sub item 1
+          > > + Subitem 3
+        `,
+        options: {
+          listStyle: UnorderedListItemStyles.Plus,
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<UnorderedListStyleOptions>[] {
+    return [
+      new DropdownOptionBuilder<UnorderedListStyleOptions, UnorderedListItemStyles>({
+        OptionsClass: UnorderedListStyleOptions,
+        name: 'List item style',
+        description: 'The list item style to use in unordered lists',
+        optionsKey: 'listStyle',
+        records: [
+          {
+            value: UnorderedListItemStyles.Dash,
+            description: 'Makes sure unordered list items use `-` as their indicator',
+          },
+          {
+            value: UnorderedListItemStyles.Asterisk,
+            description: 'Makes sure unordered list items use `*` as their indicator',
+          },
+          {
+            value: UnorderedListItemStyles.Plus,
+            description: 'Makes sure unordered list items use `+` as their indicator',
+          },
+        ],
+      }),
+    ];
+  }
+}

--- a/src/rules/unordered-list-style.ts
+++ b/src/rules/unordered-list-style.ts
@@ -6,7 +6,7 @@ import {UnorderedListItemStyles, updateUnorderedListItemIndicators} from '../uti
 
 
 class UnorderedListStyleOptions implements Options {
-  listStyle?: UnorderedListItemStyles = UnorderedListItemStyles.Dash;
+  listStyle?: UnorderedListItemStyles = UnorderedListItemStyles.Consistent;
 }
 
 @RuleBuilder.register
@@ -30,6 +30,47 @@ export default class UnorderedListStyle extends RuleBuilder<UnorderedListStyleOp
   }
   get exampleBuilders(): ExampleBuilder<UnorderedListStyleOptions>[] {
     return [
+      new ExampleBuilder({
+        description: 'Unordered lists have their indicator updated to `*` when `List item style = \'consistent\'` and `*` is the first unordered list indicator',
+        before: dedent`
+          1. ordered item 1
+          2. ordered item 2
+          ${''}
+          Checklists should be ignored
+          - [ ] Checklist item 1
+          - [x] completed item
+          ${''}
+          * Item 1
+            - Sublist 1 item 1
+            - Sublist 1 item 2
+          - Item 2
+            + Sublist 2 item 1
+            + Sublist 2 item 2
+          + Item 3
+            * Sublist 3 item 1
+            * Sublist 3 item 2
+          ${''}
+        `,
+        after: dedent`
+          1. ordered item 1
+          2. ordered item 2
+          ${''}
+          Checklists should be ignored
+          - [ ] Checklist item 1
+          - [x] completed item
+          ${''}
+          * Item 1
+            * Sublist 1 item 1
+            * Sublist 1 item 2
+          * Item 2
+            * Sublist 2 item 1
+            * Sublist 2 item 2
+          * Item 3
+            * Sublist 3 item 1
+            * Sublist 3 item 2
+          ${''}
+        `,
+      }),
       new ExampleBuilder({
         description: 'Unordered lists have their indicator updated to `-` when `List item style = \'-\'`',
         before: dedent`
@@ -72,6 +113,9 @@ export default class UnorderedListStyle extends RuleBuilder<UnorderedListStyleOp
           1. Item 3
             - Sub item 3
         `,
+        options: {
+          listStyle: UnorderedListItemStyles.Dash,
+        },
       }),
       new ExampleBuilder({
         description: 'Unordered lists have their indicator updated to `*` when `List item style = \'*\'`',
@@ -135,6 +179,10 @@ export default class UnorderedListStyle extends RuleBuilder<UnorderedListStyleOp
         description: 'The list item style to use in unordered lists',
         optionsKey: 'listStyle',
         records: [
+          {
+            value: UnorderedListItemStyles.Consistent,
+            description: 'Makes sure unordered list items use a consistent list item indicator in the file which will be based on the first list item found',
+          },
           {
             value: UnorderedListItemStyles.Dash,
             description: 'Makes sure unordered list items use `-` as their indicator',

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -42,6 +42,7 @@ export enum UnorderedListItemStyles {
   Plus = '+',
   Dash = '-',
   Asterisk = '*',
+  Consistent = 'consistent',
 }
 
 function parseTextToAST(text: string): Root {
@@ -542,14 +543,35 @@ export function updateUnorderedListItemIndicators(text: string, unorderedListSty
     return text;
   }
 
+  const orderedListAndCheckboxIndicatorRegex = /^((\d+[.)])|(- \[[ x]\]))/m;
+
+  let unorderedStyle: string = unorderedListStyle;
+  if (unorderedListStyle == UnorderedListItemStyles.Consistent) {
+    let i = positions.length - 1;
+    while (i >= 0) {
+      const listText = text.substring(positions[i].start.offset, positions[i].end.offset);
+      i--;
+      if (listText.match(orderedListAndCheckboxIndicatorRegex)) {
+        continue;
+      }
+
+      unorderedStyle = listText.charAt(0);
+      break;
+    }
+
+    if (i == -1) {
+      return text;
+    }
+  }
+
   for (const position of positions) {
     let listText = text.substring(position.start.offset, position.end.offset);
 
-    if (listText.match(/^\d+[.)]/)) {
+    if (listText.match(orderedListAndCheckboxIndicatorRegex)) {
       continue;
     }
 
-    listText = unorderedListStyle + listText.substring(1);
+    listText = unorderedStyle + listText.substring(1);
 
     text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, listText);
   }

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -38,6 +38,12 @@ export enum OrderListItemEndOfIndicatorStyles {
   Parenthesis = ')',
 }
 
+export enum UnorderedListItemStyles {
+  Plus = '+',
+  Dash = '-',
+  Asterisk = '*',
+}
+
 function parseTextToAST(text: string): Root {
   const ast = remark().use(remarkGfm).use(remarkMath).parse(text);
   return ast;
@@ -498,7 +504,7 @@ export function updateOrderedListItemIndicators(text: string, orderedListStyle: 
 
     const preListIndicatorLevelsToIndicatorNumber = new Map<number, number>();
     let lastItemListIndicatorLevel = -1;
-    listText = listText.replace(/^(( |\t|> )*)(\d(\.|\)))([^\n]*)$/gm, (_listItem: string, $1: string = '', _$2: string, _$3: string, _$4: string, $5: string) => {
+    listText = listText.replace(/^(( |\t|> )*)(\d+(\.|\)))([^\n]*)$/gm, (_listItem: string, $1: string = '', _$2: string, _$3: string, _$4: string, $5: string) => {
       let listItemIndicatorNumber = 1;
 
       const listItemIndicatorLevel = getListItemLevel($1);
@@ -525,6 +531,27 @@ export function updateOrderedListItemIndicators(text: string, orderedListStyle: 
     });
 
     text = replaceTextBetweenStartAndEndWithNewValue(text, start, position.end.offset, listText);
+  }
+
+  return text;
+}
+
+export function updateUnorderedListItemIndicators(text: string, unorderedListStyle: UnorderedListItemStyles): string {
+  const positions: Position[] = getPositions(MDAstTypes.ListItem, text);
+  if (!positions) {
+    return text;
+  }
+
+  for (const position of positions) {
+    let listText = text.substring(position.start.offset, position.end.offset);
+
+    if (listText.match(/^\d+[.)]/)) {
+      continue;
+    }
+
+    listText = unorderedListStyle + listText.substring(1);
+
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, listText);
   }
 
   return text;


### PR DESCRIPTION
Fixes #325 
Relates to #32 

Changes Made:
- Added a rule with some examples making an option available to make a list item indicator one of several styles
- Added a helper for updating the actual values for the list item indicator
- The options added are `-`, `+`, `*`, and `consistent