### PR TITLE
Fix a Typo in Unordered List Style Description

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2090,7 +2090,7 @@ Even more content here
 
 Alias: `unordered-list-style`
 
-Makes sure that unordered lists follow the style specified..
+Makes sure that unordered lists follow the style specified.
 
 Options:
 - List item style: The list item style to use in unordered lists

--- a/src/rules/unordered-list-style.ts
+++ b/src/rules/unordered-list-style.ts
@@ -18,7 +18,7 @@ export default class UnorderedListStyle extends RuleBuilder<UnorderedListStyleOp
     return 'Unordered List Style';
   }
   get description(): string {
-    return 'Makes sure that unordered lists follow the style specified..';
+    return 'Makes sure that unordered lists follow the style specified.';
   }
   get type(): RuleType {
     return RuleType.CONTENT;


### PR DESCRIPTION
Changes Made:
- Fixed a double period at the end of the list style description