### PR TITLE
Fix 3 Bugs and Add a New NPM Command

### DIFF
--- a/__tests__/consecutive-blank-lines.test.ts
+++ b/__tests__/consecutive-blank-lines.test.ts
@@ -27,5 +27,104 @@ ruleTest({
         \`\`\`
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/529
+      testName: 'Removes multiple empty lines when one of the lines just has spaces in it',
+      before: dedent`
+        Line 1
+        ${''}
+        ${'  '} 
+        Line 2
+      `,
+      after: dedent`
+        Line 1
+        ${''}
+        Line 2
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/529
+      testName: 'Removes multiple empty lines when one of the lines just has a tab in it',
+      before: dedent`
+        Line 1
+        ${''}
+        ${''}\t
+        Line 2
+      `,
+      after: dedent`
+        Line 1
+        ${''}
+        Line 2
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/529
+      testName: 'Removes multiple empty lines when one of the lines just has a carriage return in it',
+      before: dedent`
+        Line 1
+        ${''}
+        ${''}\r
+        ${''}\v
+        Line 2
+      `,
+      after: dedent`
+        Line 1
+        ${''}
+        Line 2
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/529
+      testName: 'Removes multiple empty lines when one of the lines just has a vertical tab in it',
+      before: dedent`
+        Line 1
+        ${''}
+        ${''}\v
+        Line 2
+      `,
+      after: dedent`
+        Line 1
+        ${''}
+        Line 2
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/529
+      testName: 'Removes multiple empty lines when one of the lines just has a page break in it',
+      before: dedent`
+        Line 1
+        ${''}
+        ${''}\f
+        Line 2
+      `,
+      after: dedent`
+        Line 1
+        ${''}
+        Line 2
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/529
+      testName: 'Removes multiple empty lines when one of the lines just has a page break in it',
+      before: dedent`
+        Line 1
+        ${''}
+        ${''}\f
+        Line 2
+      `,
+      after: dedent`
+        Line 1
+        ${''}
+        Line 2
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/529
+      testName: 'Removes multiple empty lines when one of the lines just has multiple kinds of whitespace in it in it',
+      before: dedent`
+        Line 1
+        ${''}
+        ${''}\f \r\v\t\t\v
+        Line 2
+      `,
+      after: dedent`
+        Line 1
+        ${''}
+        Line 2
+      `,
+    },
   ],
 });

--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -265,5 +265,36 @@ ruleTest({
         %%
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/517
+      testName: 'Table followed by header should only have 1 line after it',
+      before: dedent`
+        ### 常量
+
+        |  \`[[Link]]\`         |  A link to the file named "Link"  |
+        |:--------------------|:----------------------------------|
+        |  \`[[Link]]\`         |  A link to the file named "Link"  |
+        |  \`[1, 2, 3]\`        |  A list of numbers 1, 2, and 3    |
+        |  \`[[1, 2],[3, 4]]\`  |  A list of lists                  |
+        |  \`{ a: 1, b: 2 }\`   |  An object                        |
+        |  \`date()\`           |                                   |
+        |  \`dur()\`            |                                   |
+
+        ### 表达式
+      `,
+      after: dedent`
+        ### 常量
+
+        |  \`[[Link]]\`         |  A link to the file named "Link"  |
+        |:--------------------|:----------------------------------|
+        |  \`[[Link]]\`         |  A link to the file named "Link"  |
+        |  \`[1, 2, 3]\`        |  A list of numbers 1, 2, and 3    |
+        |  \`[[1, 2],[3, 4]]\`  |  A list of lists                  |
+        |  \`{ a: 1, b: 2 }\`   |  An object                        |
+        |  \`date()\`           |                                   |
+        |  \`dur()\`            |                                   |
+
+        ### 表达式
+      `,
+    },
   ],
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test-suite": "jest -t \"$1\"",
     "docs": "node docs.js",
     "compile": "npm run build && npm run docs && npm run lint && npm run test",
-    "lint": "eslint . --ext .ts --fix"
+    "lint": "eslint . --ext .ts --fix",
+    "clear-jest": "jest --clearCache"
   },
   "keywords": [],
   "author": "",

--- a/src/rules/consecutive-blank-lines.ts
+++ b/src/rules/consecutive-blank-lines.ts
@@ -22,6 +22,7 @@ export default class ConsecutiveBlankLines extends RuleBuilder<ConsecutiveBlankL
   }
   apply(text: string, options: ConsecutiveBlankLinesOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
+      // make sure to account for lines that are purely whitespace as well https://stackoverflow.com/a/3873354/8353749
       return text.replace(/(\n([\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?){2,}/g, '\n\n');
     });
   }

