### PR TITLE
Fix YAML Multiline Array of Dictionaries Getting Escaped

### DIFF
--- a/__tests__/escape-yaml-special-characters.test.ts
+++ b/__tests__/escape-yaml-special-characters.test.ts
@@ -1,0 +1,66 @@
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+import EscapeYamlSpecialCharactersOptions from '../src/rules/escape-yaml-special-characters';
+
+ruleTest({
+  RuleBuilderClass: EscapeYamlSpecialCharactersOptions,
+  testCases: [
+    { // accounts for https://github.com/platers/obsidian-linter/issues/467
+      testName: 'Make sure that dictionaries in a multiline array do not accidentally get escaped',
+      before: dedent`
+        ---
+        gists:
+          - id: 4d06d592f0b0ae1771c0012de3562d8d
+            url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+            createdAt: '2022-11-01T16:07:48Z'
+            updatedAt: '2022-11-01T16:35:11Z'
+            filename: Stochastic P1.md
+            isPublic: true
+        ---
+      `,
+      after: dedent`
+        ---
+        gists:
+          - id: 4d06d592f0b0ae1771c0012de3562d8d
+            url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+            createdAt: '2022-11-01T16:07:48Z'
+            updatedAt: '2022-11-01T16:35:11Z'
+            filename: Stochastic P1.md
+            isPublic: true
+        ---
+      `,
+    },
+    {
+      testName: 'Make sure that a multiline array with a key value pair in it gets escaped if there are no subsequent key value pairs at the same indentation level',
+      before: dedent`
+        ---
+        gists:
+          - id: 4d06d592f0b0ae1771c0012de3562d8d
+        url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+        ---
+      `,
+      after: dedent`
+        ---
+        gists:
+          - "id: 4d06d592f0b0ae1771c0012de3562d8d"
+        url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+        ---
+      `,
+    },
+    {
+      testName: 'Make sure that a multiline array with a key value pair in it gets escaped if and does not throw an error if there are no further lines after it',
+      before: dedent`
+        ---
+        gists:
+          - id: 4d06d592f0b0ae1771c0012de3562d8d
+        ---
+      `,
+      after: dedent`
+        ---
+        gists:
+          - "id: 4d06d592f0b0ae1771c0012de3562d8d"
+        ---
+      `,
+    },
+  ],
+});

