### PR TITLE
fix typo in example of heading-blank-lines

### DIFF
--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -93,11 +93,12 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
       }),
       new ExampleBuilder({
         // accounts for https://github.com/platers/obsidian-linter/issues/219
-        description: 'Empty line before header and after Yaml is removed with `Empty Line Between Yaml and Header=true`',
+        description: 'Empty line before header and after Yaml is removed with `Empty Line Between Yaml and Header=false`',
         before: dedent`
           ---
           key: value
           ---
+          
           # Header
           Paragraph here...
         `,

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -98,7 +98,7 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
           ---
           key: value
           ---
-          
+          ${''}
           # Header
           Paragraph here...
         `,


### PR DESCRIPTION
document: https://github.com/platers/obsidian-linter/blob/master/docs/rules.md#heading-blank-lines
related: https://github.com/platers/obsidian-linter/issues/219

> Example: Empty line before header and after Yaml is removed with `Empty Line Between Yaml and Header=true`
> 
> Before:
> ```
> ---
> key: value
> ---
> # Header
> Paragraph here...
> After:
> ```
> 
> ```
> ---
> key: value
> ---
> # Header
> 
> Paragraph here...
> ```

when `Empty Line Between Yaml and Header=true`, it should be 

```
> ---
> key: value
> ---
>
> # Header
> 
> Paragraph here...
``` 

only when `Empty Line Between Yaml and Header=false`, it is 

```
> ---
> key: value
> ---
> # Header
> 
> Paragraph here...
``` 

In addition, a blank line has been added after the YAML in `before` to better illustrate that the blank line between the YAML and the title will be removed when `Empty Line Between Yaml and Header=false`.
