### PR TITLE
Different Take on Deduplicating Description for Debug Tab

### DIFF
--- a/src/ui/helpers.ts
+++ b/src/ui/helpers.ts
@@ -3,7 +3,7 @@ import {MarkdownRenderer} from 'obsidian';
 export function parseTextToHTMLWithoutOuterParagraph(text: string, containerEl: HTMLElement) {
   MarkdownRenderer.renderMarkdown(text, containerEl, '', null);
 
-  let htmlString = containerEl.innerHTML.trim().replace(text, '');
+  let htmlString = containerEl.innerHTML.trim();
   if (htmlString.startsWith('<p>')) {
     htmlString = htmlString.substring(3);
   }

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -72,7 +72,7 @@ export class DebugTab extends Tab {
     tempDiv = this.contentEl.createDiv();
     settingName = getTextInLanguage('tabs.debug.linter-logs.name');
     settingDesc = getTextInLanguage('tabs.debug.linter-logs.description');
-    const logDisplay = new TextBoxFull(tempDiv, settingName, settingDesc);
+    const logDisplay = new TextBoxFull(tempDiv, settingName, '');
     logDisplay.inputEl.setText(logsFromLastRun.join('\n'));
 
     parseTextToHTMLWithoutOuterParagraph(settingDesc, logDisplay.descEl);


### PR DESCRIPTION
Relates to #646

The change in #646 made it so that rule names and descriptions for settings were not showing. To fix this, I reverted the change and went ahead and swapped to not setting the description initially to fix the duplication instead of the text replacement.