### PR TITLE
Fix Unicode Issue with Autocorrect

### DIFF
--- a/__tests__/auto-correct-common-misspellings.test.ts
+++ b/__tests__/auto-correct-common-misspellings.test.ts
@@ -27,5 +27,14 @@ ruleTest({
         ![absoltely not a changed](absoltely.not.changed.md)
       `,
     },
+    {
+      testName: 'Doesn\'t auto-correct words that start with unicode specific characters when not in correction list',
+      before: dedent`
+        être
+      `,
+      after: dedent`
+        être
+      `,
+    },
   ],
 });

--- a/src/rules/auto-correct-common-misspellings.ts
+++ b/src/rules/auto-correct-common-misspellings.ts
@@ -23,7 +23,7 @@ export default class AutoCorrectCommonMisspellings extends RuleBuilder<AutoCorre
   }
   apply(text: string, options: AutoCorrectCommonMisspellingsOptions): string {
     return ignoreListOfTypes([IgnoreTypes.yaml, IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.image, IgnoreTypes.url], text, (text) => {
-      const wordRegex = /[\w\-'’`]+/g;
+      const wordRegex = /[\p{L}\p{N}\p{Pc}\p{M}\-'’`]+/gu;
 
       return text.replaceAll(wordRegex, (word: string) => {
         const lowercasedWord = word.toLowerCase();


### PR DESCRIPTION
Fixes #633 

When checking for words to autocorrect, make sure unicode is supported since `\w` is not unicode aware.

Changes Made:
- Updated the regex in order to include unicode values as well
- Added a test to make sure it would not happen where the scenario in question happens again