### PR TITLE
Fix look of inactive settings tab icons

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -64,6 +64,10 @@
         max-width 0.45s cubic-bezier(0.57, 0.04, 0.58, 1) 0.2s;
 }
 
+.linter-navigation-item:not(.linter-navigation-item-selected) > span:nth-child(2) {
+	display: none;
+}
+
 /**
  * Based on https://github.com/phibr0/obsidian-commander/blob/main/src/styles.scss
  */

--- a/src/styles.css
+++ b/src/styles.css
@@ -64,10 +64,6 @@
         max-width 0.45s cubic-bezier(0.57, 0.04, 0.58, 1) 0.2s;
 }
 
-.linter-navigation-item:not(.linter-navigation-item-selected) > span:nth-child(2) {
-		opacity: 0;
-}
-
 /**
  * Based on https://github.com/phibr0/obsidian-commander/blob/main/src/styles.scss
  */
@@ -132,6 +128,8 @@
 /** Hide linter element css 
  * Based on https://zellwk.com/blog/hide-content-accessibly/
  */
+
+.linter-navigation-item:not(.linter-navigation-item-selected) > span:nth-child(2),
 .linter-visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,7 +65,7 @@
 }
 
 .linter-navigation-item:not(.linter-navigation-item-selected) > span:nth-child(2) {
-	display: none;
+		visibility: hidden;
 }
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -65,7 +65,7 @@
 }
 
 .linter-navigation-item:not(.linter-navigation-item-selected) > span:nth-child(2) {
-		visibility: hidden;
+		opacity: 0;
 }
 
 /**


### PR DESCRIPTION
the name of the inactive tab is not properly hidden, causing issues with some themes like mine. This PR adds a rule which should properly fix this issue for any theme.

without the PR:
<img width="489" alt="Pasted image 2022-10-23 19 46 03" src="https://user-images.githubusercontent.com/73286100/197407487-ee982a89-75db-4fe9-9da6-e97456e69e02.png">

with the PR:
<img width="474" alt="Pasted image 2022-10-23 19 47 43" src="https://user-images.githubusercontent.com/73286100/197407501-30a42c9e-0982-4358-a1a4-3f1c056dceda.png">
