### PR TITLE
bug: Fix Issue with Spaces Being Left Around Tags Creating Duplicate Tags with Moving Tags to YAML

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -110,5 +110,27 @@ ruleTest({
         tagArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/472
+      testName: 'If yaml tag has space after or before the tag, it should not affect the tag comparison',
+      before: dedent`
+        ---
+        tags: [ space-before-tag, space-after-tag ]
+        ---
+        #space-before-tag
+        #space-after-tag
+        #test
+      `,
+      after: dedent`
+        ---
+        tags: [space-before-tag, space-after-tag, test]
+        ---
+        #space-before-tag
+        #space-after-tag
+        #test
+      `,
+      options: {
+        tagArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
+      },
+    },
   ],
 });

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -218,15 +218,21 @@ export function splitValueIfSingleOrMultilineArray(value: string): string | stri
  * @return {string} The converted tag key value that should account for its obsidian formats.
  */
 export function convertTagValueToStringOrStringArray(value: string | string[]): string[] {
+  const tags: string[] = [];
+  let originalTagValues: string[] = [];
   if (typeof value === 'string') {
     if (value.includes(',')) {
-      return value.split(', ');
+      originalTagValues = value.split(', ');
+    } else {
+      originalTagValues = value.split(' ');
     }
-
-    return value.split(' ');
   }
 
-  return value;
+  for (const tagValue of originalTagValues) {
+    tags.push(tagValue.trim());
+  }
+
+  return tags;
 }
 
 /**

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -218,14 +218,18 @@ export function splitValueIfSingleOrMultilineArray(value: string): string | stri
  * @return {string} The converted tag key value that should account for its obsidian formats.
  */
 export function convertTagValueToStringOrStringArray(value: string | string[]): string[] {
+  if (value == null) {
+    return [];
+  }
+
   const tags: string[] = [];
   let originalTagValues: string[] = [];
-  if (typeof value === 'string') {
-    if (value.includes(',')) {
-      originalTagValues = value.split(', ');
-    } else {
-      originalTagValues = value.split(' ');
-    }
+  if (Array.isArray(value)) {
+    originalTagValues = value;
+  } else if (value.includes(',')) {
+    originalTagValues = value.split(', ');
+  } else {
+    originalTagValues = value.split(' ');
   }
 
   for (const tagValue of originalTagValues) {


### PR DESCRIPTION
Fixes #472 

Changes Made:
- Made sure to go ahead and trim tag values when parsing them out because it was causing issue with creating duplicate tags in the yaml
- Added a test to ensure the issue was fixed and that there will hopefully be no problems with this moving forward\\
