### PR TITLE
Ignore Tables for Paragraph Spacing Rules

### DIFF
--- a/src/rules/paragraph-blank-lines.ts
+++ b/src/rules/paragraph-blank-lines.ts
@@ -22,7 +22,7 @@ export default class ParagraphBlankLines extends RuleBuilder<ParagraphBlankLines
     return RuleType.SPACING;
   }
   apply(text: string, options: ParagraphBlankLinesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml], text, makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs);
+    return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml, IgnoreTypes.table], text, makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs);
   }
   get exampleBuilders(): ExampleBuilder<ParagraphBlankLinesOptions>[] {
     return [

--- a/src/rules/two-spaces-between-lines-with-content.ts
+++ b/src/rules/two-spaces-between-lines-with-content.ts
@@ -22,7 +22,7 @@ export default class TwoSpacesBetweenLinesWithContent extends RuleBuilder<TwoSpa
     return RuleType.CONTENT;
   }
   apply(text: string, options: TwoSpacesBetweenLinesWithContentOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml], text, addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent);
+    return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml, IgnoreTypes.table], text, addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent);
   }
   get exampleBuilders(): ExampleBuilder<TwoSpacesBetweenLinesWithContentOptions>[] {
     return [


### PR DESCRIPTION
Changes Made:
- Added table as an ignore type for `paragraph-blank-lines` and `two-spaces-between-lines-with-content`