### PR TITLE
Fix Erroneous Empty Line Added to Math Block End in Callout/Blockquote

### DIFF
--- a/__tests__/move-math-block-indicators-to-own-line.test.ts
+++ b/__tests__/move-math-block-indicators-to-own-line.test.ts
@@ -44,6 +44,20 @@ ruleTest({
         text here
       `,
     },
-
+    { // accounts for an issue noticed when looking at https://github.com/platers/obsidian-linter/issues/597
+      testName: 'Math block in blockquote/callout should not get an empty blockquote line added',
+      before: dedent`
+        > [!note]
+        > $$
+        > \\frac{1}{2}
+        > $$
+      `,
+      after: dedent`
+        > [!note]
+        > $$
+        > \\frac{1}{2}
+        > $$
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -717,6 +717,8 @@ export function makeSureMathBlockIndicatorsAreOnTheirOwnLines(text: string, numb
 
 function addBlankLinesAroundStartAndStopMathIndicators(text: string, mathBlockStartIndex: number, mathBlockEndIndex: number, mathOpeningIndicatorRegex: RegExp, mathEndingIndicatorRegex: RegExp): string {
   const startOfLine = text.substring(getStartOfLineIndex(text, mathBlockStartIndex), mathBlockStartIndex) ?? '';
+  const startOfEndingLine = text.substring(getStartOfLineIndex(text, mathBlockEndIndex), mathBlockEndIndex) ?? '';
+  const emptyLineBlockquoteRegex = /^(>( |\t)*)+\$+$/m;
   let mathBlock = text.substring(mathBlockStartIndex, mathBlockEndIndex);
   mathBlock = mathBlock.replace(mathOpeningIndicatorRegex, (_: string, $1: string, $2: string = '') => {
     // a new line is being added
@@ -726,9 +728,13 @@ function addBlankLinesAroundStartAndStopMathIndicators(text: string, mathBlockSt
 
     return $1 + '\n';
   });
-  mathBlock= mathBlock.replace(mathEndingIndicatorRegex, (_: string, $1: string = '', $2: string, $3: string) => {
-    // a new line is being added
-    if ($1 === '') {
+  mathBlock= mathBlock.replace(mathEndingIndicatorRegex, (match: string, $1: string = '', $2: string, $3: string) => {
+    const groupOneIsEmpty = $1 === '';
+
+    // make sure that a blank blockquote line is checked for in order to determine if a change needs to happen just for blockquotes
+    if (groupOneIsEmpty && emptyLineBlockquoteRegex.test(startOfEndingLine.trim())) {
+      return match;
+    } else if (groupOneIsEmpty) { // a new line is being added
       return '\n' + startOfLine + $2 + $3;
     }
 


### PR DESCRIPTION
Relates to #597 

Changes Made:
- Added a test for a scenario I found where a blank line was always being added for a blockqupte/callout that had a math block in it
- Updated the logic in the ending math block check to make sure that if math block is in a blockquote/callout then it should only add a blank line if the start of the ending line is not just the blockquote indicators and then the math block indicators