### PR TITLE
Fix A First Letter Capitalization Issue and Tags in Headers Breaking Header Increment

### DIFF
--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -18,7 +18,7 @@ ruleTest({
         ## this état
       `,
       after: dedent`
-        # h1
+        # H1
         ## A c++ Lan
         ## This is a Sentence.
         ## I Can't Do This
@@ -111,7 +111,7 @@ ruleTest({
       },
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/484
-      testName: 'Make sure that first letter ot be capitalized by `First Letter` is preceded by a space or tab',
+      testName: 'Make sure that first letter to be capitalized by `First Letter` is preceded by a space or tab',
       before: dedent`
         ### 1.0.0-b.4
         ### b
@@ -159,6 +159,23 @@ ruleTest({
       `,
       after: dedent`
         # Headline $LR(0)$ Set
+      `,
+      options: {
+        style: 'First letter',
+        ignoreCasedWords: true,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/601
+      testName: `Make sure that if the 1st word has a number in it, it will still be considered to be a word and have its first letter capitalized`,
+      before: dedent`
+        # EC2 instance
+        ## EC2 lab05 load balancer
+        ### lab07 bread maker
+      `,
+      after: dedent`
+        # EC2 instance
+        ## EC2 lab05 load balancer
+        ### Lab07 bread maker
       `,
       options: {
         style: 'First letter',

--- a/__tests__/header-increment.test.ts
+++ b/__tests__/header-increment.test.ts
@@ -189,5 +189,20 @@ ruleTest({
         startAtH2: true,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/598
+      testName: 'Make sure that headers with tags in them are incremented like normal',
+      before: dedent`
+        # Page Title
+        ## Foo #tag
+        ### Bar
+        ### Baz
+      `,
+      after: dedent`
+        # Page Title
+        ## Foo #tag
+        ### Bar
+        ### Baz
+      `,
+    },
   ],
 });

--- a/src/rules/capitalize-headings.ts
+++ b/src/rules/capitalize-headings.ts
@@ -425,7 +425,7 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
         let firstWord = true;
         for (let j = 1; j < headerWords.length; j++) {
           // based on https://stackoverflow.com/a/62032796 "/\p{L}/u" accounts for all unicode letters across languages
-          const isWord = headerWords[j].match(/^[\p{L}'-]{1,}[.?!,:;]?$/u);
+          const isWord = headerWords[j].match(/^[\p{L}'-]{1,}[.?!,:;\d]*$/u);
           if (!isWord) {
             continue;
           }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -2,7 +2,7 @@
 import {makeSureContentHasEmptyLinesAddedBeforeAndAfter} from './strings';
 
 // Useful regexes
-export const allHeadersRegex = /^([ \t]*)(#+)([ \t]+)([^#\n\r]*)([ \t]+#+)?$/gm;
+export const allHeadersRegex = /^([ \t]*)(#+)([ \t]+)([^\n\r]*?)([ \t]+#+)?$/gm;
 export const fencedRegexTemplate = '^XXX\\.*?\n(?:((?:.|\n)*?)\n)?XXX(?=\\s|$)$';
 export const yamlRegex = /^---\n((?:(((?!---)(?:.|\n)*?)\n)?))---(?=\n|$)/;
 export const backtickBlockRegexTemplate = fencedRegexTemplate.replaceAll('X', '`');


### PR DESCRIPTION
Fixes #598 
Fixes #601 

Changes Made:
- Added UTs for the issues in question and fixed another UT that was related to the change
- Allowed words that end in a mix of some types of punctuation and numbers to be considered to be a word in header capitalization
- Updated the header regex to allow a tag-like value in the header