### PR TITLE
Refactor Logic Around Blank Line Being Put Around Content

### DIFF
--- a/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
+++ b/__tests__/make-sure-content-has-empty-lines-added-before-and-after.test.ts
@@ -29,7 +29,7 @@ const testCases: EmptyStringBeforeAndAfterTestCase[] = [
   },
   {
     testName: 'Content with multiple empty lines before it should have one added before and after',
-    isForBlockquote: false,
+    startOfContent: 13,
     endOfContent: 29,
     before: dedent`
       # Header

--- a/__tests__/move-math-block-indicators-to-own-line.test.ts
+++ b/__tests__/move-math-block-indicators-to-own-line.test.ts
@@ -19,5 +19,31 @@ ruleTest({
         text here
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/560
+      testName: 'Moving math block indicator to its own line when in a blockquote moves the content to lines with a blockquote indicator at their start for inline math',
+      before: dedent`
+        > $$math$$
+      `,
+      after: dedent`
+        > $$
+        > math
+        > $$
+      `,
+    },
+    {
+      testName: 'Moving math block indicator to its own line when in a blockquote moves the content to lines with a blockquote indicator at their start for math block',
+      before: dedent`
+        > $$
+        > \\boldsymbol{a}=\\begin{bmatrix}a_x \\\\ a_y\\end{bmatrix}$$
+        text here
+      `,
+      after: dedent`
+        > $$
+        > \\boldsymbol{a}=\\begin{bmatrix}a_x \\\\ a_y\\end{bmatrix}
+        > $$
+        text here
+      `,
+    },
+
   ],
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -431,7 +431,7 @@ export default class LinterPlugin extends Plugin {
       if (useLogTemplateInNotice) {
         new Notice(`${errorMessage} ${error.message}.\n${seeConsoleText}`);
       } else {
-        new Notice(`${error.message}.\nS${seeConsoleText}`);
+        new Notice(`${error.message}.\n${seeConsoleText}`);
       }
     } else {
       new Notice(`${getTextInLanguage('logs.unknown-error')} ${seeConsoleText}`);

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -7,7 +7,7 @@ import {parseTextToHTMLWithoutOuterParagraph} from 'src/ui/helpers';
 import {logsFromLastRun, setLogLevel} from 'src/utils/logger';
 import {getTextInLanguage, LanguageStringKey} from 'src/lang/helpers';
 
-const logLevels = Object.keys(log.levels) as LanguageStringKey[];
+const logLevels = Object.keys(log.levels) as string[];
 const logLevelInts = Object.values(log.levels);
 
 export class DebugTab extends Tab {
@@ -25,7 +25,7 @@ export class DebugTab extends Tab {
         .setDesc(settingDesc)
         .addDropdown((dropdown) => {
           logLevels.forEach((logLevel, index) => {
-            dropdown.addOption(logLevelInts[index], getTextInLanguage(logLevel));
+            dropdown.addOption(logLevelInts[index], getTextInLanguage('enums.' + logLevel as LanguageStringKey));
           });
           // set value only takes strings so I have to cast the log level to type string in order to get it to work properly
           dropdown.setValue(this.plugin.settings.logLevel + '');

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -157,3 +157,16 @@ export function convertStringVersionOfEscapeCharactersToEscapeCharacters(val: st
 
   return val;
 }
+
+export function getStartOfLineIndex(text: string, indexToStartFrom: number): number {
+  if (indexToStartFrom < 2) {
+    return indexToStartFrom;
+  }
+
+  let startOfLineIndex = indexToStartFrom;
+  while (startOfLineIndex > 0 && text.charAt(startOfLineIndex - 1) !== '\n') {
+    startOfLineIndex--;
+  }
+
+  return startOfLineIndex;
+}


### PR DESCRIPTION
This makes the empty line around content logic more robust and reusable.

Changes Made:
- Converted the logic over to get the start of the line ignoring non-whitespace and greater than characters (>)
- Made sure the logic would decide which empty line value to use when blockquotes were involved to make things more uniform
- Updated several examples to show the change in logic