### PR TITLE
Fix Bug with Links in Headings by Converting to Text instead of Retaining Link

### DIFF
--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1080,12 +1080,56 @@ ruleTest({
       after: dedent`
         ---
         aliases:
-          - [[Heading]]
-        linter-yaml-title-alias: [[Heading]]
+          - Heading
+        linter-yaml-title-alias: Heading
         ---
         [[Link1]]
 
         # [[Heading]]
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/470
+      testName: 'Make sure that markdown links aliases and custom key are converted to text',
+      before: dedent`
+        ---
+        aliases:
+          - This is a [Heading](markdown.md)
+        linter-yaml-title-alias: This is a [Heading](markdown.md)
+        ---
+        # This is a [Heading](markdown.md)
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - This is a Heading
+        linter-yaml-title-alias: This is a Heading
+        ---
+        # This is a [Heading](markdown.md)
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/470
+      testName: 'Make sure that wiki links aliases and custom key are converted to text',
+      before: dedent`
+        ---
+        aliases:
+          - This is a [[Heading]]
+        linter-yaml-title-alias: This is a [[Heading]]
+        ---
+        # This is a [[Heading]]
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - This is a Heading
+        linter-yaml-title-alias: This is a Heading
+        ---
+        # This is a [[Heading]]
       `,
       options: {
         aliasArrayStyle: NormalArrayFormats.MultiLine,

--- a/__tests__/yaml-title.test.ts
+++ b/__tests__/yaml-title.test.ts
@@ -74,11 +74,41 @@ ruleTest({
       `,
       after: dedent`
         ---
-        title: [[Heading]]
+        title: Heading
         ---
         [[Link1]]
 
         # [[Heading]]
+      `,
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/470
+      testName: 'Make sure that markdown links in title get converted to text',
+      before: dedent`
+        ---
+        title: This is a [Heading](test heading.md)
+        ---
+        # This is a [Heading](test heading.md)
+      `,
+      after: dedent`
+        ---
+        title: This is a Heading
+        ---
+        # This is a [Heading](test heading.md)
+      `,
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/470
+      testName: 'Make sure that wiki links in title get converted to text',
+      before: dedent`
+        ---
+        title: This is a [[Heading]]
+        ---
+        # This is a [[Heading]]
+      `,
+      after: dedent`
+        ---
+        title: This is a Heading
+        ---
+        # This is a [[Heading]]
       `,
     },
   ],

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -3,7 +3,7 @@ import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} fr
 import dedent from 'ts-dedent';
 import {convertAliasValueToStringOrStringArray, escapeStringIfNecessaryAndPossible, formatYamlArrayValue, getYamlSectionValue, initYAML, LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEYS, OBSIDIAN_ALIAS_KEY_PLURAL, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
-import {convertLinksAndImagesToDisplayText, getFirstHeaderOneText, headerRegex, yamlRegex} from '../utils/regex';
+import {getFirstHeaderOneText, yamlRegex} from '../utils/regex';
 
 
 class YamlTitleAliasOptions implements Options {

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -3,7 +3,7 @@ import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} fr
 import dedent from 'ts-dedent';
 import {convertAliasValueToStringOrStringArray, escapeStringIfNecessaryAndPossible, formatYamlArrayValue, getYamlSectionValue, initYAML, LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEYS, OBSIDIAN_ALIAS_KEY_PLURAL, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
-import {convertLinksAndImagesToDisplayText, headerRegex, yamlRegex} from '../utils/regex';
+import {convertLinksAndImagesToDisplayText, getFirstHeaderOneText, headerRegex, yamlRegex} from '../utils/regex';
 
 
 class YamlTitleAliasOptions implements Options {
@@ -37,13 +37,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
   }
   apply(text: string, options: YamlTitleAliasOptions): string {
     text = initYAML(text);
-    let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.tag], text, (text) => {
-      const result = text.match(headerRegex);
-      if (result) {
-        return convertLinksAndImagesToDisplayText(result[4] ?? '');
-      }
-      return '';
-    });
+    let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.tag], text, getFirstHeaderOneText);
     title = title || options.fileName;
 
     let previousTitle: string = null;

--- a/src/rules/yaml-title.ts
+++ b/src/rules/yaml-title.ts
@@ -3,7 +3,7 @@ import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextOptionBuilder} from 
 import dedent from 'ts-dedent';
 import {escapeStringIfNecessaryAndPossible, formatYAML, initYAML} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
-import {convertLinksAndImagesToDisplayText, escapeDollarSigns, headerRegex} from '../utils/regex';
+import {escapeDollarSigns, getFirstHeaderOneText} from '../utils/regex';
 import {insert} from '../utils/strings';
 
 class YamlTitleOptions implements Options {
@@ -32,13 +32,7 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
   }
   apply(text: string, options: YamlTitleOptions): string {
     text = initYAML(text);
-    let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.tag], text, (text) => {
-      const result = text.match(headerRegex);
-      if (result) {
-        return convertLinksAndImagesToDisplayText(result[4] ?? '');
-      }
-      return '';
-    });
+    let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.tag], text, getFirstHeaderOneText);
     title = title || options.fileName;
 
     title = escapeStringIfNecessaryAndPossible(title, options.defaultEscapeCharacter);

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -83,13 +83,20 @@ export function ensureEmptyLinesAroundTables(text: string): string {
 }
 
 /**
- * Converts text to no longer have any links in it.
- * @param {string} text - The text to have the regular and image links converted to their text.
- * @return {string} The text without any links in it.
+ * Gets the first header one's text from the string provided making sure to convert any links to their display text.
+ * @param {string} text - The text to have get the first header one's text from.
+ * @return {string} The text for the first header one if present or an empty string.
  */
-export function convertLinksAndImagesToDisplayText(text: string): string {
-  text = text.replaceAll(wikiLinkRegex, '$2');
-  text = text.replaceAll(genericLinkRegex, '$2');
+export function getFirstHeaderOneText(text: string) {
+  const result = text.match(headerRegex);
+  if (result && result[4]) {
+    let headerText = result[4];
+    headerText = headerText.replaceAll(wikiLinkRegex, (_, _2, $2: string, $3: string) => {
+      return $3 ?? $2;
+    });
 
-  return text;
+    return headerText.replaceAll(genericLinkRegex, '$2');
+  }
+
+  return '';
 }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -2,15 +2,17 @@
 import {makeSureContentHasEmptyLinesAddedBeforeAndAfter} from './strings';
 
 // Useful regexes
-export const headerRegex = /^(\s*)(#+)(\s+)(.*)$/;
+export const headerRegex = /^(\s*)(#+)(\s+)(.*)$/m;
 export const fencedRegexTemplate = '^XXX\\.*?\n(?:((?:.|\n)*?)\n)?XXX(?=\\s|$)$';
 export const yamlRegex = /^---\n((?:(((?!---)(?:.|\n)*?)\n)?))---(?=\n|$)/;
 export const backtickBlockRegexTemplate = fencedRegexTemplate.replaceAll('X', '`');
 export const tildeBlockRegexTemplate = fencedRegexTemplate.replaceAll('X', '~');
 export const indentedBlockRegex = '^((\t|( {4})).*\n)+';
 export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeBlockRegexTemplate}|${indentedBlockRegex}`, 'gm');
-export const wikiLinkRegex = /(!?)(\[{2}[^[\n\]]*\]{2})/g;
-export const genericLinkRegex = /^!?\[.*\](.*)$/;
+// based on https://stackoverflow.com/a/26010910/8353749
+export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?\]{2}/g;
+// based on https://davidwells.io/snippets/regex-match-markdown-links
+export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
 export const tagRegex = /(?:\s|^)#[^\s#;.,><?!=+]+/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
@@ -76,6 +78,18 @@ export function ensureEmptyLinesAroundTables(text: string): string {
 
     text = makeSureContentHasEmptyLinesAddedBeforeAndAfter(text, start, end);
   }
+
+  return text;
+}
+
+/**
+ * Converts text to no longer have any links in it.
+ * @param {string} text - The text to have the regular and image links converted to their text.
+ * @return {string} The text without any links in it.
+ */
+export function convertLinksAndImagesToDisplayText(text: string): string {
+  text = text.replaceAll(wikiLinkRegex, '$2');
+  text = text.replaceAll(genericLinkRegex, '$2');
 
   return text;
 }


### PR DESCRIPTION
Fixes #470 

Changes Made:
- Made sure to convert links to their display text and links
- Added tests to account for the scenarios in question and hopefully make sure that down the road we don't break anything
- Refactored header regex to make it more maintainable and also clean up logic some