### PR TITLE
Make Sure Tag Like Values in Markdown Links and Wiki Links are Ignored

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -183,5 +183,19 @@ ruleTest({
         tagsToIgnore: ['ignored-tag', 'ignored-tag/nested-tag'],
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/579
+      testName: 'Make sure wiki link and markdown link text is ignored for this',
+      before: dedent`
+        [Issue #152 on Github](some_link.md)
+        [[some_link|Issue #152 on Github]]]
+      `,
+      after: dedent`
+        [Issue #152 on Github](some_link.md)
+        [[some_link|Issue #152 on Github]]]
+      `,
+      options: {
+        tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
+      },
+    },
   ],
 });

--- a/src/rules/move-tags-to-yaml.ts
+++ b/src/rules/move-tags-to-yaml.ts
@@ -42,7 +42,7 @@ export default class MoveTagsToYaml extends RuleBuilder<MoveTagsToYamlOptions> {
     return RuleType.YAML;
   }
   apply(text: string, options: MoveTagsToYamlOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.html], text, (text) => {
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.html, IgnoreTypes.wikiLink, IgnoreTypes.link], text, (text) => {
       const tags = matchTagRegex(text);
       if (tags.length === 0) {
         return text;


### PR DESCRIPTION
Fixes #579 

Changes Made:
- Ignored wiki links and markdown links in order to prevent them from being affected by moving tag info