### PR TITLE
Remove Whitespace after YAML Frontmatter after Moving Tags to YAML

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -197,5 +197,28 @@ ruleTest({
         tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/573
+      testName: 'Make sure that removing a tag after the yaml frontmatter does not leave whitespace on the same line as the frontmatter',
+      before: dedent`
+        ---
+        title: Move Tags to YAML Duplicates YAML
+        date: 2023-01-13
+        edit: 2023-01-231
+        ---
+        #tag-error${' '}
+      `,
+      after: dedent`
+        ---
+        title: Move Tags to YAML Duplicates YAML
+        date: 2023-01-13
+        edit: 2023-01-231
+        tags: tag-error
+        ---
+      `,
+      options: {
+        tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
+        howToHandleExistingTags: 'Remove whole tag',
+      },
+    },
   ],
 });

--- a/src/rules/move-tags-to-yaml.ts
+++ b/src/rules/move-tags-to-yaml.ts
@@ -107,6 +107,10 @@ export default class MoveTagsToYaml extends RuleBuilder<MoveTagsToYamlOptions> {
         });
       }
 
+      // Make sure that the yaml frontmatter does not have whitespace added after the end of the yaml frontmatter.
+      // This accounts for https://github.com/platers/obsidian-linter/issues/573
+      text = text.replace(/(\n---)( |\t)+/, '$1');
+
       return text;
     });
   }


### PR DESCRIPTION
Fixes #573 

Changes Made:
- Added a UT for the scenario in question
- Removed whitespace from the ending indicator for YAML frontmatter