### PR TITLE
Swap Re-Index from a Merged File Use Case to a Just Re-Index Use Case

### DIFF
--- a/__tests__/re-index-footnotes.test.ts
+++ b/__tests__/re-index-footnotes.test.ts
@@ -14,6 +14,35 @@ ruleTest({
         \`h[^ae]llo\`
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/359
+      testName: 'Out of order references are sorted into their proper our based on the order in which they first appear in the file',
+      before: dedent`
+        aaaaaa[^1]
+        cccccc[^3]
+        ddddd[^4]
+        bbbbb[^2]
+        fffffff[^5]
+        ${''}
+        [^1]: a-footnote
+        [^2]: b-footnote
+        [^3]: c-footnote
+        [^4]: d-footnote
+        [^5]: f-footnote
+      `,
+      after: dedent`
+        aaaaaa[^1]
+        cccccc[^2]
+        ddddd[^3]
+        bbbbb[^4]
+        fffffff[^5]
+        ${''}
+        [^1]: a-footnote
+        [^2]: c-footnote
+        [^3]: d-footnote
+        [^4]: b-footnote
+        [^5]: f-footnote
+      `,
+    },
   ],
 });
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -77,6 +77,7 @@ export default {
 
     // mdast.ts
     'missing-footnote-error-message': `Footnote '{FOOTNOTE}' has no corresponding footnote reference before the footnote contents and cannot be processed. Please make sure that all footnotes have a corresponding reference before the content of the footnote.`,
+    'too-many-footnotes-error-message': `Footnote key '{FOOTNOTE_KEY}' has more than 1 footnote referencing it. Please update the footnotes so that there is only one footnote per footnote key.`,
 
     // rules.ts
     'wrapper-yaml-error': 'error in the yaml: {ERROR_MESSAGE}',
@@ -465,7 +466,7 @@ export default {
     // re-index-footnotes.ts
     're-index-footnotes': {
       'name': 'Re-Index Footnotes',
-      'description': 'Re-indexes footnote keys and footnote, based on the order of occurrence (NOTE: This rule deliberately does *not* preserve the relation between key and footnote, to be able to re-index duplicate keys.)',
+      'description': 'Re-indexes footnote keys and footnote, based on the order of occurrence (NOTE: This rule does *not* work if there is more than one footnote for a key.)',
     },
     // remove-consecutive-list-markers.ts
     'remove-consecutive-list-markers': {

--- a/src/rules/re-index-footnotes.ts
+++ b/src/rules/re-index-footnotes.ts
@@ -72,6 +72,21 @@ export default class ReIndexFootnotes extends RuleBuilder<ReIndexFootnotesOption
           [^3]: second footnotes
         `,
       }),
