### PR TITLE
Fix for Removing First/Last Hyphen for YAML Frontmatter on Paste

### DIFF
--- a/__tests__/remove-hyphens-on-paste.test.ts
+++ b/__tests__/remove-hyphens-on-paste.test.ts
@@ -1,0 +1,38 @@
+import RemoveHyphensOnPaste from '../src/rules/remove-hyphens-on-paste';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: RemoveHyphensOnPaste,
+  testCases: [
+    { // accounts for https://github.com/platers/obsidian-linter/issues/653
+      testName: 'Make sure that hyphenated line breaks does not apply to YAML frontmatter on paste',
+      before: dedent`
+        ---
+        created: "2023-03-17"
+        aliases: []
+        source: 
+        tags: []
+        updated: "2023-03-17T11:51:50-0400"
+        ---
+        # Hello world
+        ${''}
+        Paragraph contents are here- [link text](pathToFile/file.md)
+        Paragraph contents are here- [[file]]
+      `,
+      after: dedent`
+        ---
+        created: "2023-03-17"
+        aliases: []
+        source: 
+        tags: []
+        updated: "2023-03-17T11:51:50-0400"
+        ---
+        # Hello world
+        ${''}
+        Paragraph contents are here- [link text](pathToFile/file.md)
+        Paragraph contents are here- [[file]]
+      `,
+    },
+  ],
+});

--- a/src/rules/remove-hyphens-on-paste.ts
+++ b/src/rules/remove-hyphens-on-paste.ts
@@ -18,7 +18,7 @@ export default class RemoveHyphensOnPaste extends RuleBuilder<RemoveHyphensOnPas
     return RemoveHyphensOnPasteOptions;
   }
   apply(text: string, options: RemoveHyphensOnPasteOptions): string {
-    return text.replace(/(\S)[-‐]\s+\n?(?=\w)/g, '$1');
+    return text.replace(/([^\s-])[-‐]\s+\n?(?=\w)/g, '$1');
   }
   get exampleBuilders(): ExampleBuilder<RemoveHyphensOnPasteOptions>[] {
     return [


### PR DESCRIPTION
Fixes #653 

Changes Made:
- Made sure that when removing hyphens it does not affect a hyphen then another hyphen
- Added a UT for the scenario in question