### PR TITLE
Better Table Parsing

### DIFF
--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -1,0 +1,206 @@
+import {getAllTablesInText} from '../src/utils/mdast';
+import dedent from 'ts-dedent';
+
+type tablesInTextTestCase = {
+  name: string,
+  text: string,
+  expectedTablesInText: number,
+  expectedPositions: {startIndex:number, endIndex: number}[]
+};
+
+const getTablesInTextTestCases: tablesInTextTestCase[] = [
+  {
+    name: 'matches simple table',
+    text: dedent`
+      Here is some text
+      | column1 | column2 |
+      | ------- | ------- |
+      | data1   | data2   |
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 83}],
+  },
+  {
+    name: 'matches empty table as a single table',
+    text: dedent`
+      Here is some text
+      |||
+      |-|-|
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 27}],
+  },
+  {
+    name: 'does not get a table where the header and delimiter have a different cell count',
+    text: dedent`
+      Here is some text
+      |||
+      |-|-|-|
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'matches table where delimiter has all pipes while the header is missing optional pipes',
+    text: dedent`
+      Here is some text
+      heading1|heading2
+      |-|-|
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 41}],
+  },
+  {
+    name: 'matches table where delimiter has some pipes while the header is missing optional pipes',
+    text: dedent`
+      Here is some text
+      heading1|heading2
+      |-|-
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 40}],
+  },
+  {
+    name: 'matches table where there is trailing space at the end of the table header and delimiter',
+    text: dedent`
+      Here is some text
+      |heading1|heading2|${'  '}
+      |-|-|${'  '}
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 47}],
+  },
+  {
+    name: 'matches table that uses the alignment operators (:) in table delimiter',
+    text: dedent`
+      Here is some text
+      |heading1|heading2|heading3|heading4|heading5
+      |:-|-:|-| :----:  |   -${'      '}
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 93}],
+  },
+  {
+    name: 'does not match table with a delimiter row that has an empty cell devoid of any characters',
+    text: dedent`
+      Here is some text
+      heading1|heading2|heading3
+      |:-||-|
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'does not match table with a delimiter row that has a cell at the start or middle that is missing a dash',
+    text: dedent`
+      Here is some text
+      heading1|heading2|heading3
+      |:-| |-|
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'does not match a table without a table header',
+    text: dedent`
+      Here is some text
+      |-|-|-|
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'matches text that precedes a table header when the table only has one column',
+    text: dedent`
+      Here is some text
+      |-|
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 0, endIndex: 21}],
+  },
+  {
+    name: 'does not match table in blockquote that is missing table separator row',
+    text: dedent`
+      > Here is some text
+      > | Looks like a table | Column2 |
+      > | Another | Row |
+      > | One | More |
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'matches a table in blockquote when it has a separator row',
+    text: dedent`
+      > Here is some text
+      > | Looks like a table | Column2 |
+      > | :--- | ----: |
+      > | One | More |
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 22, endIndex: 90}],
+  },
+  {
+    name: 'matches recognizes two separate tables in a blockquote/callout when there is a blank line between them',
+    text: dedent`
+      > Here is some text
+      > | Looks like a table | Column2 |
+      > | :--- | ----: |
+      > | One | More |
+      >
+      > | Header 1 | Header 2 |
+      > | -------- | -------- |
+      > | Text | Text 2 |
+      ${''}
+      Some more text here...
+    `,
+    expectedTablesInText: 2,
+    expectedPositions: [{startIndex: 95, endIndex: 164}, {startIndex: 22, endIndex: 90}],
+  },
+  {
+    name: 'matches two tables with a blank line between them',
+    text: dedent`
+      Here is some text
+      | column1 | column2 |
+      | ------- | ------- |
+      | data1   | data2   |
+      ${''}
+      | column1 | column2 |
+      | ------- | ------- |
+      | data3   | data4   |
+    `,
+    expectedTablesInText: 2,
+    expectedPositions: [{startIndex: 85, endIndex: 150}, {startIndex: 18, endIndex: 83}],
+  },
+  {
+    name: 'matches indented table',
+    text: dedent`
+      Here is some text
+      ${'   '}| column1 | column2 |
+      ${'   '}| ------- | ------- |
+      ${'   '}| data1   | data2   |
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 92}],
+  },
+  {
+    name: 'does not match yaml indicators',
+    text: dedent`
+      ---
+      ---
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
+];
+
+describe('Get All Tables in Text', () => {
+  for (const testCase of getTablesInTextTestCases) {
+    it(testCase.name, () => {
+      const tablePositions = getAllTablesInText(testCase.text);
+
+      expect(tablePositions.length).toEqual(testCase.expectedTablesInText);
+      expect(tablePositions).toEqual(testCase.expectedPositions);
+    });
+  }
+});

--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -192,6 +192,20 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
     expectedTablesInText: 0,
     expectedPositions: [],
   },
+  {
+    name: 'does not match yaml frontmatter',
+    text: dedent`
+      ---
+      date: 06/16/2022
+      type: topic
+      tags: 
+      keywords: []
+      status: WIP
+      ---
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
 ];
 
 describe('Get All Tables in Text', () => {

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -1,5 +1,5 @@
-import {obsidianMultilineCommentRegex, tagWithLeadingWhitespaceRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns, genericLinkRegex, tableRegex, urlRegex, anchorTagRegex} from './regex';
-import {getPositions, MDAstTypes} from './mdast';
+import {obsidianMultilineCommentRegex, tagWithLeadingWhitespaceRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns, genericLinkRegex, urlRegex, anchorTagRegex} from './regex';
+import {getAllTablesInText, getPositions, MDAstTypes} from './mdast';
 import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
 
@@ -23,15 +23,15 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   // RegExp
   yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns('---\n---')},
   wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}'},
