### PR TITLE
Fix Links in Italics or Bold Getting Spaces Added for Links with CJK and English Characters

### DIFF
--- a/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
+++ b/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
@@ -73,7 +73,7 @@ ruleTest({
         $M0 = 现金$
       `,
     },
-    { // accounts for https://github.com/platers/obsidian-linter/issues/407
+    { // accounts for https://github.com/platers/obsidian-linter/issues/583
       testName: 'Make sure that wiki link and markdown links are ignored in italics',
       before: dedent`
         *[[abs 接口]]*
@@ -84,6 +84,16 @@ ruleTest({
         *[abs 接口](abs 接口.md)*
       `,
     },
-    // accounts for https://github.com/platers/obsidian-linter/issues/583
+    { // relates for https://github.com/platers/obsidian-linter/issues/583
+      testName: 'Make sure that wiki link and markdown links are ignored in bold',
+      before: dedent`
+        **[[abs 接口]]**
+        **[abs 接口](abs 接口.md)**
+      `,
+      after: dedent`
+        **[[abs 接口]]**
+        **[abs 接口](abs 接口.md)**
+      `,
+    },
   ],
 });

--- a/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
+++ b/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
@@ -60,8 +60,7 @@ ruleTest({
         \`filepath = './ちしき_図書館.md'\`
       `,
     },
-    {
-      // accounts for https://github.com/platers/obsidian-linter/issues/407
+    { // accounts for https://github.com/platers/obsidian-linter/issues/407
       testName: 'Make sure that inline math blocks are not affected',
       before: dedent`
         # Title Here
@@ -74,5 +73,17 @@ ruleTest({
         $M0 = 现金$
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/407
+      testName: 'Make sure that wiki link and markdown links are ignored in italics',
+      before: dedent`
+        *[[abs 接口]]*
+        *[abs 接口](abs 接口.md)*
+      `,
+      after: dedent`
+        *[[abs 接口]]*
+        *[abs 接口](abs 接口.md)*
+      `,
+    },
+    // accounts for https://github.com/platers/obsidian-linter/issues/583
   ],
 });

--- a/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
@@ -35,35 +35,23 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
       return text.replace(head, '$1 $3').replace(tail, '$1 $3');
     };
 
-    let newText = ignoreListOfTypes(
-        [
-          IgnoreTypes.code,
-          IgnoreTypes.inlineCode,
-          IgnoreTypes.yaml,
-          IgnoreTypes.image,
-          IgnoreTypes.link,
-          IgnoreTypes.wikiLink,
-          IgnoreTypes.tag,
-          IgnoreTypes.italics,
-          IgnoreTypes.bold,
-          IgnoreTypes.math,
-          IgnoreTypes.inlineMath,
-        ],
-        text,
-        addSpaceAroundChineseJapaneseKoreanAndEnglish,
-    );
 
-    newText = updateItalicsText(
-        newText,
-        addSpaceAroundChineseJapaneseKoreanAndEnglish,
-    );
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.yaml, IgnoreTypes.image, IgnoreTypes.link,
+      IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.math, IgnoreTypes.inlineMath], text, (text: string) => {
+      let newText = ignoreListOfTypes([IgnoreTypes.italics, IgnoreTypes.bold], text, addSpaceAroundChineseJapaneseKoreanAndEnglish);
 
-    newText = updateBoldText(
-        newText,
-        addSpaceAroundChineseJapaneseKoreanAndEnglish,
-    );
+      newText = updateItalicsText(
+          newText,
+          addSpaceAroundChineseJapaneseKoreanAndEnglish,
+      );
 
-    return newText;
+      newText = updateBoldText(
+          newText,
+          addSpaceAroundChineseJapaneseKoreanAndEnglish,
+      );
+
+      return newText;
+    });
   }
   get exampleBuilders(): ExampleBuilder<SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions>[] {
     return [


### PR DESCRIPTION
Fixes #583 

Changes Made:
- Added a couple of tests for the scenario in question
- Updated logic for the CJK space rule to make sure that it would ignore the common types for all of them and just italics and bold for the non-italics and non-bold text updating methods.