### PR TITLE
Bug: Ignore Style Property Contents for Moving Tags

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -147,5 +147,22 @@ ruleTest({
         #test
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/489
+      testName: 'CSS styles are not included in tags',
+      before: dedent`
+        ---
+        tag: ${''}
+        ---
+        <mark style="background: #FFB8EBA6;">some text</mark>
+      `,
+      after: dedent`
+        ---
+        tag: ${''}
+        ---
+        <mark style="background: #FFB8EBA6;">some text</mark>
+      `,
+    },
+
+
   ],
 });

--- a/src/rules/move-tags-to-yaml.ts
+++ b/src/rules/move-tags-to-yaml.ts
@@ -42,7 +42,7 @@ export default class MoveTagsToYaml extends RuleBuilder<MoveTagsToYamlOptions> {
     return RuleType.YAML;
   }
   apply(text: string, options: MoveTagsToYamlOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math], text, (text) => {
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.html], text, (text) => {
       const tags = text.match(tagRegex);
       if (!tags) {
         return text;

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -18,14 +18,15 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   bold: {replaceAction: MDAstTypes.Bold, placeholder: '{STRONG_PLACEHOLDER}'},
   list: {replaceAction: MDAstTypes.List, placeholder: '{LIST_PLACEHOLDER}'},
   blockquote: {replaceAction: MDAstTypes.Blockquote, placeholder: '{BLOCKQUOTE_PLACEHOLDER}'},
-  table: {replaceAction: tableRegex, placeholder: '{TABLE_PLACEHOLDER}'},
   math: {replaceAction: MDAstTypes.Math, placeholder: '{MATH_PLACEHOLDER}'},
   inlineMath: {replaceAction: MDAstTypes.InlineMath, placeholder: '{INLINE_MATH_PLACEHOLDER}'},
+  html: {replaceAction: MDAstTypes.Html, placeholder: '{HTML_PLACEHOLDER}'},
   // RegExp
   yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns('---\n---')},
   wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}'},
   tag: {replaceAction: tagRegex, placeholder: '#tag-placeholder'},
   obsidianMultiLineComments: {replaceAction: obsidianMultilineCommentRegex, placeholder: '{OBSIDIAN_COMMENT_PLACEHOLDER}'},
+  table: {replaceAction: tableRegex, placeholder: '{TABLE_PLACEHOLDER}'},
   // custom functions
   link: {replaceAction: replaceMarkdownLinks, placeholder: '{REGULAR_LINK_PLACEHOLDER}'},
 } as const;

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -25,6 +25,7 @@ export enum MDAstTypes {
   List = 'list',
   Blockquote = 'blockquote',
   HorizontalRule = 'thematicBreak',
+  Html = 'html',
   // math types
   Math = 'math',
   InlineMath = 'inlineMath',

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -11,7 +11,7 @@ export const indentedBlockRegex = '^((\t|( {4})).*\n)+';
 export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeBlockRegexTemplate}|${indentedBlockRegex}`, 'gm');
 export const wikiLinkRegex = /(!?)(\[{2}[^[\n\]]*\]{2})/g;
 export const genericLinkRegex = /^!?\[.*\](.*)$/;
-export const tagRegex = /(?:\s|^)#[^\s#]{1,}/g;
+export const tagRegex = /(?:\s|^)#[^\s#;.,><?!=+]+/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 export const ellipsisRegex = /(\. ?){2}\./g;


### PR DESCRIPTION
Fixes #489 

Changes Made:
- Ignored HTML tags for moving tags to the YAML frontmatter
- Added a UT to hopefully ensure that we do not hit this issue again in the future