### PR TITLE
Fix Issue with Regex Replacement Where Escape Characters Were String Escaped and Not Actually Escape Characters

### DIFF
--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -137,5 +137,18 @@ ruleTest({
         style: 'First letter',
       },
     },
+    {
+      testName: `Make sure that 'First Letter' doesn't ignore cased words just because they are cased when ignore cased words is enabled`,
+      before: dedent`
+        ### This Header is Cased
+      `,
+      after: dedent`
+        ### This header is cased
+      `,
+      options: {
+        style: 'First letter',
+        ignoreCasedWords: true,
+      },
+    },
   ],
 });

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -18,6 +18,7 @@ import YamlTimestamp from './rules/yaml-timestamp';
 import {ObsidianCommandInterface} from './typings/obsidian-ex';
 import {CustomReplace} from './ui/linter-components/custom-replace-option';
 import {LintCommand} from './ui/linter-components/custom-command-option';
+import {convertStringVersionOfEscapeCharactersToEscapeCharacters} from './utils/strings';
 
 export type RunLinterRulesOptions = {
   oldText: string,
@@ -134,15 +135,17 @@ export class RulesRunner {
     }
   }
 
-  runCustomRegexReplacement(customRegexs: CustomReplace[], oldText: string): string {
+  runCustomRegexReplacement(customRegexes: CustomReplace[], oldText: string): string {
     logDebug(`Running Custom Regex`);
     let tempOldText = oldText;
-    for (const eachRegex of customRegexs) {
+    for (const eachRegex of customRegexes) {
       if (eachRegex.find == undefined || eachRegex.replace === undefined || eachRegex.replace === null ) {
         continue;
       }
+
       const regex = new RegExp(`${eachRegex.find}`, eachRegex.flags);
-      tempOldText = tempOldText.replace(regex, eachRegex.replace);
+      // make sure that characters are not string escaped unescape in the replace value to make sure things like \n and \t are correctly inserted
+      tempOldText = tempOldText.replace(regex, convertStringVersionOfEscapeCharactersToEscapeCharacters(eachRegex.replace));
     }
     return tempOldText;
   }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -134,3 +134,26 @@ export function hashString53Bit(str: string, seed: number = 0): number {
 
   return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 }
+
+/**
+ * Takes a string and converts string that have the string escaped form of escape characters such as new line, backspace,
+ * form feed, carriage return, horizontal tab, and vertical tab and makes sure they are their escaped character values.
+ * @param {string} val - The string to make sure has the escape characters as escape characters rather than a stringified form.
+ * @return {string} The string with the escape characters converted to their escape character form.
+ */
+export function convertStringVersionOfEscapeCharactersToEscapeCharacters(val: string): string {
+  // replace string version of backspace character with the actual backspace character
+  val = val.replace('\\b', '\b');
+  // replace string version of form feed character with the actual form feed character
+  val = val.replace('\\f', '\f');
+  // replace string version of new line character with the actual new line character
+  val = val.replace('\\n', '\n');
+  // replace string version of carriage return character with the actual carriage return character
+  val = val.replace('\\r', '\r');
+  // replace string version of horizontal tab character with the actual horizontal tab character
+  val = val.replace('\\t', '\t');
+  // replace string version of vertical tab character with the actual vertical tab character
+  val = val.replace('\\v', '\v');
+
+  return val;
+}


### PR DESCRIPTION
Fixes #524 

Changes Made
- Added the ability to actually use escape characters in regex replacement
- Added a UT to make sure that first letter does not ignore cased words when that setting is on
- Added a new method for converting string escaped escape characters to their escaped character forms