### PR TITLE
Fix duplicate settings desc

### DIFF
--- a/src/ui/helpers.ts
+++ b/src/ui/helpers.ts
@@ -3,7 +3,7 @@ import {MarkdownRenderer} from 'obsidian';
 export function parseTextToHTMLWithoutOuterParagraph(text: string, containerEl: HTMLElement) {
   MarkdownRenderer.renderMarkdown(text, containerEl, '', null);
 
-  let htmlString = containerEl.innerHTML.trim();
+  let htmlString = containerEl.innerHTML.trim().replace(text, '');
   if (htmlString.startsWith('<p>')) {
     htmlString = htmlString.substring(3);
   }

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -75,8 +75,6 @@ export class DebugTab extends Tab {
     const logDisplay = new TextBoxFull(tempDiv, settingName, settingDesc);
     logDisplay.inputEl.setText(logsFromLastRun.join('\n'));
 
-    parseTextToHTMLWithoutOuterParagraph(settingDesc, setting.descEl);
-
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
   }
 }

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -75,6 +75,8 @@ export class DebugTab extends Tab {
     const logDisplay = new TextBoxFull(tempDiv, settingName, settingDesc);
     logDisplay.inputEl.setText(logsFromLastRun.join('\n'));
 
+    parseTextToHTMLWithoutOuterParagraph(settingDesc, logDisplay.descEl);
+
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
   }
 }


### PR DESCRIPTION
There is a duplicate settings item description in the debug settings item.

before:

![Snipaste_2023-03-11_17-58-23](https://user-images.githubusercontent.com/44738481/224478051-2b0301bd-2982-43a5-892e-720ec8171109.png)

after: 

![Snipaste_2023-03-11_18-41-54](https://user-images.githubusercontent.com/44738481/224479833-a5687b49-858a-4bd1-9056-009aced52f45.png)

```ts
    /**
     * Renders markdown string to an HTML element.
     * @param markdown - The markdown source code
     * @param el - The element to append to
     * @param sourcePath - The normalized path of this markdown file, used to resolve relative internal links
     * @param component - A parent component to manage the lifecycle of the rendered child components, if any
     * @public
     */
    static renderMarkdown(markdown: string, el: HTMLElement, sourcePath: string, component: Component): Promise<void>;
```

The `el` element is appended rather than replaced, so the original text needs to be removed before processing.