-  tag: {replaceAction: replaceTags, placeholder: '#tag-placeholder'},
   obsidianMultiLineComments: {replaceAction: obsidianMultilineCommentRegex, placeholder: '{OBSIDIAN_COMMENT_PLACEHOLDER}'},
-  table: {replaceAction: tableRegex, placeholder: '{TABLE_PLACEHOLDER}'},
+  table: {replaceAction: replaceTables, placeholder: '{TABLE_PLACEHOLDER}'},
   footnoteAtStartOfLine: {replaceAction: /^(\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AT_START_OF_LINE_PLACEHOLDER}'},
   footnoteAfterATask: {replaceAction: /- \[.] (\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AFTER_A_TASK_PLACEHOLDER}'},
   url: {replaceAction: urlRegex, placeholder: '{URL_PLACEHOLDER}'},
   anchorTag: {replaceAction: anchorTagRegex, placeholder: '{ANCHOR_PLACEHOLDER}'},
   // custom functions
   link: {replaceAction: replaceMarkdownLinks, placeholder: '{REGULAR_LINK_PLACEHOLDER}'},
+  tag: {replaceAction: replaceTags, placeholder: '#tag-placeholder'},
 } as const;
 
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
@@ -165,4 +165,18 @@ function replaceTags(text: string, placeholder: string): IgnoreResults {
   });
 
   return {newText: text, replacedValues: replacedValues};
+}
+
+function replaceTables(text: string, tablePlaceholder: string): IgnoreResults {
+  const tablePositions = getAllTablesInText(text);
+
+  const replacedTables: string[] = new Array(tablePositions.length);
+  let index = 0;
+  const length = replacedTables.length;
+  for (const tablePosition of tablePositions) {
+    replacedTables[length - 1 - index++] = text.substring(tablePosition.startIndex, tablePosition.endIndex);
+    text = replaceTextBetweenStartAndEndWithNewValue(text, tablePosition.startIndex, tablePosition.endIndex, tablePlaceholder);
+  }
+
+  return {newText: text, replacedValues: replacedTables};
 }

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -24,7 +24,6 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns('---\n---')},
   wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}'},
   obsidianMultiLineComments: {replaceAction: obsidianMultilineCommentRegex, placeholder: '{OBSIDIAN_COMMENT_PLACEHOLDER}'},
