### PR TITLE
Fix Issue with Comma Delimiter not Working if You Have a Space after Some Commas and Not Others

### DIFF
--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -217,6 +217,26 @@ ruleTest({
         tagArrayStyle: SpecialArrayFormats.SingleStringToMultiLine,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/509
+      testName: 'Convert tags from single-line array to multi-line array when there is no space after one of the commas and the key for tags is `tag`',
+      before: dedent`
+        ---
+        tag: [tag1,tag2, tag3, tag4]
+        ---
+      `,
+      after: dedent`
+        ---
+        tag:
+          - tag1
+          - tag2
+          - tag3
+          - tag4
+        ---
+      `,
+      options: {
+        tagArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
 
     // aliases
     {

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -230,7 +230,7 @@ export function convertTagValueToStringOrStringArray(value: string | string[]): 
   if (Array.isArray(value)) {
     originalTagValues = value;
   } else if (value.includes(',')) {
-    originalTagValues = value.split(', ');
+    originalTagValues = value.split(',').map((val: string) => val.trim());
   } else {
     originalTagValues = value.split(' ');
   }

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -190,9 +190,7 @@ export function splitValueIfSingleOrMultilineArray(value: string): string | stri
       return null;
     }
 
-    let arrayItems = value.split(', ');
-
-    arrayItems = arrayItems.length > 1 ? arrayItems : arrayItems[0].split(',');
+    const arrayItems = value.split(',').map((val: string) => val.trim());
 
     return arrayItems.filter((el: string) => {
       return el != '';


### PR DESCRIPTION
Fixes #509 

Changes Made:
- Made sure that single-line arrays and single-line comma delimited strings for tags are split on a comma instead of a comma followed by a space and they have whitespace trimmed off of them
- Added a test to make sure this functionality continues to work in the future