### PR TITLE
Fix Issue with Wiki Links with an Alias Not Properly Grabbing the Alias

### DIFF
--- a/__tests__/yaml-title.test.ts
+++ b/__tests__/yaml-title.test.ts
@@ -141,5 +141,17 @@ ruleTest({
         #tag
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/604
+      testName: 'Make sure that aliased wiki links are properly converted to just the alias in the YAML',
+      before: dedent`
+        # [[Broken Linter|Broken]] Linter
+      `,
+      after: dedent`
+        ---
+        title: Broken Linter
+        ---
+        # [[Broken Linter|Broken]] Linter
+      `,
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -92,7 +92,11 @@ export function getFirstHeaderOneText(text: string) {
   if (result && result[1]) {
     let headerText = result[1];
     headerText = headerText.replaceAll(wikiLinkRegex, (_, _2, $2: string, $3: string) => {
-      return $3 ?? $2;
+      if ($3 != null) {
+        return $3.replace('|', '');
+      }
+
+      return $2;
     });
 
     return headerText.replaceAll(genericLinkRegex, '$2');


### PR DESCRIPTION
Fixes #604 

Changes Made:
- Added a UT in order to make sure we don't hit this scenario in the future
- Changed the logic for wiki link header text to remove the `|` in the alias for the alias