### PR TITLE
Add Pasting Linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [space-between-chinese-and-english-or-numbers](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#space-between-chinese-and-english-or-numbers)
 - [trailing-spaces](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#trailing-spaces)
 
+### Paste rules
+
+- [add-blockquote-indentation-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#add-blockquote-indentation-on-paste)
+- [prevent-double-checklist-indicator-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#prevent-double-checklist-indicator-on-paste)
+- [prevent-double-list-item-indicator-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#prevent-double-list-item-indicator-on-paste)
+- [proper-ellipsis-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#proper-ellipsis-on-paste)
+- [remove-hyphens-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-hyphens-on-paste)
+- [remove-leading-or-trailing-whitespace-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-leading-or-trailing-whitespace-on-paste)
+- [remove-leftover-footnotes-from-quote-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-leftover-footnotes-from-quote-on-paste)
+- [remove-multiple-blank-lines-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-blank-lines-on-paste)
+
 
 ### Custom Lint Commands
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [remove-multiple-blank-lines-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-blank-lines-on-paste)
 
 
+Thanks [chrisgrieser](https://github.com/chrisgrieser) for doing all of the base work for and for suggesting that the paste logic should reside in the Linter!
+
+_Note: the paste rules will only run on an attempt to paste content into a Markdown file and they cannot be disabled on a file by file basis or by saying that a folder should not be linted. Please use the command for pasting text as is to not use the active pasting lint rules._
+
 ### Custom Lint Commands
 
 These are special lint rules that the user may specify. They are Obsidian commands. If you would like to create a custom command that you can run, you can use the [QuickAdd](https://github.com/chhoumann/quickadd) plugin in order to add a JavaScript script to make modifications to a file. **This will require some level of knowledge about the Obsidian API and JavaScript.** To use a custom user script, you will want to follow these steps:

--- a/__tests__/examples.test.ts
+++ b/__tests__/examples.test.ts
@@ -1,5 +1,5 @@
 import dedent from 'ts-dedent';
-import {Example, rules} from '../src/rules';
+import {Example, rules, RuleType} from '../src/rules';
 import {yamlRegex, escapeRegExp} from '../src/utils/regex';
 import '../src/rules-registry';
 
@@ -17,8 +17,8 @@ describe('Augmented examples pass', () => {
   for (const rule of rules) {
     describe(rule.name, () => {
       test.each(rule.examples)('$description', (example: Example) => {
-        // Add a YAML
-        if (rule.type !== 'YAML' && !example.before.match(yamlRegex)) {
+        // Add YAML
+        if (rule.type !== RuleType.YAML && rule.type !== RuleType.PASTE && !example.before.match(yamlRegex)) {
           const yaml = dedent`
             ---
             foo: bar

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -3461,3 +3461,341 @@ After:
 # H1
 Line with trailing spaces and tabs.  
 ``````
+
+## Paste
+### Add Blockquote Indentation on Paste
+
+Alias: `add-blockquote-indentation-on-paste`
+
+Adds blockquotes to all but the first line, when the cursor is in a blockquote/callout line during pasting
+
+
+
+Example: Line being pasted into regular text does not get blockquotified with current line being `Part 1 of the sentence`
+
+Before:
+
+``````markdown
+was much less likely to succeed, but they tried it anyway.
+Part 2 was much more interesting.
+``````
+
+After:
+
+``````markdown
+was much less likely to succeed, but they tried it anyway.
+Part 2 was much more interesting.
+``````
+Example: Line being pasted into a blockquote gets blockquotified with current line being `> > `
+
+Before:
+
+``````markdown
+
+This content is being added to a blockquote
+Note that the second line is indented and the surrounding blank lines were trimmed
+
+``````
+
+After:
+
+``````markdown
+This content is being added to a blockquote
+> > Note that the second line is indented and the surrounding blank lines were trimmed
+``````
+
+### Prevent Double Checklist Indicator on Paste
+
+Alias: `prevent-double-checklist-indicator-on-paste`
+
+Removes starting checklist indicator from the text to paste if the line the cursor is on in the file has a checklist indicator
+
+
+
+Example: Line being pasted is left alone when current line has no checklist indicator in it: `Regular text here`
+
+Before:
+
+``````markdown
+- [ ] Checklist item being pasted
+``````
+
+After:
+
+``````markdown
+- [ ] Checklist item being pasted
+``````
+Example: Line being pasted into a blockquote without a checklist indicator is left alone when it lacks a checklist indicator: `> > `
+
+Before:
+
+``````markdown
+- [ ] Checklist item contents here
+More content here
+``````
+
+After:
+
+``````markdown
+- [ ] Checklist item contents here
+More content here
+``````
+Example: Line being pasted into a blockquote with a checklist indicator is has its checklist indicator removed when current line is: `> - [x] `
+
+Before:
+
+``````markdown
+- [ ] Checklist item contents here
+More content here
+``````
+
+After:
+
+``````markdown
+Checklist item contents here
+More content here
+``````
+Example: Line being pasted with a checklist indicator is has its checklist indicator removed when current line is: `- [ ] `
+
+Before:
+
+``````markdown
+- [x] Checklist item 1
+- [ ] Checklist item 2
+``````
+
+After:
+
+``````markdown
+Checklist item 1
+- [ ] Checklist item 2
+``````
+
+### Prevent Double List Item Indicator on Paste
+
+Alias: `prevent-double-list-item-indicator-on-paste`
+
+Removes starting list indicator from the text to paste if the line the cursor is on in the file has a list indicator
+
+
+
+Example: Line being pasted is left alone when current line has no list indicator in it: `Regular text here`
+
+Before:
+
+``````markdown
+- List item being pasted
+``````
+
+After:
+
+``````markdown
+- List item being pasted
+``````
+Example: Line being pasted into a blockquote without a list indicator is left alone when it lacks a list indicator: `> > `
+
+Before:
+
+``````markdown
+* List item contents here
+More content here
+``````
+
+After:
+
+``````markdown
+* List item contents here
+More content here
+``````
+Example: Line being pasted into a blockquote with a list indicator is has its list indicator removed when current line is: `> * `
+
+Before:
+
+``````markdown
++ List item contents here
+More content here
+``````
+
+After:
+
+``````markdown
+List item contents here
+More content here
+``````
+Example: Line being pasted with a list indicator is has its list indicator removed when current line is: `+ `
+
+Before:
+
+``````markdown
+- List item 1
+- List item 2
+``````
+
+After:
+
+``````markdown
+List item 1
+- List item 2
+``````
+
+### Proper Ellipsis on Paste
+
+Alias: `proper-ellipsis-on-paste`
+
+Replaces three consecutive dots with an ellipsis even if they have a space between them in the text to paste
+
+
+
+Example: Replacing three consecutive dots with an ellipsis even if spaces are present
+
+Before:
+
+``````markdown
+Lorem (...) Impsum.
+Lorem (. ..) Impsum.
+Lorem (. . .) Impsum.
+``````
+
+After:
+
+``````markdown
+Lorem (…) Impsum.
+Lorem (…) Impsum.
+Lorem (…) Impsum.
+``````
+
+### Remove Hyphens on Paste
+
+Alias: `remove-hyphens-on-paste`
+
+Removes hyphens from the text to paste
+
+
+
+Example: Remove hyphen in content to paste
+
+Before:
+
+``````markdown
+Text that was cool but hyper-
+tension made it uncool.
+``````
+
+After:
+
+``````markdown
+Text that was cool but hypertension made it uncool.
+``````
+
+### Remove Leading or Trailing Whitespace on Paste
+
+Alias: `remove-leading-or-trailing-whitespace-on-paste`
+
+Removes any leading non-tab whitespace and all trailing whitespace for the text to paste
+
+
+
+Example: Removes leading spaces and newline characters
+
+Before:
+
+``````markdown
+
+
+         This text was really indented
+
+``````
+
+After:
+
+``````markdown
+This text was really indented
+``````
+Example: Leaves leading tabs alone
+
+Before:
+
+``````markdown
+
+
+		This text is really indented
+
+``````
+
+After:
+
+``````markdown
+		This text is really indented
+``````
+
+### Remove Leftover Footnotes from Quote on Paste
+
+Alias: `remove-leftover-footnotes-from-quote-on-paste`
+
+Removes any leftover footnote references for the text to paste
+
+
+
+Example: Footnote reference removed
+
+Before:
+
+``````markdown
+He was sure that he would get off without doing any time, but the cops had other plans.50
+
+_Note that the format for footnote references to move is a dot or comma followed by any number of digits_
+``````
+
+After:
+
+``````markdown
+He was sure that he would get off without doing any time, but the cops had other plans
+
+_Note that the format for footnote references to move is a dot or comma followed by any number of digits_
+``````
+
+### Remove Multiple Blank Lines on Paste
+
+Alias: `remove-multiple-blank-lines-on-paste`
+
+Condenses multiple blank lines down into one blank line for the text to paste
+
+
+
+Example: Multiple blanks lines condensed down to one
+
+Before:
+
+``````markdown
+Here is the first line.
+
+
+
+
+Here is some more text.
+``````
+
+After:
+
+``````markdown
+Here is the first line.
+
+Here is some more text.
+``````
+Example: Text with only one blank line in a row is left alone
+
+Before:
+
+``````markdown
+First line.
+
+Last line.
+``````
+
+After:
+
+``````markdown
+First line.
+
+Last line.
+``````

--- a/docs/templates/readme_template.md
+++ b/docs/templates/readme_template.md
@@ -39,6 +39,10 @@ Each rule is its own set of logic and is designed to be run independently. This 
 
 {{RULES PLACEHOLDER}}
 
+Thanks [chrisgrieser](https://github.com/chrisgrieser) for doing all of the base work for and for suggesting that the paste logic should reside in the Linter!
+
+_Note: the paste rules will only run on an attempt to paste content into a Markdown file and they cannot be disabled on a file by file basis or by saying that a folder should not be linted. Please use the command for pasting text as is to not use the active pasting lint rules._
+
 ### Custom Lint Commands
 
 These are special lint rules that the user may specify. They are Obsidian commands. If you would like to create a custom command that you can run, you can use the [QuickAdd](https://github.com/chhoumann/quickadd) plugin in order to add a JavaScript script to make modifications to a file. **This will require some level of knowledge about the Obsidian API and JavaScript.** To use a custom user script, you will want to follow these steps:

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,7 +141,11 @@ export default class LinterPlugin extends Plugin {
     if (typeof save === 'function') {
       saveCommandDefinition.callback = () => {
         if (this.settings.lintOnSave && this.isEnabled) {
-          const editor = this.app.workspace.getActiveViewOfType(MarkdownView).editor;
+          const editor = this.getEditor();
+          if (!editor) {
+            return;
+          }
+
           const file = this.app.workspace.getActiveFile();
 
           if (!this.shouldIgnoreFile(file)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
-import {normalizePath, App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon} from 'obsidian';
+import {normalizePath, App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon, htmlToMarkdown} from 'obsidian';
 import {LinterSettings, rules} from './rules';
 import DiffMatchPatch from 'diff-match-patch';
 import dedent from 'ts-dedent';
 import {stripCr} from './utils/strings';
 import log from 'loglevel';
-import {logInfo, logError, logDebug, setLogLevel} from './logger';
+import {logInfo, logError, logDebug, setLogLevel, logWarn} from './logger';
 import {moment} from 'obsidian';
 import './rules-registry';
 import {iconInfo} from './icons';
@@ -98,6 +98,20 @@ export default class LinterPlugin extends Plugin {
         this.createFolderLintModal(this.app.workspace.getActiveFile().parent);
       },
     });
+
+    this.addCommand({
+      id: 'paste-as-plain-text',
+      name: 'Paste as Plain Text & without Modifications',
+      editorCallback: (editor) => this.pasteAsPlainText(editor),
+    });
+
+    this.registerEvent(
+        this.app.workspace.on('editor-paste', (clipboardEv: ClipboardEvent) => {
+          if (this.isEnabled) {
+            this.modifyPasteEvent(clipboardEv);
+          }
+        }),
+    );
 
     // https://github.com/mgmeyers/obsidian-kanban/blob/main/src/main.ts#L239-L251
     this.registerEvent(
@@ -399,5 +413,65 @@ export default class LinterPlugin extends Plugin {
     }
 
     logError(errorMessage, error);
+  }
+
+  // from https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/main.ts#L37-L41
+  private getEditor(): Editor {
+    const activeLeaf = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!activeLeaf) return;
+    return activeLeaf.editor;
+  }
+
+  // based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/main.ts#L43-L79
+  // INFO: to inspect clipboard content types, use https://evercoder.github.io/clipboard-inspector/
+  async modifyPasteEvent(clipboardEv: ClipboardEvent): Promise<void> {
+    // abort when pane isn't markdown editor
+    const editor = this.getEditor();
+    if (!editor) return;
+
+    // abort when clipboard contains an image (or is empty)
+    // check for plain text, since 'getData("text/html")' ignores plain-text
+    const plainClipboard = clipboardEv.clipboardData.getData('text/plain');
+    if (!plainClipboard) return;
+
+    // Abort when clipboard has URL, to prevent conflict with the plugins
+    // Auto Title Link & Paste URL into Selection
+    // has to search the entire clipboard (not surrounding the regex with ^$),
+    // because otherwise having 2 URLs cause Obsidian-breaking conflict
+    const urlRegex = /((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()[\]{};:'".,<>?«»“”‘’]))/i;
+    if (urlRegex.test(plainClipboard.trim())) {
+      logWarn('aborted paste lint as the clipboard content is a link and doing so will avoid conflicts with other plugins that modify pasting.');
+      return;
+    }
+
+    // prevent default pasting & abort when not successful
+    clipboardEv.stopPropagation();
+    clipboardEv.preventDefault();
+    if (!clipboardEv.defaultPrevented) return;
+
+    // use Turndown via Obsidian API to emulate "Auto Convert HTML" setting
+    const convertHtmlEnabled = this.app.vault.getConfig('autoConvertHtml');
+    const htmlClipText = clipboardEv.clipboardData.getData('text/html');
+    let clipboardText = htmlClipText && convertHtmlEnabled ? htmlToMarkdown(htmlClipText) : plainClipboard;
+    // if everything went well, run clipboard modifications (passing in current line and and text to paste)
+    clipboardText = this.rulesRunner.runPasteLint(this.getLineContent(editor), createRunLinterRulesOptions(clipboardText, null, this.momentLocale, this.settings));
+
+    editor.replaceSelection(clipboardText);
+  }
+
+  // if there is a selection, gets the content of the beginning of the selection
+  private getLineContent(editor: Editor) {
+    const currentLineNumber = editor.getCursor('from').line;
+    return editor.getLine(currentLineNumber);
+  }
+
+  async pasteAsPlainText(editor: Editor): Promise<void> {
+    const clipboardContent = await navigator.clipboard.readText();
+    if (!clipboardContent) {
+      new Notice('There is no clipboard content.');
+      return;
+    }
+
+    editor.replaceSelection(clipboardContent);
   }
 }

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -154,7 +154,7 @@ export function createRunLinterRulesOptions(text: string, file: TFile = null, mo
   return {
     oldText: text,
     fileInfo: {
-      name: file.basename,
+      name: file ? file.basename: '',
       createdAtFormatted: createdAtTime,
       modifiedAtFormatted: modifiedAtTime,
     },

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -1,6 +1,6 @@
 import {TFile, moment} from 'obsidian';
 import {logDebug, logWarn} from './logger';
-import {getDisabledRules, LinterSettings, rules, wrapLintError, LintCommand} from './rules';
+import {getDisabledRules, LinterSettings, rules, wrapLintError, LintCommand, RuleType} from './rules';
 import BlockquotifyOnPaste from './rules/blockquotify-on-paste';
 import EscapeYamlSpecialCharacters from './rules/escape-yaml-special-characters';
 import FormatTagsInYaml from './rules/format-tags-in-yaml';
@@ -44,7 +44,7 @@ export class RulesRunner {
       if (this.disabledRules.includes(rule.alias())) {
         logDebug(rule.alias() + ' is disabled');
         continue;
-      } else if (rule.hasSpecialExecutionOrder) {
+      } else if (rule.hasSpecialExecutionOrder || rule.type === RuleType.PASTE) {
         continue;
       }
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -47,6 +47,7 @@ export enum RuleType {
   FOOTNOTE = 'Footnote',
   CONTENT = 'Content',
   SPACING = 'Spacing',
+  PASTE = 'Paste',
 }
 
 /** Class representing a rule */

--- a/src/rules/blockquotify-on-paste.ts
+++ b/src/rules/blockquotify-on-paste.ts
@@ -1,0 +1,73 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L20-L36
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+
+class BlockquotifyOnPasteOptions implements Options {
+  @RuleBuilder.noSettingControl()
+    lineContent: string;
+}
+
+@RuleBuilder.register
+export default class BlockquotifyOnPaste extends RuleBuilder<BlockquotifyOnPasteOptions> {
+  get OptionsClass(): new () => BlockquotifyOnPasteOptions {
+    return BlockquotifyOnPasteOptions;
+  }
+  get name(): string {
+    return 'Add Blockquote Indentation on Paste';
+  }
+  get description(): string {
+    return 'Adds blockquotes to all but the first line, when the cursor is in a blockquote/callout line during pasting';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: BlockquotifyOnPasteOptions): string {
+    const blockquoteRegex = /^(\s*)((> ?)+) .*/;
+    const blockquoteMatch = options.lineContent.match(blockquoteRegex);
+    if (!blockquoteMatch) return text;
+
+    const indentation = blockquoteMatch[1] ?? '';
+    const blockquoteLevel = blockquoteMatch[2] ?? '';
+
+    return text.trim().replace(/\n/gm, `\n${indentation}${blockquoteLevel} `);
+  }
+  get exampleBuilders(): ExampleBuilder<BlockquotifyOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Line being pasted into regular text does not get blockquotified with current line being `Part 1 of the sentence`',
+        before: dedent`
+          was much less likely to succeed, but they tried it anyway.
+          Part 2 was much more interesting.
+        `,
+        after: dedent`
+          was much less likely to succeed, but they tried it anyway.
+          Part 2 was much more interesting.
+        `,
+        options: {
+          lineContent: 'Part 1 of the sentence',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Line being pasted into a blockquote gets blockquotified with current line being `> > `',
+        before: dedent`
+          ${''}
+          This content is being added to a blockquote
+          Note that the second line is indented and the surrounding blank lines were trimmed
+          ${''}
+        `,
+        after: dedent`
+          This content is being added to a blockquote
+          > > Note that the second line is indented and the surrounding blank lines were trimmed
+        `,
+        options: {
+          lineContent: '> > ',
+        },
+      }),
+
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<BlockquotifyOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/rules/prevent-double-checklist-indicator-on-paste.ts
+++ b/src/rules/prevent-double-checklist-indicator-on-paste.ts
@@ -1,0 +1,99 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L50-L60
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {lineStartingWithWhitespaceOrBlockquoteTemplate} from '../utils/regex';
+
+class PreventDoubleChecklistIndicatorOnPasteOptions implements Options {
+  @RuleBuilder.noSettingControl()
+    lineContent: string;
+}
+
+@RuleBuilder.register
+export default class PreventDoubleChecklistIndicatorOnPaste extends RuleBuilder<PreventDoubleChecklistIndicatorOnPasteOptions> {
+  get OptionsClass(): new () => PreventDoubleChecklistIndicatorOnPasteOptions {
+    return PreventDoubleChecklistIndicatorOnPasteOptions;
+  }
+  get name(): string {
+    return 'Prevent Double Checklist Indicator on Paste';
+  }
+  get description(): string {
+    return 'Removes starting checklist indicator from the text to paste if the line the cursor is on in the file has a checklist indicator';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: PreventDoubleChecklistIndicatorOnPasteOptions): string {
+    const indentedOrBlockquoteNestedChecklistIndicatorRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}- \\[[ x]] `);
+    const checklistRegex = /^\s*- \[[ x]] /;
+
+    const isChecklistLine = indentedOrBlockquoteNestedChecklistIndicatorRegex.test(options.lineContent);
+    const isChecklistClipboard = checklistRegex.test(text);
+    if (!isChecklistLine || !isChecklistClipboard) {
+      return text;
+    }
+
+    return text.replace(checklistRegex, '');
+  }
+  get exampleBuilders(): ExampleBuilder<PreventDoubleChecklistIndicatorOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Line being pasted is left alone when current line has no checklist indicator in it: `Regular text here`',
+        before: dedent`
+          - [ ] Checklist item being pasted
+        `,
+        after: dedent`
+          - [ ] Checklist item being pasted
+        `,
+        options: {
+          lineContent: 'Regular text here',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Line being pasted into a blockquote without a checklist indicator is left alone when it lacks a checklist indicator: `> > `',
+        before: dedent`
+          - [ ] Checklist item contents here
+          More content here
+        `,
+        after: dedent`
+          - [ ] Checklist item contents here
+          More content here
+        `,
+        options: {
+          lineContent: '> > ',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Line being pasted into a blockquote with a checklist indicator is has its checklist indicator removed when current line is: `> - [x] `',
+        before: dedent`
+          - [ ] Checklist item contents here
+          More content here
+        `,
+        after: dedent`
+          Checklist item contents here
+          More content here
+        `,
+        options: {
+          lineContent: '> - [x] ',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Line being pasted with a checklist indicator is has its checklist indicator removed when current line is: `- [ ] `',
+        before: dedent`
+          - [x] Checklist item 1
+          - [ ] Checklist item 2
+        `,
+        after: dedent`
+          Checklist item 1
+          - [ ] Checklist item 2
+        `,
+        options: {
+          lineContent: '- [ ] ',
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<PreventDoubleChecklistIndicatorOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/rules/prevent-double-list-item-indicator-on-paste.ts
+++ b/src/rules/prevent-double-list-item-indicator-on-paste.ts
@@ -1,0 +1,99 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L38-L48
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {lineStartingWithWhitespaceOrBlockquoteTemplate} from '../utils/regex';
+
+class PreventDoubleListItemIndicatorOnPasteOptions implements Options {
+  @RuleBuilder.noSettingControl()
+    lineContent: string;
+}
+
+@RuleBuilder.register
+export default class PreventDoubleListItemIndicatorOnPaste extends RuleBuilder<PreventDoubleListItemIndicatorOnPasteOptions> {
+  get OptionsClass(): new () => PreventDoubleListItemIndicatorOnPasteOptions {
+    return PreventDoubleListItemIndicatorOnPasteOptions;
+  }
+  get name(): string {
+    return 'Prevent Double List Item Indicator on Paste';
+  }
+  get description(): string {
+    return 'Removes starting list indicator from the text to paste if the line the cursor is on in the file has a list indicator';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: PreventDoubleListItemIndicatorOnPasteOptions): string {
+    const indentedOrBlockquoteNestedListIndicatorRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}[*+-] `);
+    const listRegex = /^\s*[*+-] /;
+
+    const isListLine = indentedOrBlockquoteNestedListIndicatorRegex.test(options.lineContent);
+    const isListClipboard = listRegex.test(text);
+    if (!isListLine || !isListClipboard) {
+      return text;
+    }
+
+    return text.replace(listRegex, '');
+  }
+  get exampleBuilders(): ExampleBuilder<PreventDoubleListItemIndicatorOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Line being pasted is left alone when current line has no list indicator in it: `Regular text here`',
+        before: dedent`
+          - List item being pasted
+        `,
+        after: dedent`
+          - List item being pasted
+        `,
+        options: {
+          lineContent: 'Regular text here',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Line being pasted into a blockquote without a list indicator is left alone when it lacks a list indicator: `> > `',
+        before: dedent`
+          * List item contents here
+          More content here
+        `,
+        after: dedent`
+          * List item contents here
+          More content here
+        `,
+        options: {
+          lineContent: '> > ',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Line being pasted into a blockquote with a list indicator is has its list indicator removed when current line is: `> * `',
+        before: dedent`
+          + List item contents here
+          More content here
+        `,
+        after: dedent`
+          List item contents here
+          More content here
+        `,
+        options: {
+          lineContent: '> * ',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Line being pasted with a list indicator is has its list indicator removed when current line is: `+ `',
+        before: dedent`
+          - List item 1
+          - List item 2
+        `,
+        after: dedent`
+          List item 1
+          - List item 2
+        `,
+        options: {
+          lineContent: '+ ',
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<PreventDoubleListItemIndicatorOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/rules/proper-ellipsis-on-paste.ts
+++ b/src/rules/proper-ellipsis-on-paste.ts
@@ -1,0 +1,47 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L16
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {ellipsisRegex} from '../utils/regex';
+
+class ProperEllipsisOnPasteOptions implements Options {
+}
+
+@RuleBuilder.register
+export default class ProperEllipsisOnPaste extends RuleBuilder<ProperEllipsisOnPasteOptions> {
+  get OptionsClass(): new () => ProperEllipsisOnPasteOptions {
+    return ProperEllipsisOnPasteOptions;
+  }
+  get name(): string {
+    return 'Proper Ellipsis on Paste';
+  }
+  get description(): string {
+    return 'Replaces three consecutive dots with an ellipsis even if they have a space between them in the text to paste';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: ProperEllipsisOnPasteOptions): string {
+    return text.replaceAll(ellipsisRegex, '…');
+  }
+  get exampleBuilders(): ExampleBuilder<ProperEllipsisOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Replacing three consecutive dots with an ellipsis even if spaces are present',
+        before: dedent`
+          Lorem (...) Impsum.
+          Lorem (. ..) Impsum.
+          Lorem (. . .) Impsum.
+        `,
+        after: dedent`
+          Lorem (…) Impsum.
+          Lorem (…) Impsum.
+          Lorem (…) Impsum.
+        `,
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<ProperEllipsisOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/rules/proper-ellipsis.ts
+++ b/src/rules/proper-ellipsis.ts
@@ -2,6 +2,7 @@ import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {ellipsisRegex} from '../utils/regex';
 
 class ProperEllipsisOptions implements Options {
 }
@@ -22,7 +23,7 @@ export default class ProperEllipsis extends RuleBuilder<ProperEllipsisOptions> {
   }
   apply(text: string, options: ProperEllipsisOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      return text.replaceAll('...', '…');
+      return text.replaceAll(ellipsisRegex, '…');
     });
   }
   get exampleBuilders(): ExampleBuilder<ProperEllipsisOptions>[] {

--- a/src/rules/remove-empty-list-markers.ts
+++ b/src/rules/remove-empty-list-markers.ts
@@ -2,6 +2,7 @@ import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
+import {lineStartingWithWhitespaceOrBlockquoteTemplate} from '../utils/regex';
 
 class RemoveEmptyListMarkersOptions implements Options {
 }
@@ -22,7 +23,7 @@ export default class RemoveEmptyListMarkers extends RuleBuilder<RemoveEmptyListM
   }
   apply(text: string, options: RemoveEmptyListMarkersOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      const emptyListMarkerRegex = /^\s*(>\s*)*(-|\*|\+|\d+[.)]|- (\[( |x)\]))\s*?$/gm;
+      const emptyListMarkerRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}(-|\\*|\\+|\\d+[.)]|- (\\[( |x)\\]))\\s*?$`, 'gm');
       // remove all empty list markers followed by a new line
       text = text.replace(new RegExp(emptyListMarkerRegex.source + '\\n', 'gm'), '');
       // remove all empty list markers proceeded by a new line

--- a/src/rules/remove-hyphens-on-paste.ts
+++ b/src/rules/remove-hyphens-on-paste.ts
@@ -1,0 +1,43 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L13
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+
+class RemoveHyphensOnPasteOptions implements Options {
+}
+
+@RuleBuilder.register
+export default class RemoveHyphensOnPaste extends RuleBuilder<RemoveHyphensOnPasteOptions> {
+  get OptionsClass(): new () => RemoveHyphensOnPasteOptions {
+    return RemoveHyphensOnPasteOptions;
+  }
+  get name(): string {
+    return 'Remove Hyphens on Paste';
+  }
+  get description(): string {
+    return 'Removes hyphens from the text to paste';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: RemoveHyphensOnPasteOptions): string {
+    return text.replace(/(\S)[-‐]\s+\n?(?=\w)/g, '$1');
+  }
+  get exampleBuilders(): ExampleBuilder<RemoveHyphensOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Remove hyphen in content to paste',
+        before: dedent`
+          Text that was cool but hyper-
+          tension made it uncool.
+        `,
+        after: dedent`
+          Text that was cool but hypertension made it uncool.
+        `,
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<RemoveHyphensOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/rules/remove-leading-or-trailing-whitespace-on-paste.ts
+++ b/src/rules/remove-leading-or-trailing-whitespace-on-paste.ts
@@ -1,0 +1,55 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L17
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+
+class RemoveLeadingOrTrailingWhitespaceOnPasteOptions implements Options {
+}
+
+@RuleBuilder.register
+export default class RemoveLeadingOrTrailingWhitespaceOnPaste extends RuleBuilder<RemoveLeadingOrTrailingWhitespaceOnPasteOptions> {
+  get OptionsClass(): new () => RemoveLeadingOrTrailingWhitespaceOnPasteOptions {
+    return RemoveLeadingOrTrailingWhitespaceOnPasteOptions;
+  }
+  get name(): string {
+    return 'Remove Leading or Trailing Whitespace on Paste';
+  }
+  get description(): string {
+    return 'Removes any leading non-tab whitespace and all trailing whitespace for the text to paste';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: RemoveLeadingOrTrailingWhitespaceOnPasteOptions): string {
+    return text.replace(/^[\n ]+|\s+$/g, '');
+  }
+  get exampleBuilders(): ExampleBuilder<RemoveLeadingOrTrailingWhitespaceOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Removes leading spaces and newline characters',
+        before: dedent`
+          ${''}
+          ${''}
+                   This text was really indented
+          ${''}
+        `,
+        after: dedent`
+          This text was really indented
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Leaves leading tabs alone',
+        before: dedent`
+          ${''}
+          ${''}
+          \t\tThis text is really indented
+          ${''}
+        `,
+        after: '\t\tThis text is really indented',
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<RemoveLeadingOrTrailingWhitespaceOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
+++ b/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
@@ -1,0 +1,46 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L15
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+
+class RemoveLeftoverFootnotesFromQuoteOnPasteOptions implements Options {
+}
+
+@RuleBuilder.register
+export default class RemoveLeftoverFootnotesFromQuoteOnPaste extends RuleBuilder<RemoveLeftoverFootnotesFromQuoteOnPasteOptions> {
+  get OptionsClass(): new () => RemoveLeftoverFootnotesFromQuoteOnPasteOptions {
+    return RemoveLeftoverFootnotesFromQuoteOnPasteOptions;
+  }
+  get name(): string {
+    return 'Remove Leftover Footnotes from Quote on Paste';
+  }
+  get description(): string {
+    return 'Removes any leftover footnote references for the text to paste';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: RemoveLeftoverFootnotesFromQuoteOnPasteOptions): string {
+    return text.replace(/(\D)[.,]\d+/g, '$1');
+  }
+  get exampleBuilders(): ExampleBuilder<RemoveLeftoverFootnotesFromQuoteOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Footnote reference removed',
+        before: dedent`
+          He was sure that he would get off without doing any time, but the cops had other plans.50
+          ${''}
+          _Note that the format for footnote references to move is a dot or comma followed by any number of digits_
+        `,
+        after: dedent`
+          He was sure that he would get off without doing any time, but the cops had other plans
+          ${''}
+          _Note that the format for footnote references to move is a dot or comma followed by any number of digits_
+        `,
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<RemoveLeftoverFootnotesFromQuoteOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/rules/remove-multiple-blank-lines-on-paste.ts
+++ b/src/rules/remove-multiple-blank-lines-on-paste.ts
@@ -1,0 +1,62 @@
+// based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L14
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+
+class RemoveMultipleBlankLinesOnPasteOptions implements Options {
+}
+
+@RuleBuilder.register
+export default class RemoveMultipleBlankLinesOnPaste extends RuleBuilder<RemoveMultipleBlankLinesOnPasteOptions> {
+  get OptionsClass(): new () => RemoveMultipleBlankLinesOnPasteOptions {
+    return RemoveMultipleBlankLinesOnPasteOptions;
+  }
+  get name(): string {
+    return 'Remove Multiple Blank Lines on Paste';
+  }
+  get description(): string {
+    return 'Condenses multiple blank lines down into one blank line for the text to paste';
+  }
+  get type(): RuleType {
+    return RuleType.PASTE;
+  }
+  apply(text: string, options: RemoveMultipleBlankLinesOnPasteOptions): string {
+    return text.replace(/\n{3,}/g, '\n\n');
+  }
+  get exampleBuilders(): ExampleBuilder<RemoveMultipleBlankLinesOnPasteOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Multiple blanks lines condensed down to one',
+        before: dedent`
+          Here is the first line.
+          ${''}
+          ${''}
+          ${''}
+          ${''}
+          Here is some more text.
+        `,
+        after: dedent`
+          Here is the first line.
+          ${''}
+          Here is some more text.
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Text with only one blank line in a row is left alone',
+        before: dedent`
+          First line.
+          ${''}
+          Last line.
+        `,
+        after: dedent`
+          First line.
+          ${''}
+          Last line.
+        `,
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<RemoveMultipleBlankLinesOnPasteOptions>[] {
+    return [];
+  }
+}

--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -18,7 +18,12 @@ declare module 'obsidian' {
       appContainerEl: HTMLElement;
     };
   }
+
+  interface Vault {
+    getConfig(id: string): boolean;
+  }
 }
+
 
 declare global {
   interface Window {

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -18,6 +18,7 @@ const tabNameToTabIconId: Record<string | RuleType, string> = {
   'Footnote': iconInfo.footer.id,
   'Content': iconInfo.content.id,
   'Spacing': iconInfo.whitespace.id,
+  'Paste': iconInfo.paste.id,
 };
 
 export class SettingTab extends PluginSettingTab {

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -13,6 +13,8 @@ export const genericLinkRegex = /^!?\[.*\](.*)$/;
 export const tagRegex = /(?:\s|^)#[^\s#]{1,}/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
+export const ellipsisRegex = /(\. ?){2}\./g;
+export const lineStartingWithWhitespaceOrBlockquoteTemplate = `\\s*(>\\s*)*`;
 
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string


### PR DESCRIPTION
Fixes #372 

Thanks again @chrisgrieser for suggestion this. It will hopefully be a very useful addition to the plugin.

Changes Made:
- Updated documentation for new rules added
- Made sure to ignore both YAML and Paste type rules for augmented example tests as they do not apply
- Added the command for pasting without making any changes
- Added the listener to modify the paste content before pasting by running active paste rules when the plugin is enabled
- Added logic for running the Linter against the current line in a file and the text to paste
- Added logic to the rule runner to accommodate the running of the current file for pasting
- Added a rule type for pasting
- Refactored ellipsis text that needs updating to be reused by both rules
- Refactored indentation or blockquote regex to be reused where needed
- Added a needed vault override to include the `getConfig` method
- Added icon usage for the paste tab
- Updated docs to reflect that psuedometadata suggested the additions and wrote the base for the logic
- Added logic for the following rules on paste
  - Making pasted text continue the blockquote if it is more than one line and is being added to a blockquote
  - Preventing the doubling of list indicators
  - Preventing the doubling of checklist indicators
  - Converting three dots to an ellipsis even if there are spaces between the dots
  - Make sure to remove hyphens
  - Removing trailing whitespace and all non-tab leading whitespace
  - Removing footnote references