### PR TITLE
Fix Linter Setting Tab Headers not Respecting Selected Language

### DIFF
--- a/src/ui/linter-components/tab-components/tab.ts
+++ b/src/ui/linter-components/tab-components/tab.ts
@@ -51,12 +51,14 @@ export abstract class Tab {
 
     this.navButton.addClass(tabClass);
     setIcon(this.navButton.createSpan({cls: 'linter-navigation-item-icon'}), tabNameToTabIconId[name], 20);
-    this.navButton.createSpan().setText(name);
+
+    const nameInLanguage = getTextInLanguage(tabNameToTextKey[name]);
+    this.navButton.createSpan().setText(nameInLanguage);
 
     this.contentEl = settingsEl.createDiv('linter-tab-settings');
     this.contentEl.id = name.toLowerCase().replace(' ', '-');
 
-    this.headingEl = this.contentEl.createEl('h2', {text: getTextInLanguage(tabNameToTextKey[name])});
+    this.headingEl = this.contentEl.createEl('h2', {text: nameInLanguage});
     hideEl(this.headingEl);
   }
 


### PR DESCRIPTION
The Linter was not respecting the selected language for the tab header buttons in the settings panel. To fix this, I just grabbed the translated text before adding the text to the button.