### PR TITLE
Fix Table Matching Logic and Add Paragraph Blank Lines Example

### DIFF
--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -206,6 +206,18 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
     expectedTablesInText: 0,
     expectedPositions: [],
   },
+  {
+    name: 'does not match an empty list indicator with a blank line before it',
+    text: dedent`
+      ## Attendees
+      ${''}
+      - 
+      ${''}
+      ## Agenda
+    `,
+    expectedTablesInText: 0,
+    expectedPositions: [],
+  },
 ];
 
 describe('Get All Tables in Text', () => {

--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -211,7 +211,7 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
     text: dedent`
       ## Attendees
       ${''}
-      - 
+      -${' '}
       ${''}
       ## Agenda
     `,

--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -284,7 +284,7 @@ ruleTest({
       testName: 'Table followed by header should only have 1 line after it',
       before: dedent`
         ### 常量
-
+        ${''}
         |  \`[[Link]]\`         |  A link to the file named "Link"  |
         |:--------------------|:----------------------------------|
         |  \`[[Link]]\`         |  A link to the file named "Link"  |
@@ -293,12 +293,12 @@ ruleTest({
         |  \`{ a: 1, b: 2 }\`   |  An object                        |
         |  \`date()\`           |                                   |
         |  \`dur()\`            |                                   |
-
+        ${''}
         ### 表达式
       `,
       after: dedent`
         ### 常量
-
+        ${''}
         |  \`[[Link]]\`         |  A link to the file named "Link"  |
         |:--------------------|:----------------------------------|
         |  \`[[Link]]\`         |  A link to the file named "Link"  |
@@ -307,8 +307,25 @@ ruleTest({
         |  \`{ a: 1, b: 2 }\`   |  An object                        |
         |  \`date()\`           |                                   |
         |  \`dur()\`            |                                   |
-
+        ${''}
         ### 表达式
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/704
+      testName: 'Make sure that an empty list indicator does not have an extra empty line added around it',
+      before: dedent`
+        ## Attendees
+        ${''}
+        - 
+        ${''}
+        ## Agenda
+      `,
+      after: dedent`
+        ## Attendees
+        ${''}
+        - 
+        ${''}
+        ## Agenda
       `,
     },
   ],

--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -316,14 +316,14 @@ ruleTest({
       before: dedent`
         ## Attendees
         ${''}
-        - 
+        -${' '}
         ${''}
         ## Agenda
       `,
       after: dedent`
         ## Attendees
         ${''}
-        - 
+        -${' '}
         ${''}
         ## Agenda
       `,

--- a/src/rules/paragraph-blank-lines.ts
+++ b/src/rules/paragraph-blank-lines.ts
@@ -38,6 +38,30 @@ export default class ParagraphBlankLines extends RuleBuilder<ParagraphBlankLines
           A paragraph is a line that starts with a letter.
         `,
       }),
+      new ExampleBuilder({
+        description: 'Paragraphs can be extended via the use of 2 or more spaces at the end of a line or line break html',
+        before: dedent`
+          # H1
+          Content${'  '}
+          Paragraph content continued <br>
+          Paragraph content continued once more <br/>
+          Last line of paragraph
+          A new paragraph
+          # H2
+        `,
+        after: dedent`
+          # H1
+          ${''}
+          Content${'  '}
+          Paragraph content continued <br>
+          Paragraph content continued once more <br/>
+          Last line of paragraph
+          ${''}
+          A new paragraph
+          ${''}
+          # H2
+        `,
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<ParagraphBlankLinesOptions>[] {

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -769,9 +769,8 @@ export function getAllTablesInText(text: string): {startIndex: number, endIndex:
 
     let start = startOfPreviousLine;
     let firstLine = text.substring(startOfPreviousLine, startOfCurrentLine - 1);
-    // if the separator row matches a yaml block indicator and the first line is missing
-    // a pipe, then we must assume that we are dealing with a header or yaml instead of a table
-    if (separatorRowMatch === '---' && !firstLine.includes('|')) {
+    // a table must have a pipe in either the header or the separator row
+    if (!separatorRowMatch.includes('|') && !firstLine.includes('|')) {
       continue;
     }
 


### PR DESCRIPTION
Fixes #704 

Changes Made:
- Added UTs for paragraph blank lines and table matching for the scenario with an empty list item proceeded by a blank line
- Updated table recognition of invalid tables to be more generic just checking that the first or second line of the table has a pipe in it otherwise it cannot be a table