### PR TITLE
Fix Multicuror Multiline Paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Now the next time you run the linter, the custom lint commands should run.
 - The plugin only works with the standard pasting (`cmd/ctrl + v`) shortcut, and not with the `p` operator in vim. (Pasting with `cmd/ctrl + v` in normal or insert mode does work though.)
 - To avoid conflicts with Plugins like [Auto Link Title](https://obsidian.md/plugins?id=obsidian-auto-link-title) or [Paste URL into Selection](https://obsidian.md/plugins?id=url-into-selection), will not be triggered when an URL is detected in the clipboard.
 - On mobile, in order to paste the URL, ensure you perform the `Tap and Hold -> Paste` action to paste into your document and use the paste rules.
+- When doing a multicursor multiline paste, the cursors will stay where they were after pasting the values instead of moving to the end of the pasted value
 
 ## Installing
 

--- a/docs/templates/readme_template.md
+++ b/docs/templates/readme_template.md
@@ -58,6 +58,7 @@ Now the next time you run the linter, the custom lint commands should run.
 - The plugin only works with the standard pasting (`cmd/ctrl + v`) shortcut, and not with the `p` operator in vim. (Pasting with `cmd/ctrl + v` in normal or insert mode does work though.)
 - To avoid conflicts with Plugins like [Auto Link Title](https://obsidian.md/plugins?id=obsidian-auto-link-title) or [Paste URL into Selection](https://obsidian.md/plugins?id=url-into-selection), will not be triggered when an URL is detected in the clipboard.
 - On mobile, in order to paste the URL, ensure you perform the `Tap and Hold -> Paste` action to paste into your document and use the paste rules.
+- When doing a multicursor multiline paste, the cursors will stay where they were after pasting the values instead of moving to the end of the pasted value
 
 ## Installing
 


### PR DESCRIPTION
Fixes #480 

Change Made:
- Made sure to account for the scenario where there are multiple cursors by going ahead and breaking the clipboard text into multiple different paste values if it has a line count that is an exact multiple of the amount of cursors, otherwise it just pastes the same text to all of the multiple cursors
- Added documentation around this limitation

There is a possible issue where you copy the same amount of lines that you would like to have it pasted as (i.e. copy two lines then enter multicursor mode and want to paste it in 2 places, but I am not sure how I would know that on my end).