### PR TITLE
Update Escape Logic and Fix Issue with Failure to Escape Titles and Aliases

### DIFF
--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -432,17 +432,48 @@ ruleTest({
       },
     },
     {
-      testName: 'Titles with special characters are escaped',
+      testName: 'Titles with special a colon and then a space are escaped',
       before: dedent`
-        # Title with: colon, 'quote', "single quote"
+        # Title with: colon
       `,
       after: dedent`
         ---
         aliases:
-          - 'Title with: colon, ''quote'', "single quote"'
-        linter-yaml-title-alias: 'Title with: colon, ''quote'', "single quote"'
+          - 'Title with: colon'
+        linter-yaml-title-alias: 'Title with: colon'
         ---
-        # Title with: colon, 'quote', "single quote"
+        # Title with: colon
+      `,
+      options: {
+        defaultEscapeCharacter: '\'',
+      },
+    },
+    {
+      testName: 'Titles with double quote are escaped',
+      before: dedent`
+        # Title with "double quote"
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - 'Title with "double quote"'
+        linter-yaml-title-alias: 'Title with "double quote"'
+        ---
+        # Title with "double quote"
+      `,
+    },
+    {
+      testName: 'Titles with single quote are escaped',
+      before: dedent`
+        # Title with 'single quote'
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - "Title with 'single quote'"
+        linter-yaml-title-alias: "Title with 'single quote'"
+        ---
+        # Title with 'single quote'
       `,
     },
     {
@@ -1028,8 +1059,8 @@ ruleTest({
       after: dedent`
         ---
         aliases:
-          - '[[Heading]]'
-        linter-yaml-title-alias: '[[Heading]]'
+          - [[Heading]]
+        linter-yaml-title-alias: [[Heading]]
         ---
         [[Link1]]
 
@@ -1037,6 +1068,27 @@ ruleTest({
       `,
       options: {
         aliasArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/439
+      testName: 'Make sure escaped aliases that match the H1 do not get added back',
+      before: dedent`
+        ---
+        aliases:
+          - "It's strange"
+        ---
+        # It's strange
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - "It's strange"
+        ---
+        # It's strange
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
   ],

--- a/__tests__/yaml-title.test.ts
+++ b/__tests__/yaml-title.test.ts
@@ -24,7 +24,7 @@ ruleTest({
       `,
       after: dedent`
         ---
-        title: 'Hello: world'
+        title: "Hello: world"
         ---
         # Hello: world
       `,
@@ -36,7 +36,7 @@ ruleTest({
       `,
       after: dedent`
         ---
-        title: '''Hello world'
+        title: "'Hello world"
         ---
         # 'Hello world
       `,
@@ -74,7 +74,7 @@ ruleTest({
       `,
       after: dedent`
         ---
-        title: '[[Heading]]'
+        title: [[Heading]]
         ---
         [[Link1]]
 

--- a/src/rules/force-yaml-escape.ts
+++ b/src/rules/force-yaml-escape.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
-import {formatYAML, getYamlSectionValue, isValueEscapedAlready, setYamlSection} from '../utils/yaml';
+import {escapeStringIfNecessaryAndPossible, formatYAML, getYamlSectionValue, isValueEscapedAlready, setYamlSection} from '../utils/yaml';
 
 class ForceYamlEscapeOptions implements Options {
   @RuleBuilder.noSettingControl()
@@ -26,7 +26,7 @@ export default class ForceYamlEscape extends RuleBuilder<ForceYamlEscapeOptions>
   apply(text: string, options: ForceYamlEscapeOptions): string {
     return formatYAML(text, (text) => {
       for (const yamlKeyToEscape of options.forceYamlEscape) {
-        const keyValue = getYamlSectionValue(text, yamlKeyToEscape);
+        let keyValue = getYamlSectionValue(text, yamlKeyToEscape);
 
         if (keyValue != null) {
           // skip yaml array values or already escaped values
@@ -34,7 +34,8 @@ export default class ForceYamlEscape extends RuleBuilder<ForceYamlEscapeOptions>
             continue;
           }
 
-          text = setYamlSection(text, yamlKeyToEscape, ` ${options.defaultEscapeCharacter}${keyValue}${options.defaultEscapeCharacter}`);
+          keyValue = escapeStringIfNecessaryAndPossible(keyValue, options.defaultEscapeCharacter, true);
+          text = setYamlSection(text, yamlKeyToEscape, ' ' + keyValue);
         }
       }
 

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -102,7 +102,6 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
       return originalValue;
     };
 
-    // title = toYamlString(title);
     if (Object.keys(parsedYaml).includes(OBSIDIAN_ALIASES_KEY)) {
       const aliasesValue = getYamlSectionValue(newYaml, OBSIDIAN_ALIASES_KEY);
       let currentAliasStyle: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.MultiLine;

--- a/src/rules/yaml-title.ts
+++ b/src/rules/yaml-title.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
-import {formatYAML, initYAML, toYamlString} from '../utils/yaml';
+import {escapeStringIfNecessaryAndPossible, formatYAML, initYAML} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {escapeDollarSigns} from '../utils/regex';
 import {insert} from '../utils/strings';
@@ -9,6 +9,9 @@ import {insert} from '../utils/strings';
 class YamlTitleOptions implements Options {
   @RuleBuilder.noSettingControl()
     fileName: string;
+
+  @RuleBuilder.noSettingControl()
+    defaultEscapeCharacter?: string = '"';
 
   titleKey?: string = 'title';
 }
@@ -38,7 +41,7 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
     });
     title = title || options.fileName;
 
-    title = toYamlString(title);
+    title = escapeStringIfNecessaryAndPossible(title, options.defaultEscapeCharacter);
 
     return formatYAML(text, (text) => {
       const title_match_str = `\n${options.titleKey}.*\n`;

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,4 +1,4 @@
-import {load, dump} from 'js-yaml';
+import {load} from 'js-yaml';
 import {escapeDollarSigns, yamlRegex} from './regex';
 
 export const OBSIDIAN_TAG_KEY = 'tags';


### PR DESCRIPTION
Fixes #439 

Changes Made:
- Updated the UTs for yaml title and yaml title alias
- Refactored escape logic to `yaml.ts` to make sure it could be reused by other services
- Made sure that rules like yaml title and yaml title alias as well as forcing the use of escape characters all use the same logic for escaping values