-  table: {replaceAction: replaceTables, placeholder: '{TABLE_PLACEHOLDER}'},
   footnoteAtStartOfLine: {replaceAction: /^(\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AT_START_OF_LINE_PLACEHOLDER}'},
   footnoteAfterATask: {replaceAction: /- \[.] (\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AFTER_A_TASK_PLACEHOLDER}'},
   url: {replaceAction: urlRegex, placeholder: '{URL_PLACEHOLDER}'},
@@ -32,6 +31,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   // custom functions
   link: {replaceAction: replaceMarkdownLinks, placeholder: '{REGULAR_LINK_PLACEHOLDER}'},
   tag: {replaceAction: replaceTags, placeholder: '#tag-placeholder'},
+  table: {replaceAction: replaceTables, placeholder: '{TABLE_PLACEHOLDER}'},
 } as const;
 
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -769,9 +769,9 @@ export function getAllTablesInText(text: string): {startIndex: number, endIndex:
 
     let start = startOfPreviousLine;
     let firstLine = text.substring(startOfPreviousLine, startOfCurrentLine - 1);
-    // if the table header and table separator are 3 dashes before striping any characters,
-    // we are likely dealing with the yaml placeholder or an empty yaml frontmatter, so skip it
-    if (firstLine === '---' && separatorRowMatch === '---') {
+    // if the separator row matches a yaml block indicator and the first line is missing
+    // a pipe, then we must assume that we are dealing with a header or yaml instead of a table
+    if (separatorRowMatch === '---' && !firstLine.includes('|')) {
       continue;
     }
 

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -2,7 +2,7 @@ import {visit} from 'unist-util-visit';
 import type {Position} from 'unist';
 import type {Root} from 'mdast';
 import {hashString53Bit, makeSureContentHasEmptyLinesAddedBeforeAndAfter, replaceTextBetweenStartAndEndWithNewValue, getStartOfLineIndex, replaceAt} from './strings';
-import {genericLinkRegex} from './regex';
+import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe} from './regex';
 import {gfmFootnote} from 'micromark-extension-gfm-footnote';
 import {gfmTaskListItem} from 'micromark-extension-gfm-task-list-item';
 import {combineExtensions} from 'micromark-util-combine-extensions';
@@ -742,4 +742,106 @@ function addBlankLinesAroundStartAndStopMathIndicators(text: string, mathBlockSt
   });
 
   return replaceTextBetweenStartAndEndWithNewValue(text, mathBlockStartIndex, mathBlockEndIndex, mathBlock);
+}
+
+/**
+ * Gets a list of all tables in the provided text and returns a list of starting and ending positions from the
+ * last to first found based on index.
+ * @param {string} text - The text to get the list of table locations from.
+ * @return {{startIndex: number, endIndex: number}[]} An array of start and end indexes of each table found from last to earliest.
+ */
+export function getAllTablesInText(text: string): {startIndex: number, endIndex: number}[] {
+  const regexMatches = [...text.matchAll(tableSeparator)];
+  const positions: {startIndex: number, endIndex: number}[] = [];
+  for (const match of regexMatches) {
+    const startOfCurrentLine = getStartOfLineIndex(text, match.index);
+    if (startOfCurrentLine === 0) {
+      continue;
+    }
+
+    const startOfPreviousLine = getStartOfLineIndex(text, startOfCurrentLine - 1);
+
+    const separatorRowMatch = match[0];
+    const tableRowSeparator = text.substring(startOfCurrentLine, match.index + separatorRowMatch.length);
+    if (isInvalidTableSeparatorRow(tableRowSeparator, separatorRowMatch)) {
+      continue;
+    }
+
+    let start = startOfPreviousLine;
+    let firstLine = text.substring(startOfPreviousLine, startOfCurrentLine - 1);
+    // if the table header and table separator are 3 dashes before striping any characters,
+    // we are likely dealing with the yaml placeholder or an empty yaml frontmatter, so skip it
+    if (firstLine === '---' && separatorRowMatch === '---') {
+      continue;
+    }
+
+    firstLine = firstLine.replace(tableStartingPipe, (match: string)=> {
+      // do nothing if the table only has whitespace or a pipe before it
+      const trimmedMatch = match.trim();
+      if (trimmedMatch === '' || trimmedMatch === '|') {
+        return '';
+      }
+
+      start += match.length - 1;
+
+      return '';
+    });
+    let delimiterLine = separatorRowMatch.replace(tableStartingPipe, '');
+    if (firstLine.endsWith('|')) {
+      firstLine = firstLine.slice(0, -1);
+    }
+
+    if (delimiterLine.endsWith('|')) {
+      delimiterLine = delimiterLine.slice(0, -1);
+    }
+
+    // if the delimiter row and the first row do not have the same amount of cells,
+    // we are not dealing with a table
+    if (firstLine.split('|').length !== delimiterLine.split('|').length) {
+      continue;
+    }
+
+    let end = match.index + match[0].length;
+
+    if (end >= text.length - 1) {
+      positions.push({
+        startIndex: start,
+        endIndex: text.length,
+      });
+
+      continue;
+    }
+
+    const remainingLines = text.substring(end + 1).split('\n');
+    let index = 0;
+    // grab rows as part of the table until empty line or it no longer matches row content
+    while (index < remainingLines.length && tableRow.test(remainingLines[index])) {
+      end += remainingLines[index].length + 1;
+      index++;
+    }
+
+    positions.push({
+      startIndex: start,
+      endIndex: end,
+    });
+  }
+
+  return positions.reverse();
+}
+
+function isInvalidTableSeparatorRow(fullRow: string, separatorMatch: string): boolean {
+  if (fullRow.trim() === '') {
+    return true;
+  }
+
+  // The regex for the separator allows for two back to back pipes in the middle of the row, so we need to filter those results out
+  // since they are not valid
+  if (separatorMatch.includes('||')) {
+    return true;
+  }
+
+  // handle a scenario where the regex fails to work as intended and matches the ending of an invalid table separator
+  // it could contain text or an invalid table cell for the separator
+  const nonSeparatorContent = fullRow.replace(separatorMatch, '');
+  return /[^\s>]/.test(nonSeparatorContent);
 }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -272,7 +272,7 @@ export function convertStringVersionOfEscapeCharactersToEscapeCharacters(val: st
 }
 
 export function getStartOfLineIndex(text: string, indexToStartFrom: number): number {
-  if (indexToStartFrom < 2) {
+  if (indexToStartFrom == 0) {
     return indexToStartFrom;
   }
 


### PR DESCRIPTION
Fixes #652 
Fixes #597 

The regex table parsing logic was a little too complex and could cause performance issues. Thus it was replaced with a different parser that starts by identifying the table separator row and validates that it has no text earlier on the line, that there is an actual line before it, and that all cells in the separator row have at least one dash in it. Then it verifies that the separator row is not three dashes that has a line of text since that is either YAML or a header. Once that is done, it grabs any rows that may exist after the table separator row.

Changes Made:
- Updated the table parsing logic
- Added UTs for the table parsing
- Added a UT for the paragraph blank lines issue