--- a/src/rules/consecutive-blank-lines.ts
+++ b/src/rules/consecutive-blank-lines.ts
@@ -22,7 +22,7 @@ export default class ConsecutiveBlankLines extends RuleBuilder<ConsecutiveBlankL
   }
   apply(text: string, options: ConsecutiveBlankLinesOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      return text.replace(/\n{2,}/g, '\n\n');
+      return text.replace(/(\n([\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?){2,}/g, '\n\n');
     });
   }
   get exampleBuilders(): ExampleBuilder<ConsecutiveBlankLinesOptions>[] {

--- a/src/rules/footnote-after-punctuation.ts
+++ b/src/rules/footnote-after-punctuation.ts
@@ -21,10 +21,9 @@ export default class FootnoteAfterPunctuation extends RuleBuilder<FootnoteAfterP
     return RuleType.FOOTNOTE;
   }
   apply(text: string, options: FootnoteAfterPunctuationOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-    // regex uses hack to treat lookahead as lookaround https://stackoverflow.com/a/43232659
-    // needed to ensure that no footnote text followed by ":" is matched
-      return text.replace(/(?!^)(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.footnoteAtStartOfLine, IgnoreTypes.footnoteAfterATask], text, (text) => {
+      // needed to ensure that no footnote text followed by ":" is matched
+      return text.replace(/(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
     });
   }
   get exampleBuilders(): ExampleBuilder<FootnoteAfterPunctuationOptions>[] {
@@ -36,6 +35,19 @@ export default class FootnoteAfterPunctuation extends RuleBuilder<FootnoteAfterP
         `,
         after: dedent`
           Lorem.[^1] Ipsum,[^2] doletes.
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'A footnote at the start of a task is not moved to after the punctuation',
+        before: dedent`
+          - [ ] [^1]: This is a footnote and a task.
+          - [ ] This is a footnote and a task that gets swapped with the punctuation[^2]!
+          [^2]: This footnote got modified
+        `,
+        after: dedent`
+          - [ ] [^1]: This is a footnote and a task.
+          - [ ] This is a footnote and a task that gets swapped with the punctuation![^2]
+          [^2]: This footnote got modified
         `,
       }),
     ];

--- a/src/rules/footnote-after-punctuation.ts
+++ b/src/rules/footnote-after-punctuation.ts
@@ -22,7 +22,6 @@ export default class FootnoteAfterPunctuation extends RuleBuilder<FootnoteAfterP
   }
   apply(text: string, options: FootnoteAfterPunctuationOptions): string {
     return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.footnoteAtStartOfLine, IgnoreTypes.footnoteAfterATask], text, (text) => {
-      // needed to ensure that no footnote text followed by ":" is matched
       return text.replace(/(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
     });
   }

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -27,6 +27,8 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   tag: {replaceAction: tagRegex, placeholder: '#tag-placeholder'},
   obsidianMultiLineComments: {replaceAction: obsidianMultilineCommentRegex, placeholder: '{OBSIDIAN_COMMENT_PLACEHOLDER}'},
   table: {replaceAction: tableRegex, placeholder: '{TABLE_PLACEHOLDER}'},
+  footnoteAtStartOfLine: {replaceAction: /^(\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AT_START_OF_LINE_PLACEHOLDER}'},
+  footnoteAfterATask: {replaceAction: /- \[.] (\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AFTER_A_TASK_PLACEHOLDER}'},
   // custom functions
   link: {replaceAction: replaceMarkdownLinks, placeholder: '{REGULAR_LINK_PLACEHOLDER}'},
 } as const;

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -21,7 +21,7 @@ export const ellipsisRegex = /(\. ?){2}\./g;
 export const lineStartingWithWhitespaceOrBlockquoteTemplate = `\\s*(>\\s*)*`;
 // Note that the following regex has an issue where if the table is followed by another table with only 1 blank line between them, it considers them to be one table
 // if this becomes an issue, we can address it then
-export const tableRegex = /((((>[ ]?)*)|([ ]{0,3}))\[.*?\][ \t]*\n)?((((>[ ]?)*)|([ ]{0,3}))\S+.*?\|.*?\n([^\n]*?\|[^\n]*?\n)*?)?(((>[ ]?)*)|([ ]{0,3}))[|\-+:.][ \-+|:.]*?\|[ \-+|:.]*(?:\n?[^\n]*?\|([^\n]*?)*(\n)?)+/g;
+export const tableRegex = /((((>[ ]?)*)|([ ]{0,3}))\[.*?\][ \t]*\n)?((((>[ ]?)*)|([ ]{0,3}))\S+.*?\|.*?\n([^\n]*?\|[^\n]*?\n)*?)?(((>[ ]?)*)|([ ]{0,3}))[|\-+:.][ \-+|:.]*?\|[ \-+|:.]*(?:\n?[^\n]*?\|([^\n]*?)*)+/g;
 export const urlRegex = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"‘’“”>]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"‘’“”>]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'"‘’“”>]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'"‘’“”>]{2,})/gi;
 
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
@@ -70,7 +70,7 @@ export function ensureEmptyLinesAroundTables(text: string): string {
 
   for (const table of tableMatches) {
     let start = text.indexOf(table);
-    const end = start + table.trimEnd().length;
+    const end = start + table.length;
     if (table.trim().startsWith('>')) {
       while (text.charAt(start).trim() === '' || text.charAt(start) === '>') {
         start++;


### PR DESCRIPTION
Fixes #529 
Fixes #517 
Relates to #516 

Changes Made:
- Updated consecutive blank lines to consider a line to be empty if it is solely whitespace
- Added UTs to test out several new scenarios for whitespace removal
- Added a command to allow for the removal of the jest cache to better help when renaming rules or when the jest cache causes UTs to fail
- Added ability to ignore footnotes after a task for moving footnote to after punctuation
- Updated table regex to make sure it does not end with a new line character in order to help fix some issues with new lines around it