### PR TITLE
Fix minor issue with string replacement in main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -325,7 +325,7 @@ export default class LinterPlugin extends Plugin {
 
     const userClickTimeout = 0;
     if (numberOfErrors === 0) {
-      new Notice(getTextInLanguage('commands.lint-all-files-in-folder.success-message').replace('{NUM}', lintedFiles.toString().replace('{FOLDER_NAME}', folder.name)), userClickTimeout);
+      new Notice(getTextInLanguage('commands.lint-all-files-in-folder.success-message').replace('{NUM}', lintedFiles.toString()).replace('{FOLDER_NAME}', folder.name), userClickTimeout);
     } else {
       const errorMessageText = numberOfErrors === 1 ? getTextInLanguage('commands.lint-all-files-in-folder.message-singular').replace('{NUM}', lintedFiles.toString()).replace('{FOLDER_NAME}', folder.name):
       getTextInLanguage('commands.lint-all-files-in-folder.message-plural').replace('{FILE_COUNT}', lintedFiles.toString()).replace('{FOLDER_NAME}', folder.name).replace('{ERROR_COUNT}', numberOfErrors.toString());


### PR DESCRIPTION
Two of the parentheses in the `runLinterAllFilesInFolder()` function were misplaced, which meant that the string replacement in the success message did not work properly. The notice showed `Linted all x files in {FOLDER_NAME}` – the number was inserted correctly but the folder name wasn't:

![Bildschirmfoto vom 2023-04-23 15-07-48](https://user-images.githubusercontent.com/69049131/233842482-cee137c8-0dae-455d-9642-9fb9748d548a.png)

The other replace() calls seem to be correct.