### PR TITLE
No Bare URLs Add Smart Typography as Acceptable Wrapping Characters and Ignore Inline Code

### DIFF
--- a/__tests__/no-bare-urls.test.ts
+++ b/__tests__/no-bare-urls.test.ts
@@ -27,5 +27,25 @@ ruleTest({
         <https://google.com#hashtag>
       `,
     },
+    {// accounts for https://github.com/platers/obsidian-linter/issues/469
+      testName: 'Urls that are surrounded by smart quotes should be left alone',
+      before: dedent`
+        “https://google.com”
+        ‘https://google.com’
+      `,
+      after: dedent`
+        “https://google.com”
+        ‘https://google.com’
+      `,
+    },
+    {// accounts for https://github.com/platers/obsidian-linter/issues/469
+      testName: 'Urls that are in inline code should be left alone',
+      before: dedent`
+        \`http --headers --follow --all https://google.com\`
+      `,
+      after: dedent`
+        \`http --headers --follow --all https://google.com\`
+      `,
+    },
   ],
 });


### PR DESCRIPTION
Fixes #469 

Changes Made:
- Refactored the logic for determining if a URL is acceptably escaped to make it simpler visually
- Added UTs to help avoid issues with this down the road
- Updated example to make sure it would pass the test and make it corroborate the functionality of the rule as it was changed