### PR TITLE
feat: lint command that respects ignored folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-linter",
-  "version": "1.7.1",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
-      "version": "1.7.1",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",

--- a/src/main.ts
+++ b/src/main.ts
@@ -162,6 +162,19 @@ export default class LinterPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: 'lint-file-unless-ignored',
+      name: 'Lint the current file unless ignored',
+      editorCallback: (editor: Editor) => {
+        const file = this.app.workspace.getActiveFile();
+
+        if (!this.shouldIgnoreFile(file)) {
+          this.runLinterEditor(editor);
+        }
+      },
+      icon: iconInfo.file.id,
+    });
+
+    this.addCommand({
       id: 'lint-all-files',
       name: 'Lint all files in the vault',
       icon: iconInfo.vault.id,


### PR DESCRIPTION
Fixes #546. See discussion there.

Additionally contains small change in package-lock, which was not updated for `1.9.1`.