### PR TITLE
Fixed a Test and Made Paragraph Blank Lines Ignore Lines Starting with '>'

### DIFF
--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -125,19 +125,34 @@ ruleTest({
         > blockquote line 2
       `,
     },
-    {
-      testName: 'Make sure lists are not affected',
+    { // accounts for https://github.com/platers/obsidian-linter/issues/669
+      testName: 'Make sure blockquotes that have a value starting with the blockquote indicator and no whitespace after are not affected',
       before: dedent`
         # Hello world
         ${''}
         > blockquote
-        > blockquote line 2
+        >blockquote line 2
       `,
       after: dedent`
         # Hello world
         ${''}
         > blockquote
-        > blockquote line 2
+        >blockquote line 2
+      `,
+    },
+    {
+      testName: 'Make sure lists are not affected',
+      before: dedent`
+        # Hello world
+        ${''}
+        - List item 1
+        - List item 2
+      `,
+      after: dedent`
+        # Hello world
+        ${''}
+        - List item 1
+        - List item 2
       `,
     },
     {

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -250,7 +250,7 @@ export function makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs(text: st
 
     // exclude list items and blockquotes
     const firstLine = paragraphLines[0].trimStart();
-    if (firstLine.startsWith('> ') || firstLine.startsWith('>\t') || firstLine.startsWith('- ') || firstLine.startsWith('-\t') ||
+    if (firstLine.startsWith('>') || firstLine.startsWith('- ') || firstLine.startsWith('-\t') ||
       firstLine.match(/^[0-9]+\.( |\t)+/)) {
       continue;
     }


### PR DESCRIPTION
Fixes #669 

Changes Made:
- Fixed a test that was just copied and pasted without changing the logic
- Added a test for the scenario where you have a blockquote indicator followed by a character instead of whtiespace
- Updated the logic in paragraph blank lines in order to make sure it ignores a line that starts with '>'