### PR TITLE
[fix] hotkey not work on macOS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,7 @@ export default class LinterPlugin extends Plugin {
       hotkeys: [
         {
           modifiers: ['Mod', 'Alt'],
-          key: 'l',
+          key: 'L',
         },
       ],
     });


### PR DESCRIPTION
`l` not work on Apple M1 Pro with Ventura 13.0, modify `l` to `L`.