### PR TITLE
Fix Blockquotes Merging When Blank Blockquote Line Between 2 Blockquotes

### DIFF
--- a/__tests__/empty-line-around-blockquotes.test.ts
+++ b/__tests__/empty-line-around-blockquotes.test.ts
@@ -23,7 +23,7 @@ ruleTest({
       `,
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/668
-      testname: 'Make sure that consecutive blockquotes are not merged when multiple blank lines are between them',
+      testName: 'Make sure that consecutive blockquotes are not merged when multiple blank lines are between them',
       before: dedent`
         > [!quote] title 1
         > the quote 1
@@ -89,6 +89,23 @@ ruleTest({
         > [!quote] Title 3
         > The quote 3
       `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/684
+      testName: 'Make sure that consecutive blockquotes ends with empty blockquote line',
+      before: dedent`
+> [!FAQ] Title
+> 
+${''}
+> [!NOTES] Title
+> Content
+`,
+      after: dedent`
+> [!FAQ] Title
+> 
+
+> [!NOTES] Title
+> Content
+    `,
     },
   ],
 });

--- a/__tests__/empty-line-around-blockquotes.test.ts
+++ b/__tests__/empty-line-around-blockquotes.test.ts
@@ -91,21 +91,40 @@ ruleTest({
       `,
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/684
-      testName: 'Make sure that consecutive blockquotes ends with empty blockquote line',
+      testName: 'Make sure that consecutive blockquotes do not get merged when the first one ends with an empty blockquote line',
       before: dedent`
-> [!FAQ] Title
-> 
-${''}
-> [!NOTES] Title
-> Content
-`,
+        > [!FAQ] Title
+        > 
+        ${''}
+        > [!NOTES] Title
+        > Content
+      `,
       after: dedent`
-> [!FAQ] Title
-> 
-
-> [!NOTES] Title
-> Content
-    `,
+        > [!FAQ] Title
+        > 
+        ${''}
+        > [!NOTES] Title
+        > Content
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/684
+      testName: 'Make sure that consecutive blockquotes do not get merged when the second one starts with an empty blockquote line',
+      before: dedent`
+        > [!FAQ] Title
+        > Content here
+        ${''}
+        >
+        > [!NOTES] Title
+        > Content
+      `,
+      after: dedent`
+        > [!FAQ] Title
+        > Content here
+        ${''}
+        >
+        > [!NOTES] Title
+        > Content
+      `,
     },
   ],
 });

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -248,7 +248,7 @@ export function makeSureContentHasEmptyLinesAddedBeforeAndAfter(text: string, st
   const [startOfLine, startOfLineIndex] = getStartOfLineWhitespaceOrBlockquoteLevel(text, start);
   if (startOfLine.trim() !== '') {
     const newText = makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text, startOfLine, end);
-  
+
     return makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(newText, startOfLine, startOfLineIndex);
   }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -92,21 +92,33 @@ function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockqu
   let index = startOfContent;
   let startOfNewContent = startOfContent;
   let lineNestingLevel = 0;
+  let foundABlankLine = false;
+  let previousChar = '';
   while (index >= 0) {
     const currentChar = text.charAt(index);
     if (currentChar.trim() !== '' && currentChar !== '>') {
       break; // if non-whitespace, non-gt-bracket is encountered, then the line has content
     } else if (currentChar === '>') {
+      // if we go from having a blank line at any point to then having more blockquote content we know we have encountered another blockquote
+      if (foundABlankLine) {
+        break;
+      }
+
       lineNestingLevel++;
     } else if (currentChar === '\n') {
       if (lineNestingLevel === 0 || lineNestingLevel === nestingLevel || (lineNestingLevel + 1) === nestingLevel) {
         startOfNewContent = index;
         lineNestingLevel = 0;
+
+        if (previousChar === '\n') {
+          foundABlankLine = true;
+        }
       } else {
         break;
       }
     }
     index--;
+    previousChar = currentChar;
   }
 
   if (index < 0 || startOfNewContent === 0) {
@@ -116,6 +128,7 @@ function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockqu
   const startingEmptyLines = text.substring(startOfNewContent, startOfContent);
   const startsWithEmptyLine = startingEmptyLines === '\n' || startingEmptyLines.startsWith('\n\n');
   if (startsWithEmptyLine) {
+    console.log('starts with empty line');
     return text.substring(0, startOfNewContent) + '\n' + text.substring(startOfContent);
   }
 
@@ -127,6 +140,7 @@ function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockqu
     priorLine = text.substring(indexOfLastNewLine, startOfNewContent);
   }
 
+  console.log('prior line', priorLine);
   return text.substring(0, startOfNewContent) + getEmptyLine(priorLine) + text.substring(startOfContent);
 }
 
@@ -223,7 +237,7 @@ export function makeSureContentHasEmptyLinesAddedBeforeAndAfter(text: string, st
   const [startOfLine, startOfLineIndex] = getStartOfLineWhitespaceOrBlockquoteLevel(text, start);
   if (startOfLine.trim() !== '') {
     const newText = makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text, startOfLine, end);
-
+    console.log('after end', newText);
     return makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(newText, startOfLine, startOfLineIndex);
   }
 


### PR DESCRIPTION
Fixes #684 

Changes Made:
- When looking at blockquote values prior to it or after it, make sure that a blank line ends the blockquote content search to avoid merging blockquotes.
- Added tests for the scenarios in question