### PR TITLE
Make Sure Not to Paste if Paste Already Handled

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -186,6 +186,12 @@ export default class LinterPlugin extends Plugin {
 
   registerEventsAndSaveCallback() {
     let eventRef = this.app.workspace.on('editor-paste', (clipboardEv: ClipboardEvent) => {
+      // do not paste if another handler has already handled pasting text as that would likely cause a
+      // double pasting of the clipboard contents
+      if (clipboardEv.defaultPrevented) {
+        return;
+      }
+
       this.modifyPasteEvent(clipboardEv);
     });
     this.registerEvent(eventRef);


### PR DESCRIPTION
Relates to #464 

I am not sure if this will fix the issue reported there as conflicting paste code could cause the issue, but this will at least make sure that we are not actually pasting if the paste event has already been handled and the event is received.

Changes Made:
- on a paste event, just make sure that it has not already been handled before going ahead and running the paste rules