### PR TITLE
Fix First Letter Being Capitalized if not Preceded by Tab or Space

### DIFF
--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -97,8 +97,7 @@ ruleTest({
         style: 'First letter',
       },
     },
-    {
-      // accounts for https://github.com/platers/obsidian-linter/issues/321
+    { // accounts for https://github.com/platers/obsidian-linter/issues/321
       testName: 'Make sure non-english letters get capitalized when they are the first letter and the rule is set to capitalize the first letter',
       before: dedent`
         # état
@@ -110,5 +109,22 @@ ruleTest({
         style: 'First letter',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/484
+      testName: 'Make sure that first letter ot be capitalized by `First Letter` is preceded by a space',
+      before: dedent`
+        ### 1.0.0-b.4
+        ### b
+        # 1.0-b this is a heading
+      `,
+      after: dedent`
+        ### 1.0.0-b.4
+        ### B
+        # 1.0-b This is a heading
+      `,
+      options: {
+        style: 'First letter',
+      },
+    },
+    // ### 1.0.0-b.4
   ],
 });

--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -110,7 +110,7 @@ ruleTest({
       },
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/484
-      testName: 'Make sure that first letter ot be capitalized by `First Letter` is preceded by a space',
+      testName: 'Make sure that first letter ot be capitalized by `First Letter` is preceded by a space or tab',
       before: dedent`
         ### 1.0.0-b.4
         ### b
@@ -125,6 +125,5 @@ ruleTest({
         style: 'First letter',
       },
     },
-    // ### 1.0.0-b.4
   ],
 });

--- a/src/rules/capitalize-headings.ts
+++ b/src/rules/capitalize-headings.ts
@@ -117,7 +117,9 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
             // based on https://stackoverflow.com/a/62032796 "/\p{L}/u" accounts for all unicode letters across languages
             lines[i] = lines[i]
                 .toLowerCase()
-                .replace(/^#*\s+([^\p{L}])*([\p{L}])/u, (string) => string.toUpperCase()); // capitalize first letter of heading
+                .replace(/\s+([\p{L}])/u, (lowerCaseMatch: string) => {
+                  return lowerCaseMatch.toUpperCase();
+                }); // capitalize first letter of heading
             break;
         }
       }


### PR DESCRIPTION
Fixes #484 

Changes Made:
- Added a test for the case in question and made sure that the first letter capitalization only affects a letter preceded by a space or tab.