### PR TITLE
Make Sure YAML Timestamp Comparisons are Done in the Same Format

### DIFF
--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -109,7 +109,7 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
         if (keyWithValueFound) {
           const modifiedDateTime = moment(text.match(modified_match)[0].replace(options.dateModifiedKey + ':', '').trim(), options.format, options.locale, true);
           if (textModified || modifiedDateTime == undefined || !modifiedDateTime.isValid() ||
-              Math.abs(modifiedDateTime.diff(modified_date, 'seconds')) > 5
+            this.getTimeDifferenceInSeconds(modifiedDateTime, modified_date, options) > 5
           ) {
             text = text.replace(
                 modified_match,
@@ -129,6 +129,14 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
 
       return text;
     });
+  }
+  getTimeDifferenceInSeconds(modifiedDateTimeMetadata: moment.Moment, yamlModifiedDateTime: moment.Moment, options: YamlTimestampOptions): number {
+    // the metadata value may not be in the correct format, so we need to convert it to the correct format
+    // and then do the time comparison otherwise we get erroneously large differences in seconds
+    // see https://github.com/platers/obsidian-linter/issues/568
+    const formattedDateModifiedDate = moment(yamlModifiedDateTime.format(options.format), options.format, options.locale, true);
+
+    return Math.abs(modifiedDateTimeMetadata.diff(formattedDateModifiedDate, 'seconds'));
   }
   get exampleBuilders(): ExampleBuilder<YamlTimestampOptions>[] {
     return [


### PR DESCRIPTION
Fixes #568 

The problem was created when the system clock was in 24 hour mode (i.e. hours display like 19:00) while the date format had 12 hour mode or vice versa. It caused it to think there was a time difference of like 40k+ seconds.

Changes Made:
- Updated date comparison to force the moment instances to use the same format to prevent accidental date differences in the moment values 
  - this may be a bug in moment or operator error on my part, but doing this seems to fix the issue just fine