+      new ExampleBuilder({ // accounts for https://github.com/platers/obsidian-linter/issues/466
+        description: 'Re-indexing footnotes condense duplicate footnotes into 1 when key and footnote are the same',
+        before: dedent`
+          bla[^1], bla[^1], bla[^2]
+          [^1]: bla
+          [^1]: bla
+          [^2]: bla
+        `,
+        after: dedent`
+          bla[^1], bla[^1], bla[^2]
+          ${''}
+          [^1]: bla
+          [^2]: bla
+        `,
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<ReIndexFootnotesOptions>[] {

--- a/src/rules/re-index-footnotes.ts
+++ b/src/rules/re-index-footnotes.ts
@@ -2,6 +2,7 @@ import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {reIndexFootnotes} from '../utils/mdast';
 
 class ReIndexFootnotesOptions implements Options {}
 
@@ -18,23 +19,7 @@ export default class ReIndexFootnotes extends RuleBuilder<ReIndexFootnotesOption
     return ReIndexFootnotesOptions;
   }
   apply(text: string, options: ReIndexFootnotesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      // re-index footnote-text
-      let ft_index = 0;
-      text = text.replace(/^\[\^\w+\]: /gm, function() {
-        ft_index++;
-        return '[^' + String(ft_index) + ']: ';
-      });
-
-      // re-index footnote-keys
-      // regex uses hack to treat lookahead as lookaround https://stackoverflow.com/a/43232659
-      ft_index = 0;
-      text = text.replace(/(?!^)\[\^\w+\]/gm, function() {
-        ft_index++;
-        return '[^' + String(ft_index) + ']';
-      });
-      return text;
-    });
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, reIndexFootnotes);
   }
   get exampleBuilders(): ExampleBuilder<ReIndexFootnotesOptions>[] {
     return [
@@ -71,18 +56,20 @@ export default class ReIndexFootnotes extends RuleBuilder<ReIndexFootnotesOption
         `,
       }),
       new ExampleBuilder({
-        description: 'Re-indexing duplicate footnote keys',
+        description: 'Re-indexing footnotes preserves multiple references to the same footnote index',
         before: dedent`
-          Lorem ipsum at aliquet felis.[^1] Donec dictum turpis quis pellentesque,[^1] et iaculis tortor condimentum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.[^1] Aenean at aliquet felis. Donec dictum turpis quis ipsum pellentesque, et iaculis tortor condimentum.[^1a] Vestibulum nec blandit felis, vulputate finibus purus.[^2] Praesent quis iaculis diam.[^1]
           ${''}
           [^1]: first footnote
-          [^1]: second footnote
+          [^1a]: third footnote, inserted later
+          [^2]: second footnotes
         `,
         after: dedent`
-          Lorem ipsum at aliquet felis.[^1] Donec dictum turpis quis pellentesque,[^2] et iaculis tortor condimentum.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.[^1] Aenean at aliquet felis. Donec dictum turpis quis ipsum pellentesque, et iaculis tortor condimentum.[^2] Vestibulum nec blandit felis, vulputate finibus purus.[^3] Praesent quis iaculis diam.[^1]
           ${''}
           [^1]: first footnote
-          [^2]: second footnote
+          [^2]: third footnote, inserted later
+          [^3]: second footnotes
         `,
       }),
     ];

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -146,21 +146,20 @@ export function moveFootnotesToEnd(text: string) {
     footnoteKeyToFootnoteKeyInfo.set(footnoteReference, keyInfo);
   };
 
-  text = removeFootnotesAndDoActionForEachFootnote(positions, text, footnotes, getAllReferencePositionsForFootnote);
-  // for (const position of positions) {
-  //   const footnote = text.substring(position.start.offset, position.end.offset);
-  //   footnotes.push(footnote);
-  //   // Remove the newline after the footnote if it exists
-  //   if (position.end.offset < text.length && text[position.end.offset] === '\n') {
-  //     text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
-  //   }
-  //   // Remove the newline after the footnote if it exists
-  //   if (position.end.offset < text.length && text[position.end.offset] === '\n') {
-  //     text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
-  //   }
-  //   text = text.substring(0, position.start.offset) + text.substring(position.end.offset);
-  //   getAllReferencePositionsForFootnote(footnote, position.start.offset);
-  // }
+  for (const position of positions) {
+    const footnote = text.substring(position.start.offset, position.end.offset);
+    footnotes.push(footnote);
+    // Remove the newline after the footnote if it exists
+    if (position.end.offset < text.length && text[position.end.offset] === '\n') {
+      text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
+    }
+    // Remove the newline after the footnote if it exists
+    if (position.end.offset < text.length && text[position.end.offset] === '\n') {
+      text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
+    }
+    text = text.substring(0, position.start.offset) + text.substring(position.end.offset);
+    getAllReferencePositionsForFootnote(footnote, position.start.offset);
+  }
 
   for (const footnoteData of footnoteKeyToFootnoteKeyInfo) {
     const keyInfo = footnoteData[1];
@@ -240,9 +239,20 @@ export function reIndexFootnotes(text: string) {
     return firstFootnoteReferenceIndex;
   };
 
-  text = removeFootnotesAndDoActionForEachFootnote(positions, text, footnotes, (footnote: string, startOfFootnoteReferenceSearch: number): void => {
-    mapOfFootnoteToFirstFootnoteReferenceIndex.set(footnote, getFirstReferenceToFootnote(footnote, startOfFootnoteReferenceSearch));
-  });
+  for (const position of positions) {
+    const footnote = text.substring(position.start.offset, position.end.offset);
+    footnotes.push(footnote);
+    // Remove the newline after the footnote if it exists
+    if (position.end.offset < text.length && text[position.end.offset] === '\n') {
+      text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
+    }
+    // Remove the newline after the footnote if it exists
+    if (position.end.offset < text.length && text[position.end.offset] === '\n') {
+      text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
+    }
+    text = text.substring(0, position.start.offset) + text.substring(position.end.offset);
+    mapOfFootnoteToFirstFootnoteReferenceIndex.set(footnote, getFirstReferenceToFootnote(footnote, position.start.offset));
+  }
 
   // Sort the footnotes into the order of their references in the text
   footnotes = footnotes.sort((f1: string, f2: string) => {
@@ -272,26 +282,6 @@ export function reIndexFootnotes(text: string) {
     const newFootnoteKey = oldKeyToNewKey.get(footnoteReference.key);
 
     text = replaceAt(text, footnoteReference.key, newFootnoteKey, footnoteReference.position);
-  }
-
-  return text;
-}
-
-function removeFootnotesAndDoActionForEachFootnote(positions: Position[], text: string, footnotes: string[], action: (footnote: string, startOfFootnoteReferenceSearch: number) => void) {
-  for (const position of positions) {
-    const footnote = text.substring(position.start.offset, position.end.offset);
-    footnotes.push(footnote);
-    // Remove the newline after the footnote if it exists
-    if (position.end.offset < text.length && text[position.end.offset] === '\n') {
-      text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
-    }
-    // Remove the newline after the footnote if it exists
-    if (position.end.offset < text.length && text[position.end.offset] === '\n') {
-      text = text.substring(0, position.end.offset) + text.substring(position.end.offset + 1);
-    }
-    text = text.substring(0, position.start.offset) + text.substring(position.end.offset);
-    action(footnote, position.start.offset);
-    // mapOfFootnoteToFirstFootnoteReferenceIndex.set(footnote, action(footnote, position.start.offset));
   }
 
   return text;

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -283,3 +283,20 @@ export function getStartOfLineIndex(text: string, indexToStartFrom: number): num
 
   return startOfLineIndex;
 }
+
+/**
+ * Replace the first instance of the matching search string in the text after the provided starting position.
+ * @param {string} text - The text in which to do the find and replace given the starting position.
+ * @param {string} search - The text to search for and replace in the provided string.
+ * @param {string} replace - The text to replace the search text with in the provided string.
+ * @param {number} start - The position to start the replace search at.
+ * @return {string} The new string after replacing the value if found.
+ */
+export function replaceAt(text: string, search: string, replace: string, start: number): string {
+  if (start > text.length - 1) {
+    return text;
+  }
+
+  return text.slice(0, start) +
+      text.slice(start, text.length).replace(search, replace);
+}


### PR DESCRIPTION
Fixes #625 
Fixes #359 
Fixes #466 

The rule for re-indexing footnotes was originally added for the purpose of merging two files and then de-duping the footnotes that had the same key in a 1 to 1 manner. However there is a desire to move the logic over to a 1 to many option where there is 1 footnote for many keys. This allows for preserving the footnote to key relationship while also making things a little clearer as to how they work.

Changes Made:
- Added a couple of tests for the scenarios provided on the relevant FRs and Bug report
- Updated the wording of the re-index rule to make it clear that the functionality has changed
- Updated the logic of re-index to re-order the footnotes and de-dupe footnotes based on the content in the files
- Made sure to throw an error if there was more than 1 distinct footnote for a key since that makes it really hard to know which footnote goes with which key(s)
- Removed a test that no longer makes sense and updated another to make it clear that multiple footnote keys are now allowed
- Fixed a variable typo
- Updated the logic to have another strings helper for replacing a value starting at a particular index in a string since that was needed for proper indexing in this case