### PR TITLE
Add Empty Lines Around Blockquotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [compact-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#compact-yaml)
 - [consecutive-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#consecutive-blank-lines)
 - [convert-spaces-to-tabs](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#convert-spaces-to-tabs)
+- [empty-line-around-blockquotes](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#empty-line-around-blockquotes)
 - [empty-line-around-code-fences](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#empty-line-around-code-fences)
 - [empty-line-around-tables](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#empty-line-around-tables)
 - [heading-blank-lines](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#heading-blank-lines)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2372,6 +2372,88 @@ After:
 		- text indented with 6 spaces
 ``````
 
+### Empty Line Around Blockquotes
+
+Alias: `empty-line-around-blockquotes`
+
+Ensures that there is an empty line around blockquotes unless they start or end a document. **Note that an empty line is either one less level of nesting for blockquotes or a newline character.**
+
+
+
+Example: Blockquotes that start a document do not get an empty line before them.
+
+Before:
+
+``````markdown
+> Quote content here
+> quote content continued
+# Title here
+``````
+
+After:
+
+``````markdown
+> Quote content here
+> quote content continued
+
+# Title here
+``````
+Example: Blockquotes that end a document do not get an empty line after them.
+
+Before:
+
+``````markdown
+# Heading 1
+> Quote content here
+> quote content continued
+``````
+
+After:
+
+``````markdown
+# Heading 1
+
+> Quote content here
+> quote content continued
+``````
+Example: Blockquotes that are nested have the proper empty line added
+
+Before:
+
+``````markdown
+# Make sure that nested blockquotes are accounted for correctly
+> Quote content here
+> quote content continued
+> > Nested Blockquote
+> > content continued
+
+**Note that the empty line is either one less blockquote indicator if followed/proceeded by more blockquote content or it is an empty line**
+
+# Doubly nested code block
+
+> > Quote content here
+> > quote content continued
+``````
+
+After:
+
+``````markdown
+# Make sure that nested blockquotes are accounted for correctly
+
+> Quote content here
+> quote content continued
+>
+> > Nested Blockquote
+> > content continued
+
+**Note that the empty line is either one less blockquote indicator if followed/proceeded by more blockquote content or it is an empty line**
+
+# Doubly nested code block
+
+> > Quote content here
+> > quote content continued
+``````
+
 ### Empty Line Around Code Fences
 
 Alias: `empty-line-around-code-fences`

--- a/src/rules/empty-line-around-blockquotes.ts
+++ b/src/rules/empty-line-around-blockquotes.ts
@@ -15,7 +15,7 @@ export default class EmptyLineAroundBlockquotes extends RuleBuilder<EmptyLineAro
     return 'Empty Line Around Blockquotes';
   }
   get description(): string {
-    return 'Ensures that there is an empty line around blockquotes unless they start or end a document. **Note that an empty line is either one less level of indentation for blockquotes or a newline character and both are acceptable for blockquotes.**';
+    return 'Ensures that there is an empty line around blockquotes unless they start or end a document. **Note that an empty line is either one less level of nesting for blockquotes or a newline character.**';
   }
   get type(): RuleType {
     return RuleType.SPACING;

--- a/src/rules/empty-line-around-blockquotes.ts
+++ b/src/rules/empty-line-around-blockquotes.ts
@@ -1,0 +1,94 @@
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {ensureEmptyLinesAroundBlockquotes} from '../utils/mdast';
+
+class EmptyLineAroundBlockquotesOptions implements Options {
+}
+
+@RuleBuilder.register
+export default class EmptyLineAroundBlockquotes extends RuleBuilder<EmptyLineAroundBlockquotesOptions> {
+  get OptionsClass(): new () => EmptyLineAroundBlockquotesOptions {
+    return EmptyLineAroundBlockquotesOptions;
+  }
+  get name(): string {
+    return 'Empty Line Around Blockquotes';
+  }
+  get description(): string {
+    return 'Ensures that there is an empty line around blockquotes unless they start or end a document. **Note that an empty line is either one less level of indentation for blockquotes or a newline character and both are acceptable for blockquotes.**';
+  }
+  get type(): RuleType {
+    return RuleType.SPACING;
+  }
+  apply(text: string, options: EmptyLineAroundBlockquotesOptions): string {
+    return ensureEmptyLinesAroundBlockquotes(text);
+  }
+  get exampleBuilders(): ExampleBuilder<EmptyLineAroundBlockquotesOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Blockquotes that start a document do not get an empty line before them.',
+        before: dedent`
+          > Quote content here
+          > quote content continued
+          # Title here
+        `,
+        after: dedent`
+          > Quote content here
+          > quote content continued
+          ${''}
+          # Title here
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Blockquotes that end a document do not get an empty line after them.',
+        before: dedent`
+          # Heading 1
+          > Quote content here
+          > quote content continued
+        `,
+        after: dedent`
+          # Heading 1
+          ${''}
+          > Quote content here
+          > quote content continued
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Blockquotes that are nested have the proper empty line added',
+        before: dedent`
+          # Make sure that nested blockquotes are accounted for correctly
+          > Quote content here
+          > quote content continued
+          > > Nested Blockquote
+          > > content continued
+          ${''}
+          **Note that the empty line is either one less blockquote indicator if followed/proceeded by more blockquote content or it is an empty line**
+          ${''}
+          # Doubly nested code block
+          ${''}
+          > > Quote content here
+          > > quote content continued
+        `,
+        after: dedent`
+          # Make sure that nested blockquotes are accounted for correctly
+          ${''}
+          > Quote content here
+          > quote content continued
+          >
+          > > Nested Blockquote
+          > > content continued
+          ${''}
+          **Note that the empty line is either one less blockquote indicator if followed/proceeded by more blockquote content or it is an empty line**
+          ${''}
+          # Doubly nested code block
+          ${''}
+          > > Quote content here
+          > > quote content continued
+        `,
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<EmptyLineAroundBlockquotesOptions>[] {
+    return [];
+  }
+}


### PR DESCRIPTION
Fixes #418

Changes Made:
- Added a rule for making sure that there are empty lines around blockquotes
- Refactored some of the logic for making sure there are empty lines around content and moved it to the strings file