--- a/__tests__/escape-yaml-special-characters.test.ts
+++ b/__tests__/escape-yaml-special-characters.test.ts
@@ -10,22 +10,22 @@ ruleTest({
       before: dedent`
         ---
         gists:
-          - id: 4d06d592f0b0ae1771c0012de3562d8d
-            url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+          - id: testing123
+            url: 'https://gist.github.com/testing123'
             createdAt: '2022-11-01T16:07:48Z'
             updatedAt: '2022-11-01T16:35:11Z'
-            filename: Stochastic P1.md
+            filename: file1.md
             isPublic: true
         ---
       `,
       after: dedent`
         ---
         gists:
-          - id: 4d06d592f0b0ae1771c0012de3562d8d
-            url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+          - id: testing123
+            url: 'https://gist.github.com/testing123'
             createdAt: '2022-11-01T16:07:48Z'
             updatedAt: '2022-11-01T16:35:11Z'
-            filename: Stochastic P1.md
+            filename: file1.md
             isPublic: true
         ---
       `,
@@ -35,15 +35,15 @@ ruleTest({
       before: dedent`
         ---
         gists:
-          - id: 4d06d592f0b0ae1771c0012de3562d8d
-        url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+          - id: testing123
+        url: 'https://gist.github.com/testing123'
         ---
       `,
       after: dedent`
         ---
         gists:
-          - "id: 4d06d592f0b0ae1771c0012de3562d8d"
-        url: 'https://gist.github.com/4d06d592f0b0ae1771c0012de3562d8d'
+          - "id: testing123"
+        url: 'https://gist.github.com/testing123'
         ---
       `,
     },
@@ -52,13 +52,13 @@ ruleTest({
       before: dedent`
         ---
         gists:
-          - id: 4d06d592f0b0ae1771c0012de3562d8d
+          - id: testing123
         ---
       `,
       after: dedent`
         ---
         gists:
-          - "id: 4d06d592f0b0ae1771c0012de3562d8d"
+          - "id: testing123"
         ---
       `,
     },

--- a/src/rules/escape-yaml-special-characters.ts
+++ b/src/rules/escape-yaml-special-characters.ts
@@ -46,6 +46,22 @@ export default class EscapeYamlSpecialCharacters extends RuleBuilder<EscapeYamlS
         let valueStartIndex = 1;
         if (!startsWithDash) {
           valueStartIndex += firstColonIndex;
+        } else if (firstColonIndex !== -1 && i + 1 < yamlLineCount) { // account for arrays of dictionaries
+          const fullLine = yamlLines[i];
+          let expectedIndentationToBeAnArrayOfDictionaries = fullLine.indexOf('-') + 1;
+          while (expectedIndentationToBeAnArrayOfDictionaries < fullLine.length && fullLine.charAt(expectedIndentationToBeAnArrayOfDictionaries) === ' ') {
+            expectedIndentationToBeAnArrayOfDictionaries++;
+          }
+
+          let actualIndentationOfNextLine = 0;
+          const nextLine = yamlLines[i+1];
+          while (actualIndentationOfNextLine < nextLine.length && nextLine.charAt(actualIndentationOfNextLine) === ' ') {
+            actualIndentationOfNextLine++;
+          }
+
+          if (expectedIndentationToBeAnArrayOfDictionaries <= actualIndentationOfNextLine) {
+            valueStartIndex += firstColonIndex;
+          }
         }
 
         const value = line.substring(valueStartIndex).trim();

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -70,7 +70,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
 
         for (const key of Object.keys(yaml)) {
           // skip non-arrays, arrays of objects, ignored keys, and already accounted for keys
-          if (keysToIgnore.includes(key) || !Array.isArray(yaml[key]) || typeof yaml[key][0] === 'object') {
+          if (keysToIgnore.includes(key) || !Array.isArray(yaml[key]) || (yaml[key].length !== 0 && typeof yaml[key][0] === 'object' && yaml[key][0] !== null)) {
             continue;
           }
 

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -69,8 +69,8 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         const keysToIgnore = [...OBSIDIAN_ALIASES_KEYS, ...OBSIDIAN_TAG_KEYS, ...options.forceMultiLineArrayStyle, ...options.forceSingleLineArrayStyle];
 
         for (const key of Object.keys(yaml)) {
-          // skip non-arrays and already accounted for keys
-          if (keysToIgnore.includes(key) || !Array.isArray(yaml[key])) {
+          // skip non-arrays, arrays of objects, ignored keys, and already accounted for keys
+          if (keysToIgnore.includes(key) || !Array.isArray(yaml[key]) || typeof yaml[key][0] === 'object') {
             continue;
           }
 
@@ -157,6 +157,31 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
         options: {
           formatAliasKey: false,
           tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Arrays with dictionaries in them are ignored',
+        before: dedent`
+          ---
+          gists:
+            - id: test123
+              url: 'some_url'
+              filename: file.md
+              isPublic: true
+          ---
+        `,
+        after: dedent`
+          ---
+          gists:
+            - id: test123
+              url: 'some_url'
+              filename: file.md
+              isPublic: true
+          ---
+        `,
+        options: {
+          formatArrayKeys: true,
+          defaultArrayStyle: NormalArrayFormats.SingleLine,
         },
       }),
     ];


### PR DESCRIPTION
Fixes #467 

Changes Made:
- Check for dictionaries or other more complex multiline arrays by checking the whitespace of the next line to determine if the current line is part of a dictionary if it starts with a dash (note that single-line dictionaries are not supported by this). If the whitespace of the next line is the same or greater than that of the beginning of the potential key, then it will be treated as a dictionary.
- Made sure add a couple of tests to make sure that the escaping did not create any weird issues
- Made sure to update format YAML arrays to disregard arrays of objects as that will potentially cause them to be put into invalid YAML format. Added a test for this scenario.