### PR TITLE
Rewrite Header Increment to Better Handle Heading Level Groupings

### DIFF
--- a/__tests__/header-increment.test.ts
+++ b/__tests__/header-increment.test.ts
@@ -10,29 +10,29 @@ ruleTest({
       before: dedent`
         # H1
         #### H4
-        ####### H7
+        ###### H6
       `,
       after: dedent`
         # H1
         ## H4
-        ### H7
+        ### H6
       `,
     },
     {
       testName: 'Handles change from decrement to regular increment',
       before: dedent`
         # H1
-        ##### H5
-        ####### H7
+        #### H4
         ###### H6
+        ##### H5
         ## H2
       `,
       after: dedent`
         # H1
+        ## H4
+        ### H6
         ## H5
-        ### H7
-        ## H6
-        ## H2
+        # H2
       `,
     },
     {
@@ -56,13 +56,13 @@ ruleTest({
         ## H3
         ### H4
         #### H6
-        ## H2
+        # H2
         # H1
         ## H2
         ### H3
         #### H4
         ##### H6
-        ##### H5
+        #### H5
         ### H3
       `,
     },
@@ -127,6 +127,63 @@ ruleTest({
         #### H6
 
         Nothing gets promoted above H2
+      `,
+      options: {
+        startAtH2: true,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/576
+      testName: 'When decreasing the heading level, when the previous value was decreased and the next value is 1 more than the decreased value, but the same as the value just decremented, make sure the header is decremented with `startAtH2 = true`',
+      before: dedent`
+        ## HHELLO
+        #### HHELLO
+        ## HHELLO
+        ## HHELLO
+        ## HHELLO
+      `,
+      after: dedent`
+        ## HHELLO
+        ### HHELLO
+        ## HHELLO
+        ## HHELLO
+        ## HHELLO
+      `,
+      options: {
+        startAtH2: true,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/589
+      testName: 'When decreasing the heading level, when the previous value was decreased and the next value is 1 more than the decreased value, but the same as the value just decremented, make sure the header is decremented',
+      before: dedent`
+        ## Second
+        ### Third
+        ## Second again
+        ### Third again
+      `,
+      after: dedent`
+        # Second
+        ## Third
+        # Second again
+        ## Third again
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/589
+      testName: 'Make sure that when all header levels are present and we need to start at H2, that the H6 is left as an H6 since H7 is not valid',
+      before: dedent`
+        # H1
+        ## H2
+        ### H3
+        #### H4
+        ##### H5
+        ###### H6
+      `,
+      after: dedent`
+        ## H1
+        ### H2
+        #### H3
+        ##### H4
+        ###### H5
+        ###### H6
       `,
       options: {
         startAtH2: true,


### PR DESCRIPTION
Fixes #576 

Changes Made:
- Added a couple of UTs
- Fixed several UTs and examples where it was not written to be consistent
- Added a way to track which headings are a part of which heading level group and assign heading levels that way