### PR TITLE
Refactor Common Settings and Add Force YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Each rule is its own set of logic and is designed to be run independently. This 
 ### YAML rules
 
 - [escape-yaml-special-characters](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#escape-yaml-special-characters)
+- [force-yaml-escape](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#force-yaml-escape)
 - [format-tags-in-yaml](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#format-tags-in-yaml)
 - [format-yaml-array](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#format-yaml-array)
 - [insert-yaml-attributes](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#insert-yaml-attributes)
@@ -111,10 +112,6 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [remove-multiple-blank-lines-on-paste](https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#remove-multiple-blank-lines-on-paste)
 
 
-Thanks [chrisgrieser](https://github.com/chrisgrieser) for doing all of the base work for and for suggesting that the paste logic should reside in the Linter!
-
-_Note: the paste rules will only run on an attempt to paste content into a Markdown file and they cannot be disabled on a file by file basis or by saying that a folder should not be linted. Please use the command for pasting text as is to not use the active pasting lint rules._
-
 ### Custom Lint Commands
 
 These are special lint rules that the user may specify. They are Obsidian commands. If you would like to create a custom command that you can run, you can use the [QuickAdd](https://github.com/chhoumann/quickadd) plugin in order to add a JavaScript script to make modifications to a file. **This will require some level of knowledge about the Obsidian API and JavaScript.** To use a custom user script, you will want to follow these steps:
@@ -129,6 +126,11 @@ These are special lint rules that the user may specify. They are Obsidian comman
 8. Now you just need to search up this newly created command in the custom command settings for Obsidian Linter.
 
 Now the next time you run the linter, the custom lint commands should run.
+
+### Paste Limitations
+- The plugin only works with the standard pasting (`cmd/ctrl + v`) shortcut, and not with the `p` operator in vim. (Pasting with `cmd/ctrl + v` in normal or insert mode does work though.)
+- To avoid conflicts with Plugins like [Auto Link Title](https://obsidian.md/plugins?id=obsidian-auto-link-title) or [Paste URL into Selection](https://obsidian.md/plugins?id=url-into-selection), will not be triggered when an URL is detected in the clipboard.
+- On mobile, in order to paste the URL, ensure you perform the `Tap and Hold -> Paste` action to paste into your document and use the paste rules.
 
 ## Installing
 
@@ -146,3 +148,8 @@ Note: On some machines the `.obsidian` folder may be hidden. On MacOS you should
 
 Contributions are welcome, especially for new rules. If this is something you would like to do, take a look at the
 [contribution guidelines](CONTRIBUTING.md).
+
+## Credits
+
+Thanks to all of the different people who have contributed to this plugin!  
+A special thanks to [chrisgrieser](https://github.com/chrisgrieser) for doing all of the base work for and for suggesting that the paste logic should reside in the Linter!

--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1,6 +1,7 @@
 import YamlTitleAlias from '../src/rules/yaml-title-alias';
 import dedent from 'ts-dedent';
 import {ruleTest} from './common';
+import {NormalArrayFormats, SpecialArrayFormats} from '../src/utils/yaml';
 
 ruleTest({
   RuleBuilderClass: YamlTitleAlias,
@@ -48,7 +49,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single-line array',
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
       },
     },
     {
@@ -63,7 +64,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single-line array',
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
@@ -80,7 +81,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -95,7 +96,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
@@ -151,7 +152,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single-line array',
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
       },
     },
     {
@@ -169,7 +170,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single-line array',
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
@@ -189,7 +190,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -207,7 +208,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
@@ -368,7 +369,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -388,7 +389,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
@@ -408,7 +409,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to single-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
       },
     },
     {
@@ -426,7 +427,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to single-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
@@ -717,7 +718,7 @@ ruleTest({
       options: {
         keepAliasThatMatchesTheFilename: true,
         fileName: 'Filename',
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
     {
@@ -739,7 +740,7 @@ ruleTest({
       options: {
         keepAliasThatMatchesTheFilename: true,
         fileName: 'Filename',
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
@@ -842,7 +843,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Multi-line array',
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -865,7 +866,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -887,7 +888,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Multi-line array',
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -909,7 +910,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single-line array',
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -932,7 +933,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to single-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -953,7 +954,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single-line array',
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -975,7 +976,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -996,7 +997,7 @@ ruleTest({
         # Title
       `,
       options: {
-        yamlAliasesSectionStyle: 'Single string that expands to multi-line array if needed',
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
         preserveExistingAliasesSectionStyle: false,
       },
     },
@@ -1035,7 +1036,7 @@ ruleTest({
         # [[Heading]]
       `,
       options: {
-        yamlAliasesSectionStyle: 'Multi-line array',
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
   ],

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -12,14 +12,8 @@ Alias: `escape-yaml-special-characters`
 Escapes colons with a space after them (: ), single quotes ('), and double quotes (") in YAML.
 
 Options:
-- Default Escape Character: The default character to use to escape YAML values when a single quote and double quote are not present.
-	- Default: `"`
-	- `"`: Use a double quote to escape if no single or double quote is present
-	- `'`: Use a single quote to escape if no single or double quote is present
 - Try to Escape Single Line Arrays: Tries to escape array values assuming that an array starts with "[", ends with "]", and has items that are delimited by ",".
 	- Default: `false`
-- Force Yaml Escape on Keys: Uses the Yaml escape character on the specified Yaml keys separated by a new line character if it is not already escaped. Do not use on Yaml arrays.
-	- Default: ``
 
 Example: YAML without anything to escape
 
@@ -123,7 +117,37 @@ nestedArray2: [["value: with colon in the middle"], "value with ' a single quote
 
 _Note that escaped commas in a YAML array will be treated as a separator._
 ``````
-Example: Force YAML keys to be escaped with double quotes where not already escaped with `Force Yaml Escape on Keys = ['key', 'title', 'bool']`
+
+### Force YAML Escape
+
+Alias: `force-yaml-escape`
+
+Escapes the values for the specified YAML keys.
+
+Options:
+- Force YAML Escape on Keys: Uses the Yaml escape character on the specified Yaml keys separated by a new line character if it is not already escaped. Do not use on Yaml arrays.
+	- Default: ``
+
+Example: YAML without anything to escape
+
+Before:
+
+``````markdown
+---
+key: value
+otherKey: []
+---
+``````
+
+After:
+
+``````markdown
+---
+key: value
+otherKey: []
+---
+``````
+Example: Force YAML keys to be escaped with double quotes where not already escaped with `Force Yaml Escape on Keys = 'key'\n'title'\n'bool'`
 
 Before:
 
@@ -222,24 +246,8 @@ Alias: `format-yaml-array`
 Allows for the formatting of regular yaml arrays as either multi-line or single-line and `tags` and `aliases` are allowed to have some Obsidian specific yaml formats. Note that single string to single-line goes from a single string entry to a single-line array if more than 1 entry is present. The same is true for single string to multi-line except it becomes a multi-line array.
 
 Options:
-- Yaml aliases section style: The style of the yaml aliases section
-	- Default: `single-line`
-	- `multi-line`: ```aliases:\n  - Title```
-	- `single-line`: ```aliases: [Title]```
-	- `single string comma delimited`: ```aliases: Title, Other Title```
-	- `single string to single-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a single-line array.
-	- `single string to multi-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a multi-line array.
 - Format yaml aliases section: Turns on formatting for the yaml aliases section. You should not enable this option alongside the rule `YAML Title Alias` as they may not work well together or they may have different format styles selected causing unexpected results.
 	- Default: `true`
-- Yaml tags section style: The style of the yaml tags section
-	- Default: `single-line`
-	- `multi-line`: ```tags:\n  - tag1```
-	- `single-line`: ```tags: [tag1]```
-	- `single string to single-line`: Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.
-	- `single string to multi-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.
-	- `single-line space delimited`: ```tags: [tag1 tag2]```
-	- `single string space delimited`: ```tags: tag1 tag2```
-	- `single string comma delimited`: ```tags: tag1, tag2```
 - Format yaml tags section: Turns on formatting for the yaml tags section.
 	- Default: `true`
 - Default yaml array section style: The style of other yaml arrays that are not `tags`, `aliases` or  in `Force key values to be single-line arrays` and `Force key values to be multi-line arrays`
@@ -354,15 +362,6 @@ Alias: `move-tags-to-yaml`
 Move all tags to Yaml frontmatter of the document.
 
 Options:
-- Yaml tags section style: The style of the Yaml tags section
-	- Default: `single-line`
-	- `multi-line`: ```tags:\n  - tag1```
-	- `single-line`: ```tags: [tag1]```
-	- `single string to single-line`: Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.
-	- `single string to multi-line`: Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.
-	- `single-line space delimited`: ```tags: [tag1 tag2]```
-	- `single string space delimited`: ```tags: tag1 tag2```
-	- `single string comma delimited`: ```tags: tag1, tag2```
 - Remove the hashtag from tags in content body: Removes `#` from tags in content body after moving them to the Yaml frontmatter
 	- Default: `false`
 - Tags to ignore: The tags that will not be moved to the tags array or removed from the body content if `Remove the hashtag from tags in content body` is enabled. Each tag should be on a new line and without the `#`. **Make sure not to include the hashtag in the tag name.**
@@ -755,12 +754,6 @@ Alias: `yaml-title-alias`
 Inserts the title of the file into the YAML frontmatter's aliases section. Gets the title from the first H1 or filename.
 
 Options:
-- YAML aliases section style: The style of the aliases YAML section. It is recommended that the value here matches the aliases format for format YAML arrays if in use.
-	- Default: `Multi-line array`
-	- `Multi-line array`: ```aliases:\n  - Title```
-	- `Single-line array`: ```aliases: [Title]```
-	- `Single string that expands to multi-line array if needed`: ```aliases: Title```
-	- `Single string that expands to single-line array if needed`: ```aliases: Title```
 - Preserve existing aliases section style: If set, the `YAML aliases section style` setting applies only to the newly created sections
 	- Default: `true`
 - Keep alias that matches the filename: Such aliases are usually redundant

--- a/docs/templates/readme_template.md
+++ b/docs/templates/readme_template.md
@@ -39,10 +39,6 @@ Each rule is its own set of logic and is designed to be run independently. This 
 
 {{RULES PLACEHOLDER}}
 
-Thanks [chrisgrieser](https://github.com/chrisgrieser) for doing all of the base work for and for suggesting that the paste logic should reside in the Linter!
-
-_Note: the paste rules will only run on an attempt to paste content into a Markdown file and they cannot be disabled on a file by file basis or by saying that a folder should not be linted. Please use the command for pasting text as is to not use the active pasting lint rules._
-
 ### Custom Lint Commands
 
 These are special lint rules that the user may specify. They are Obsidian commands. If you would like to create a custom command that you can run, you can use the [QuickAdd](https://github.com/chhoumann/quickadd) plugin in order to add a JavaScript script to make modifications to a file. **This will require some level of knowledge about the Obsidian API and JavaScript.** To use a custom user script, you will want to follow these steps:
@@ -57,6 +53,11 @@ These are special lint rules that the user may specify. They are Obsidian comman
 8. Now you just need to search up this newly created command in the custom command settings for Obsidian Linter.
 
 Now the next time you run the linter, the custom lint commands should run.
+
+### Paste Limitations
+- The plugin only works with the standard pasting (`cmd/ctrl + v`) shortcut, and not with the `p` operator in vim. (Pasting with `cmd/ctrl + v` in normal or insert mode does work though.)
+- To avoid conflicts with Plugins like [Auto Link Title](https://obsidian.md/plugins?id=obsidian-auto-link-title) or [Paste URL into Selection](https://obsidian.md/plugins?id=url-into-selection), will not be triggered when an URL is detected in the clipboard.
+- On mobile, in order to paste the URL, ensure you perform the `Tap and Hold -> Paste` action to paste into your document and use the paste rules.
 
 ## Installing
 
@@ -74,3 +75,8 @@ Note: On some machines the `.obsidian` folder may be hidden. On MacOS you should
 
 Contributions are welcome, especially for new rules. If this is something you would like to do, take a look at the
 [contribution guidelines](CONTRIBUTING.md).
+
+## Credits
+
+Thanks to all of the different people who have contributed to this plugin!  
+A special thanks to [chrisgrieser](https://github.com/chrisgrieser) for doing all of the base work for and for suggesting that the paste logic should reside in the Linter!

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -20,6 +20,7 @@ export type CommonStyles = {
   aliasArrayStyle: NormalArrayFormats | SpecialArrayFormats;
   tagArrayStyle: TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats;
   minimumNumberOfDollarSignsToBeAMathBlock: number;
+  escapeCharacter: string;
 }
 
 export type Options = { [optionName: string]: any};

--- a/src/rules/force-yaml-escape.ts
+++ b/src/rules/force-yaml-escape.ts
@@ -1,0 +1,103 @@
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder} from './rule-builder';
+import dedent from 'ts-dedent';
+import {formatYAML, getYamlSectionValue, isValueEscapedAlready, setYamlSection} from '../utils/yaml';
+
+class ForceYamlEscapeOptions implements Options {
+  @RuleBuilder.noSettingControl()
+    defaultEscapeCharacter?: string = '"';
+  forceYamlEscape?: string[] = [];
+}
+
+@RuleBuilder.register
+export default class ForceYamlEscape extends RuleBuilder<ForceYamlEscapeOptions> {
+  get OptionsClass(): new () => ForceYamlEscapeOptions {
+    return ForceYamlEscapeOptions;
+  }
+  get name(): string {
+    return 'Force YAML Escape';
+  }
+  get description(): string {
+    return 'Escapes the values for the specified YAML keys.';
+  }
+  get type(): RuleType {
+    return RuleType.YAML;
+  }
+  apply(text: string, options: ForceYamlEscapeOptions): string {
+    return formatYAML(text, (text) => {
+      for (const yamlKeyToEscape of options.forceYamlEscape) {
+        const keyValue = getYamlSectionValue(text, yamlKeyToEscape);
+
+        if (keyValue != null) {
+          // skip yaml array values or already escaped values
+          if (keyValue.includes('\n') || keyValue.startsWith(' [') || isValueEscapedAlready(keyValue)) {
+            continue;
+          }
+
+          text = setYamlSection(text, yamlKeyToEscape, ` ${options.defaultEscapeCharacter}${keyValue}${options.defaultEscapeCharacter}`);
+        }
+      }
+
+      return text;
+    });
+  }
+  get exampleBuilders(): ExampleBuilder<ForceYamlEscapeOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'YAML without anything to escape',
+        before: dedent`
+          ---
+          key: value
+          otherKey: []
+          ---
+        `,
+        after: dedent`
+          ---
+          key: value
+          otherKey: []
+          ---
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Force YAML keys to be escaped with double quotes where not already escaped with `Force Yaml Escape on Keys = \'key\'\\n\'title\'\\n\'bool\'`',
+        before: dedent`
+          ---
+          key: 'Already escaped value'
+          title: This is a title
+          bool: false
+          unaffected: value
+          ---
+          ${''}
+          _Note that the force Yaml key option should not be used with arrays._
+        `,
+        after: dedent`
+          ---
+          key: 'Already escaped value'
+          title: "This is a title"
+          bool: "false"
+          unaffected: value
+          ---
+          ${''}
+          _Note that the force Yaml key option should not be used with arrays._
+        `,
+        options: {
+          forceYamlEscape: ['key', 'title', 'bool'],
+          defaultEscapeCharacter: '"',
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<ForceYamlEscapeOptions>[] {
+    return [
+      new TextAreaOptionBuilder({
+        OptionsClass: ForceYamlEscapeOptions,
+        name: 'Force YAML Escape on Keys',
+        description: 'Uses the Yaml escape character on the specified Yaml keys separated by a new line character if it is not already escaped. Do not use on Yaml arrays.',
+        optionsKey: 'forceYamlEscape',
+      }),
+    ];
+  }
+  get hasSpecialExecutionOrder(): boolean {
+    return true;
+  }
+}

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -16,9 +16,11 @@ import {convertAliasValueToStringOrStringArray,
   TagSpecificArrayFormats} from '../utils/yaml';
 
 class FormatYamlArrayOptions implements Options {
-  aliasArrayStyle?: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
+  @RuleBuilder.noSettingControl()
+    aliasArrayStyle?: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
   formatAliasKey?: boolean = true;
-  tagArrayStyle?: TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
+  @RuleBuilder.noSettingControl()
+    tagArrayStyle?: TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
   formatTagKey?: boolean = true;
   defaultArrayStyle?: NormalArrayFormats = NormalArrayFormats.SingleLine;
   formatArrayKeys?: boolean = true;
@@ -158,75 +160,11 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
   }
   get optionBuilders(): OptionBuilderBase<FormatYamlArrayOptions>[] {
     return [
-      new DropdownOptionBuilder({
-        OptionsClass: FormatYamlArrayOptions,
-        name: 'Yaml aliases section style',
-        description: 'The style of the yaml aliases section',
-        optionsKey: 'aliasArrayStyle',
-        records: [
-          { // as types is needed to allow for the proper types as options otherwise it assumes it has to be the specific enum value
-            value: NormalArrayFormats.MultiLine as NormalArrayFormats | SpecialArrayFormats,
-            description: '```aliases:\\n  - Title```',
-          },
-          {
-            value: NormalArrayFormats.SingleLine,
-            description: '```aliases: [Title]```',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringCommaDelimited,
-            description: '```aliases: Title, Other Title```',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringToSingleLine,
-            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a single-line array.',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringToMultiLine,
-            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a multi-line array.',
-          },
-        ],
-      }),
       new BooleanOptionBuilder({
         OptionsClass: FormatYamlArrayOptions,
         name: 'Format yaml aliases section',
         description: 'Turns on formatting for the yaml aliases section. You should not enable this option alongside the rule `YAML Title Alias` as they may not work well together or they may have different format styles selected causing unexpected results.',
         optionsKey: 'formatAliasKey',
-      }),
-      new DropdownOptionBuilder({
-        OptionsClass: FormatYamlArrayOptions,
-        name: 'Yaml tags section style',
-        description: 'The style of the yaml tags section',
-        optionsKey: 'tagArrayStyle',
-        records: [
-          {
-            value: NormalArrayFormats.MultiLine as TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats,
-            description: '```tags:\\n  - tag1```',
-          },
-          {
-            value: NormalArrayFormats.SingleLine,
-            description: '```tags: [tag1]```',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringToSingleLine,
-            description: 'Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringToMultiLine,
-            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.',
-          },
-          {
-            value: TagSpecificArrayFormats.SingleLineSpaceDelimited,
-            description: '```tags: [tag1 tag2]```',
-          },
-          {
-            value: TagSpecificArrayFormats.SingleStringSpaceDelimited,
-            description: '```tags: tag1 tag2```',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringCommaDelimited,
-            description: '```tags: tag1, tag2```',
-          },
-        ],
       }),
       new BooleanOptionBuilder({
         OptionsClass: FormatYamlArrayOptions,

--- a/src/rules/move-tags-to-yaml.ts
+++ b/src/rules/move-tags-to-yaml.ts
@@ -1,5 +1,5 @@
 import {Options, RuleType} from '../rules';
-import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder} from './rule-builder';
+import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {tagRegex} from '../utils/regex';
@@ -18,7 +18,8 @@ import {
 } from '../utils/yaml';
 
 class MoveTagsToYamlOptions implements Options {
-  tagArrayStyle? : TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
+  @RuleBuilder.noSettingControl()
+    tagArrayStyle? : TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.SingleLine;
   removeHashtagsFromTagsInBody?: boolean = false;
   tagsToIgnore?: string[] = [];
 }
@@ -169,42 +170,6 @@ export default class MoveTagsToYaml extends RuleBuilder<MoveTagsToYamlOptions> {
   }
   get optionBuilders(): OptionBuilderBase<MoveTagsToYamlOptions>[] {
     return [
-      new DropdownOptionBuilder({
-        OptionsClass: MoveTagsToYamlOptions,
-        name: 'Yaml tags section style',
-        description: 'The style of the Yaml tags section',
-        optionsKey: 'tagArrayStyle',
-        records: [
-          {
-            value: NormalArrayFormats.MultiLine as TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats,
-            description: '```tags:\\n  - tag1```',
-          },
-          {
-            value: NormalArrayFormats.SingleLine,
-            description: '```tags: [tag1]```',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringToSingleLine,
-            description: 'Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringToMultiLine,
-            description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.',
-          },
-          {
-            value: TagSpecificArrayFormats.SingleLineSpaceDelimited,
-            description: '```tags: [tag1 tag2]```',
-          },
-          {
-            value: TagSpecificArrayFormats.SingleStringSpaceDelimited,
-            description: '```tags: tag1 tag2```',
-          },
-          {
-            value: SpecialArrayFormats.SingleStringCommaDelimited,
-            description: '```tags: tag1, tag2```',
-          },
-        ],
-      }),
       new BooleanOptionBuilder({
         OptionsClass: MoveTagsToYamlOptions,
         name: 'Remove the hashtag from tags in content body',

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -1,18 +1,14 @@
 import {Options, RuleType} from '../rules';
-import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
 import {convertAliasValueToStringOrStringArray, formatYamlArrayValue, getYamlSectionValue, initYAML, LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEY, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray, toYamlString} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {yamlRegex} from '../utils/regex';
 
-type YamlAliasesSectionStyle =
-  'Multi-line array' |
-  'Single-line array' |
-  'Single string that expands to multi-line array if needed' |
-  'Single string that expands to single-line array if needed';
 
 class YamlTitleAliasOptions implements Options {
-  yamlAliasesSectionStyle?: YamlAliasesSectionStyle = 'Multi-line array';
+  @RuleBuilder.noSettingControl()
+    aliasArrayStyle?: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.MultiLine;
   preserveExistingAliasesSectionStyle?: boolean = true;
   keepAliasThatMatchesTheFilename?: boolean = false;
   useYamlKeyToKeepTrackOfOldFilenameOrHeading?: boolean = true;
@@ -58,24 +54,6 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     const parsedYaml = loadYAML(yaml);
 
     previousTitle = loadYAML(getYamlSectionValue(yaml, LINTER_ALIASES_HELPER_KEY));
-
-    let newAliasStyle: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.MultiLine;
-    switch (options.yamlAliasesSectionStyle) {
-      case 'Multi-line array':
-        newAliasStyle = NormalArrayFormats.MultiLine;
-        break;
-      case 'Single-line array':
-        newAliasStyle = NormalArrayFormats.SingleLine;
-        break;
-      case 'Single string that expands to multi-line array if needed':
-        newAliasStyle = SpecialArrayFormats.SingleStringToMultiLine;
-        break;
-      case 'Single string that expands to single-line array if needed':
-        newAliasStyle = SpecialArrayFormats.SingleStringToSingleLine;
-        break;
-      default:
-        throw new Error(`Unsupported setting 'YAML aliases section style': ${options.yamlAliasesSectionStyle}`);
-    }
 
     const getNewAliasValue = function(originalValue: string |string[], shouldRemoveTitle: boolean): string |string[] {
       if (originalValue == null) {
@@ -144,13 +122,13 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
         if (!isEmpty && ((isSingleString && title == newAliasValue) || !isSingleString || currentAliasValue == newAliasValue)) {
           newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, currentAliasStyle));
         } else {
-          newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, newAliasStyle));
+          newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, options.aliasArrayStyle));
         }
       } else {
-        newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, newAliasStyle));
+        newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(newAliasValue, options.aliasArrayStyle));
       }
     } else if (!shouldRemoveTitleAlias) {
-      newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(title, newAliasStyle));
+      newYaml = setYamlSection(newYaml, OBSIDIAN_ALIASES_KEY, formatYamlArrayValue(title, options.aliasArrayStyle));
     }
 
     if (!options.useYamlKeyToKeepTrackOfOldFilenameOrHeading || shouldRemoveTitleAlias) {
@@ -260,30 +238,6 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
   }
   get optionBuilders(): OptionBuilderBase<YamlTitleAliasOptions>[] {
     return [
-      new DropdownOptionBuilder<YamlTitleAliasOptions, YamlAliasesSectionStyle>({
-        OptionsClass: YamlTitleAliasOptions,
-        name: 'YAML aliases section style',
-        description: 'The style of the aliases YAML section. It is recommended that the value here matches the aliases format for format YAML arrays if in use.',
-        optionsKey: 'yamlAliasesSectionStyle',
-        records: [
-          {
-            value: 'Multi-line array',
-            description: '```aliases:\\n  - Title```',
-          },
-          {
-            value: 'Single-line array',
-            description: '```aliases: [Title]```',
-          },
-          {
-            value: 'Single string that expands to multi-line array if needed',
-            description: '```aliases: Title```',
-          },
-          {
-            value: 'Single string that expands to single-line array if needed',
-            description: '```aliases: Title```',
-          },
-        ],
-      }),
       new BooleanOptionBuilder({
         OptionsClass: YamlTitleAliasOptions,
         name: 'Preserve existing aliases section style',

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -6,6 +6,7 @@ import CommandSuggester from './suggesters/command-suggester';
 import {SearchOptionInfo} from 'src/option';
 import {iconInfo} from 'src/icons';
 import {parseTextToHTMLWithoutOuterParagraph} from './helpers';
+import {NormalArrayFormats, SpecialArrayFormats, TagSpecificArrayFormats} from 'src/utils/yaml';
 
 type settingSearchInfo = {containerEl: HTMLDivElement, name: string, description: string, options: SearchOptionInfo[], alias?: string}
 type TabContentInfo = {content: HTMLDivElement, heading: HTMLElement, navButton: HTMLElement}
@@ -308,6 +309,119 @@ export class SettingTab extends PluginSettingTab {
           dropdown.onChange(async (value) => {
             this.plugin.settings.linterLocale = value;
             await this.plugin.setOrUpdateMomentInstance();
+            await this.plugin.saveSettings();
+          });
+        });
+
+    this.addSettingToMasterSettingsList(tabName, tempDiv, settingName, settingDesc);
+
+    const yamlAliasRecords = [
+      { // as types is needed to allow for the proper types as options otherwise it assumes it has to be the specific enum value
+        value: NormalArrayFormats.MultiLine as NormalArrayFormats | SpecialArrayFormats,
+        description: '```aliases:\\n  - Title```',
+      },
+      {
+        value: NormalArrayFormats.SingleLine,
+        description: '```aliases: [Title]```',
+      },
+      {
+        value: SpecialArrayFormats.SingleStringCommaDelimited,
+        description: '```aliases: Title, Other Title```',
+      },
+      {
+        value: SpecialArrayFormats.SingleStringToSingleLine,
+        description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a single-line array.',
+      },
+      {
+        value: SpecialArrayFormats.SingleStringToMultiLine,
+        description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```aliases: Title```. If there is more than 1 element, it will be formatted like a multi-line array.',
+      },
+    ];
+
+    tempDiv = containerEl.createDiv();
+    settingName = 'YAML aliases section style';
+    settingDesc = 'The style of the YAML aliases section';
+    new Setting(tempDiv)
+        .setName(settingName)
+        .setDesc(settingDesc)
+        .addDropdown((dropdown) => {
+          yamlAliasRecords.forEach((tagRecord) => {
+            dropdown.addOption(tagRecord.value, tagRecord.value);
+          });
+          dropdown.setValue(this.plugin.settings.commonStyles.aliasArrayStyle);
+          dropdown.onChange(async (value) => {
+            this.plugin.settings.commonStyles.aliasArrayStyle = value as NormalArrayFormats | SpecialArrayFormats;
+            await this.plugin.saveSettings();
+          });
+        });
+
+    this.addSettingToMasterSettingsList(tabName, tempDiv, settingName, settingDesc);
+
+    const yamlTagRecords = [
+      {
+        value: NormalArrayFormats.MultiLine as TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats,
+        description: '```tags:\\n  - tag1```',
+      },
+      {
+        value: NormalArrayFormats.SingleLine,
+        description: '```tags: [tag1]```',
+      },
+      {
+        value: SpecialArrayFormats.SingleStringToSingleLine,
+        description: 'Tags will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a single-line array.',
+      },
+      {
+        value: SpecialArrayFormats.SingleStringToMultiLine,
+        description: 'Aliases will be formatted as a string if there is 1 or fewer elements like so ```tags: tag1```. If there is more than 1 element, it will be formatted like a multi-line array.',
+      },
+      {
+        value: TagSpecificArrayFormats.SingleLineSpaceDelimited,
+        description: '```tags: [tag1 tag2]```',
+      },
+      {
+        value: TagSpecificArrayFormats.SingleStringSpaceDelimited,
+        description: '```tags: tag1 tag2```',
+      },
+      {
+        value: SpecialArrayFormats.SingleStringCommaDelimited,
+        description: '```tags: tag1, tag2```',
+      },
+    ];
+
+    tempDiv = containerEl.createDiv();
+    settingName = 'YAML tags section style';
+    settingDesc = 'The style of the YAML tags section';
+    new Setting(tempDiv)
+        .setName(settingName)
+        .setDesc(settingDesc)
+        .addDropdown((dropdown) => {
+          yamlTagRecords.forEach((tagRecord) => {
+            dropdown.addOption(tagRecord.value, tagRecord.value);
+          });
+          dropdown.setValue(this.plugin.settings.commonStyles.tagArrayStyle);
+          dropdown.onChange(async (value) => {
+            this.plugin.settings.commonStyles.tagArrayStyle = value as TagSpecificArrayFormats | NormalArrayFormats | SpecialArrayFormats;
+            await this.plugin.saveSettings();
+          });
+        });
+
+    this.addSettingToMasterSettingsList(tabName, tempDiv, settingName, settingDesc);
+
+    const escapeCharRecords = ['"', '\''];
+
+    tempDiv = containerEl.createDiv();
+    settingName = 'Default Escape Character';
+    settingDesc = 'The default character to use to escape YAML values when a single quote and double quote are not present.';
+    new Setting(tempDiv)
+        .setName(settingName)
+        .setDesc(settingDesc)
+        .addDropdown((dropdown) => {
+          escapeCharRecords.forEach((escapeChar) => {
+            dropdown.addOption(escapeChar, escapeChar);
+          });
+          dropdown.setValue(this.plugin.settings.commonStyles.escapeCharacter);
+          dropdown.onChange(async (value) => {
+            this.plugin.settings.commonStyles.escapeCharacter = value;
             await this.plugin.saveSettings();
           });
         });

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -249,3 +249,13 @@ export function convertAliasValueToStringOrStringArray(value: string | string[])
 
   return value;
 }
+
+/**
+ * Returns whether or not the YAML string value is already escaped
+ * @param {string} value The YAML string to check if it is already escaped
+ * @return {boolean} Whether or not the YAML string value is already escaped
+ */
+export function isValueEscapedAlready(value: string): boolean {
+  return value.length > 1 && ((value.startsWith('\'') && value.endsWith('\'')) ||
+    (value.startsWith('"') && value.endsWith('"')));
+}


### PR DESCRIPTION
Fixes #440 

Changes Made:
- Updated the credits in the README to be their own thing near the end and added the limitation of the plugin as well with regards to pasting
- Fixed tests for refactored settings
- Added logic for moving settings to their new locations and remove the old versions of the settings
- Added a set of default settings making the logic for adding a new setting simpler
- Refactored the registering of events and the addition of commands to make it simpler as well
- Updated the rules runner to handle the common values and add the force escape rule in the list of rules to run after everything except the date and time
- Refactored out a method needed for multiple yaml rules from the escape yaml special characters rule and moved the forcing of the escape to its own rule
- Made sure to keep existing docs just under the general settings in the rules doc