### PR TITLE
Make Sure that Wiki Images with Alt and Size Specified Are Ignored for CJK and English Character Spaces

### DIFF
--- a/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
+++ b/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
@@ -113,5 +113,14 @@ ruleTest({
         <u>自己想说的</u>
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/681
+      testName: 'Make sure that wiki links with their size specified are unaffected',
+      before: dedent`
+        ![[流浪地球-1.webp|image title|600]]
+      `,
+      after: dedent`
+        ![[流浪地球-1.webp|image title|600]]
+      `,
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -10,7 +10,7 @@ export const tildeBlockRegexTemplate = fencedRegexTemplate.replaceAll('X', '~');
 export const indentedBlockRegex = '^((\t|( {4})).*\n)+';
 export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeBlockRegexTemplate}|${indentedBlockRegex}`, 'gm');
 // based on https://stackoverflow.com/a/26010910/8353749
-export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?\]{2}/g;
+export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|]+))?\]{2}/g;
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
 export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+]+)/g;


### PR DESCRIPTION
Fixes #681 

Changes Made:
- Allowed the regex for wiki links to include an option for size as well
- Added a UT for the scenario in question