### PR TITLE
Add More Robust YAML String to Array Parsing

### DIFF
--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -868,5 +868,24 @@ ruleTest({
         defaultArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
+    {
+      // accounts for https://github.com/platers/obsidian-linter/issues/525
+      testName: 'Converting a single string comma separated array to a multi-line array should respect escaped entries',
+      before: dedent`
+        ---
+        aliases: Scott, "Scott, Jr."
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Scott
+          - "Scott, Jr."
+        ---
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
   ],
 });

--- a/__tests__/yaml-string-to-array.test.ts
+++ b/__tests__/yaml-string-to-array.test.ts
@@ -1,0 +1,62 @@
+import {convertYAMLStringToArray} from '../src/utils/yaml';
+
+type YAMLStringTestCase = {
+  testName: string,
+  delimiter: string,
+  before: string,
+  after: string[],
+}
+
+const testCases: YAMLStringTestCase[] = [
+  {
+    testName: 'Two entry string with empty last value',
+    delimiter: ',',
+    before: 'value1, ',
+    after: ['value1'],
+  },
+  {
+    testName: 'A delimiter escaped with a double quote should not be counted as a delimiter',
+    delimiter: ',',
+    before: 'value1, "Scott, Jr.", Bob',
+    after: ['value1', '"Scott, Jr."', 'Bob'],
+  },
+  {
+    testName: 'A delimiter escaped with a single quote should not be counted as a delimiter',
+    delimiter: ',',
+    before: 'value1, \'Scott, Jr.\', Bob',
+    after: ['value1', '\'Scott, Jr.\'', 'Bob'],
+  },
+  {
+    testName: 'An empty string should return null',
+    delimiter: ',',
+    before: '',
+    after: null,
+  },
+  {
+    testName: 'A null value should return null',
+    delimiter: ',',
+    before: null,
+    after: null,
+  },
+  {
+    testName: 'A single single quote in the string should not result in an escaped value and it should parse it as normal',
+    delimiter: ',',
+    before: 'Bob, John\'s,Doug',
+    after: ['Bob', 'John\'s', 'Doug'],
+  },
+  {
+    testName: 'A single double quote in the string should not result in an escaped value and it should parse it as normal',
+    delimiter: ',',
+    before: 'Bob, "John,Doug',
+    after: ['Bob', '"John', 'Doug'],
+  },
+];
+
+
+describe('Parse YAML Strings to Arrays', () => {
+  for (const testCase of testCases) {
+    it(testCase.testName, () => {
+      expect(convertYAMLStringToArray(testCase.before, testCase.delimiter)).toStrictEqual(testCase.after);
+    });
+  }
+});


### PR DESCRIPTION
Relates to #525 

Changs Made:
- Instead of Assuming all delimiters were valid, the logic was updated to check for only unescaped delimiters. This means delimiters not surrounded by a single or double quote. _Note that double nesting is not supported._
- Added tests for the new parser and to verify that the YAML array format rule is working well with it
