### PR TITLE
Fixed Error Message String, Logging Level Dropdown Text, and Bug with Moving Math Indicators to New Lines

### DIFF
--- a/__tests__/move-math-block-indicators-to-own-line.test.ts
+++ b/__tests__/move-math-block-indicators-to-own-line.test.ts
@@ -19,5 +19,31 @@ ruleTest({
         text here
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/560
+      testName: 'Moving math block indicator to its own line when in a blockquote moves the content to lines with a blockquote indicator at their start for inline math',
+      before: dedent`
+        > $$math$$
+      `,
+      after: dedent`
+        > $$
+        > math
+        > $$
+      `,
+    },
+    {
+      testName: 'Moving math block indicator to its own line when in a blockquote moves the content to lines with a blockquote indicator at their start for math block',
+      before: dedent`
+        > $$
+        > \\boldsymbol{a}=\\begin{bmatrix}a_x \\\\ a_y\\end{bmatrix}$$
+        text here
+      `,
+      after: dedent`
+        > $$
+        > \\boldsymbol{a}=\\begin{bmatrix}a_x \\\\ a_y\\end{bmatrix}
+        > $$
+        text here
+      `,
+    },
+
   ],
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -431,7 +431,7 @@ export default class LinterPlugin extends Plugin {
       if (useLogTemplateInNotice) {
         new Notice(`${errorMessage} ${error.message}.\n${seeConsoleText}`);
       } else {
-        new Notice(`${error.message}.\nS${seeConsoleText}`);
+        new Notice(`${error.message}.\n${seeConsoleText}`);
       }
     } else {
       new Notice(`${getTextInLanguage('logs.unknown-error')} ${seeConsoleText}`);

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -7,7 +7,7 @@ import {parseTextToHTMLWithoutOuterParagraph} from 'src/ui/helpers';
 import {logsFromLastRun, setLogLevel} from 'src/utils/logger';
 import {getTextInLanguage, LanguageStringKey} from 'src/lang/helpers';
 
-const logLevels = Object.keys(log.levels) as LanguageStringKey[];
+const logLevels = Object.keys(log.levels) as string[];
 const logLevelInts = Object.values(log.levels);
 
 export class DebugTab extends Tab {
@@ -25,7 +25,7 @@ export class DebugTab extends Tab {
         .setDesc(settingDesc)
         .addDropdown((dropdown) => {
           logLevels.forEach((logLevel, index) => {
-            dropdown.addOption(logLevelInts[index], getTextInLanguage(logLevel));
+            dropdown.addOption(logLevelInts[index], getTextInLanguage('enums.' + logLevel as LanguageStringKey));
           });
           // set value only takes strings so I have to cast the log level to type string in order to get it to work properly
           dropdown.setValue(this.plugin.settings.logLevel + '');

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -157,3 +157,16 @@ export function convertStringVersionOfEscapeCharactersToEscapeCharacters(val: st
 
   return val;
 }
+
+export function getStartOfLineIndex(text: string, indexToStartFrom: number): number {
+  if (indexToStartFrom < 2) {
+    return indexToStartFrom;
+  }
+
+  let startOfLineIndex = indexToStartFrom;
+  while (startOfLineIndex > 0 && text.charAt(startOfLineIndex - 1) !== '\n') {
+    startOfLineIndex--;
+  }
+
+  return startOfLineIndex;
+}


### PR DESCRIPTION
Fixes #560 

Changes Made:
- Added UTs for the scenarios in question
- Updated the logic around moving math block indicators to new lines taking into account the start of the line