### PR TITLE
Fix Heading Placed on Same Line as Frontmatter When File is Just Frontmatter

### DIFF
--- a/__tests__/file-name-heading.test.ts
+++ b/__tests__/file-name-heading.test.ts
@@ -26,5 +26,23 @@ ruleTest({
         fileName: 'File Name',
       },
     },
+    {
+      testName: 'Inserts the heading on the line after the frontmatter of the file when it is the only thing in the file',
+      before: dedent`
+        ---
+        hello: test
+        ---
+      `,
+      after: dedent`
+        ---
+        hello: test
+        ---
+        # Test note
+        ${''}
+      `,
+      options: {
+        fileName: 'Test note',
+      },
+    },
   ],
 });

--- a/__tests__/file-name-heading.test.ts
+++ b/__tests__/file-name-heading.test.ts
@@ -26,7 +26,7 @@ ruleTest({
         fileName: 'File Name',
       },
     },
-    {
+    { // accounts for https://github.com/platers/obsidian-linter/issues/513
       testName: 'Inserts the heading on the line after the frontmatter of the file when it is the only thing in the file',
       before: dedent`
         ---

--- a/src/rules/file-name-heading.ts
+++ b/src/rules/file-name-heading.ts
@@ -36,7 +36,13 @@ export default class FileNameHeading extends RuleBuilder<FileNameHeadingOptions>
       let yaml_end = text.indexOf('\n---');
       yaml_end =
         yaml_end == -1 || !text.startsWith('---\n') ? 0 : yaml_end + 5;
-      return insert(text, yaml_end, `# ${fileName}\n`);
+
+      let header = `# ${fileName}\n`;
+      if (text.length < yaml_end) {
+        header = '\n' + header;
+      }
+
+      return insert(text, yaml_end, header);
     });
   }
   get exampleBuilders(): ExampleBuilder<FileNameHeadingOptions>[] {


### PR DESCRIPTION
Fixes #513 

Changes Made:
- Added a UT to make sure we cover the scenario in question
- Made sure to add a new line character before the heading if the heading was to be placed after the ending of the current document since that would mean there is no newline after the frontmatter