### PR TITLE
Fix Issue with Checklist not Getting Pasted Correctly when List Indicator Paste Lint is Active Too

### DIFF
--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -133,9 +133,9 @@ export class RulesRunner {
 
     [newText] = RemoveLeadingOrTrailingWhitespaceOnPaste.applyIfEnabled(newText, runOptions.settings, []);
 
-    [newText] = PreventDoubleListItemIndicatorOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine});
-
     [newText] = PreventDoubleChecklistIndicatorOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine});
+
+    [newText] = PreventDoubleListItemIndicatorOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine});
 
     [newText] = BlockquotifyOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine});
 


### PR DESCRIPTION
Changes Made:
- Make sure to lint for checklist before list on paste because list can match checklist, but not vice versa