### PR TITLE
Improve Performance by Adding LRU for ASTs and Fix Issue with Multiple Lines Between Heading and Tag

### DIFF
--- a/__tests__/heading-blank-lines.test.ts
+++ b/__tests__/heading-blank-lines.test.ts
@@ -82,5 +82,26 @@ ruleTest({
         ### H3
       `,
     },
+    {
+      testName: 'Make sure a tag after a header still only has 1 blank line when bottom is set to true',
+      before: dedent`
+        ## diary
+
+        #study
+        blah blah blah
+
+        #life
+        blah blah blah
+      `,
+      after: dedent`
+        ## diary
+
+        #study
+        blah blah blah
+
+        #life
+        blah blah blah
+      `,
+    },
   ],
 });

--- a/__tests__/heading-blank-lines.test.ts
+++ b/__tests__/heading-blank-lines.test.ts
@@ -82,7 +82,7 @@ ruleTest({
         ### H3
       `,
     },
-    {
+    { // accounts for https://github.com/platers/obsidian-linter/issues/501
       testName: 'Make sure a tag after a header still only has 1 blank line when bottom is set to true',
       before: dedent`
         ## diary

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "micromark-extension-gfm-task-list-item": "^1.0.3",
     "micromark-extension-math": "^2.0.2",
     "micromark-util-combine-extensions": "^1.0.0",
+    "quick-lru": "^6.1.1",
     "ts-dedent": "^2.2.0"
   }
 }

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -24,7 +24,7 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
     return RuleType.SPACING;
   }
   apply(text: string, options: HeadingBlankLinesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink], text, (text) => {
       if (!options.bottom) {
         text = text.replace(/(^#+\s.*)\n+/gm, '$1\n'); // trim blank lines after headings
         text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -119,6 +119,7 @@ export function makeSureContentHasEmptyLinesAddedBeforeAndAfter(text: string, st
   return contentPriorToContent + content + contentAfterContent;
 }
 
+// from https://stackoverflow.com/a/52171480/8353749
 export function hashString53Bit(str: string, seed: number = 0): number {
   let h1 = 0xdeadbeef ^ seed;
   let h2 = 0x41c6ce57 ^ seed;

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -118,3 +118,18 @@ export function makeSureContentHasEmptyLinesAddedBeforeAndAfter(text: string, st
 
   return contentPriorToContent + content + contentAfterContent;
 }
+
+export function hashString53Bit(str: string, seed: number = 0): number {
+  let h1 = 0xdeadbeef ^ seed;
+  let h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}


### PR DESCRIPTION
Fixes #501 
Relates to #488 

Changes Made:
- Added an LRU cache for AST parsing where the text content of the file is hashed to determine if we already have parsed the file before recently
- The LRU allows for faster rule running since it can allow us to not need to parse files again if nothing has changed and the text is the same (i.e. not a new ignore pattern)
- Updated the heading blank lines rule to not ignore tags as that is not needed and was causing the trailing new line character to get ignored with it causing a bug