### PR TITLE
Better H2 Header Increment Level Support

### DIFF
--- a/__tests__/header-increment.test.ts
+++ b/__tests__/header-increment.test.ts
@@ -67,7 +67,7 @@ ruleTest({
       `,
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/412
-      testName: 'When H1 starts file, header increment should act like normal',
+      testName: 'H1s become H2s and all other headers are shifted accordingly when an H1 starts a file',
       before: dedent`
         # H1
         ### H3
@@ -75,42 +75,34 @@ ruleTest({
         # H1
         #### H4
         ###### H6
-
-        H1 at beginning of file: same as existing behavior
       `,
       after: dedent`
-        # H1
-        ## H3
+        ## H1
+        ### H3
+        #### H4
+        ## H1
         ### H4
-        # H1
-        ## H4
-        ### H6
-
-        H1 at beginning of file: same as existing behavior
+        #### H6
       `,
       options: {
         startAtH2: true,
       },
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/412
-      testName: 'When H1 does not start the file, H1s are left alone and minimum header is H2 for decremented headers',
+      testName: 'When H1 does not start the file, H1s are converted to H2 where they are and the next header is an H3',
       before: dedent`
         ### H3
         #### H4
         # H1
         ##### H5
         ###### H6
-
-        No H1 at beginning of file: No header promoted beyond H2; H1s left alone
       `,
       after: dedent`
         ## H3
         ### H4
-        # H1
-        ## H5
-        ### H6
-
-        No H1 at beginning of file: No header promoted beyond H2; H1s left alone
+        ## H1
+        ### H5
+        #### H6
       `,
       options: {
         startAtH2: true,

--- a/src/rules/header-increment.ts
+++ b/src/rules/header-increment.ts
@@ -27,15 +27,10 @@ export default class HeaderIncrement extends RuleBuilder<HeaderIncrementOptions>
       let lastLevel = options.startAtH2 ? 1 : 0; // level of last header processed
       let decrement = 0; // number of levels to decrement following headers
       const minimumLevel = options.startAtH2 ? 2: 1;
+      const levelOffSet = options.startAtH2 ? 1: 0;
 
       return text.replace(allHeadersRegex, (headerText: string, $1: string = '', $2: string = '', $3: string = '', $4: string = '', $5: string = '') => {
-        // skip any headers with a header level less than the minimum
-        if ($2.length < minimumLevel) {
-          lastLevel = minimumLevel - 1; // makes sure that header increment starts off at the minimum level if the last level was greater than it
-          return headerText;
-        }
-
-        let level = $2.length - decrement;
+        let level = $2.length + levelOffSet - decrement;
         if (level > lastLevel + 1) {
           decrement += level - (lastLevel + 1);
           level = lastLevel + 1;
@@ -122,26 +117,26 @@ export default class HeaderIncrement extends RuleBuilder<HeaderIncrementOptions>
         `,
       }),
       new ExampleBuilder({
-        description: 'When start at heading level 2 is set to true, H1s are left alone and the next header will be an H2',
+        description: 'When `Start Header Increment at Heading Level 2 = true`, H1s become H2s and the other headers are incremented accordingly',
         before: dedent`
-          # H1 stays the same
-          ### H3 becomes H2
+          # H1 becomes H2
+          #### H4 becomes H3
           ####### H7
           ###### H6
           ## H2
           ###### H6
           # H1
-          ####### H7
+          ## H2
         `,
         after: dedent`
-          # H1 stays the same
-          ## H3 becomes H2
-          ### H7
-          ## H6
+          ## H1 becomes H2
+          ### H4 becomes H3
+          #### H7
+          ### H6
           ## H2
           ### H6
-          # H1
-          ## H7
+          ## H1
+          ### H2
         `,
         options: {
           startAtH2: true,
@@ -154,7 +149,7 @@ export default class HeaderIncrement extends RuleBuilder<HeaderIncrementOptions>
       new BooleanOptionBuilder({
         OptionsClass: HeaderIncrementOptions,
         name: 'Start Header Increment at Heading Level 2',
-        description: 'Ignores level 1 headings and makes sure that level 1 headings are followed by an level 2 heading',
+        description: 'Makes heading level 2 the minimum heading level in a file for header increment and shifts all headings accordingly so they increment starting with a level 2 heading.',
         optionsKey: 'startAtH2',
       }),
     ];


### PR DESCRIPTION
Relates to #412 

Changes Made:
- Updated tests to make them work with all headers being shifted up by 1 instead of ignoring H1s
- Updated the logic so that it will just add an offset of 1 to the header level calculation when we want to start at heading level 2