### PR TITLE
Add Blockquote Style Rule

### DIFF
--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -719,6 +719,8 @@ export default {
     '-': '-', // leave as is
     '*': '*', // leave as is
     '+': '+', // leave as is
+    'space': 'Raum',
+    'no space': 'kein Platz',
     'None': 'Nichts',
     'Ascending Alphabetical': 'Aufsteigend Alphabetisch',
     'Descending Alphabetical': 'Absteigend Alphabetisch',

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -216,6 +216,15 @@ export default {
       'name': 'Blockquote-Einrückung beim Einfügen hinzufügen',
       'description': 'Fügt Blockzitate zu allen außer der ersten Zeile hinzu, wenn sich der Cursor während des Einfügens in einer Blockquote/Callout-Zeile befindet',
     },
+    // blockquote-style.ts
+    'blockquote-style': {
+      'name': 'Blockquote-Stil',
+      'description': 'Stellt sicher, dass der Blockquote-Stil konsistent ist.',
+      'style': {
+        'name': 'Stil',
+        'description': 'Der für Blockquote-Indikatoren verwendete Stil',
+      },
+    },
     // capitalize-headings.ts
     'capitalize-headings': {
       'name': 'Überschriften groß schreiben',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -216,6 +216,15 @@ export default {
       'name': 'Add Blockquote Indentation on Paste',
       'description': 'Adds blockquotes to all but the first line, when the cursor is in a blockquote/callout line during pasting',
     },
+    // blockquote-style.ts
+    'blockquote-style': {
+      'name': 'Blockquote Style',
+      'description': 'Makes sure the blockquote style is consistent.',
+      'style': {
+        'name': 'Style',
+        'description': 'The style used on blockquote indicators',
+      },
+    },
     // capitalize-headings.ts
     'capitalize-headings': {
       'name': 'Capitalize Headings',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -719,6 +719,8 @@ export default {
     '-': '-', // leave as is
     '*': '*', // leave as is
     '+': '+', // leave as is
+    'space': 'space',
+    'no space': 'no space',
     'None': 'None',
     'Ascending Alphabetical': 'Ascending Alphabetical',
     'Descending Alphabetical': 'Descending Alphabetical',

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -626,6 +626,8 @@ export default {
     '-': '-', // leave as is
     '*': '*', // leave as is
     '+': '+', // leave as is
+    'space': 'espacio',
+    'no space': 'sin espacio',
     'None': 'nada',
     'Ascending Alphabetical': 'Ascendente alfabético',
     'Descending Alphabetical': 'Descendiente alfabético',

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -182,6 +182,14 @@ export default {
       'name': 'Agregar sangría de blockquote en pegar',
       'description': 'Agrega blockquotes a todas menos a la primera línea, cuando el cursor está en una línea blockquote/callout durante el pegado',
     },
+    'blockquote-style': {
+      'name': 'Estilo de cotización en bloque',
+      'description': 'Se asegura de que el estilo de la cita en bloque sea consistente.',
+      'style': {
+        'name': 'Estilo',
+        'description': 'El estilo utilizado en los indicadores de cotización en bloque',
+      },
+    },
     'capitalize-headings': {
       'name': 'Poner mayúsculas en los encabezados',
       'description': 'Los encabezados deben estar formateados con mayúsculas',
@@ -462,7 +470,6 @@ export default {
         'description': 'Otros símbolos para incluir',
       },
     },
-    // remove-space-before-or-after-characters.ts
     'remove-space-before-or-after-characters': {
       'name': 'Quitar el espacio antes o después de los caracteres',
       'description': 'Elimina el espacio antes de los caracteres especificados y después de los caracteres especificados. Tenga en cuenta que esto puede causar problemas con el formato de descuento en algunos casos.',

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -216,6 +216,15 @@ export default {
       'name': '粘贴时添加块引用(blockquote)缩进',
       'description': '在粘贴过程中光标位于块引用/标注行中时，将块引用添加到除第一行以外的所有行',
     },
+    // blockquote-style.ts
+    'blockquote-style': {
+      'name': '块引用样式',
+      'description': '确保块引用样式一致。',
+      'style': {
+        'name': '风格',
+        'description': '块引用指示器上使用的样式',
+      },
+    },
     // capitalize-headings.ts
     'capitalize-headings': {
       'name': '大写标题(Headdings)',

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -719,6 +719,8 @@ export default {
     '-': '-', // leave as is
     '*': '*', // leave as is
     '+': '+', // leave as is
+    'space': '空间',
+    'no space': '没有空间',
     'None': 'None',
     'Ascending Alphabetical': '按字母顺序升序',
     'Descending Alphabetical': '按字母顺序降序',

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -21,6 +21,7 @@ import {LintCommand} from './ui/linter-components/custom-command-option';
 import {convertStringVersionOfEscapeCharactersToEscapeCharacters} from './utils/strings';
 import {getTextInLanguage} from './lang/helpers';
 import CapitalizeHeadings from './rules/capitalize-headings';
+import BlockquoteStyle from './rules/blockquote-style';
 
 export type RunLinterRulesOptions = {
   oldText: string,
@@ -102,6 +103,8 @@ export class RulesRunner {
     const postRuleLogText = getTextInLanguage('logs.post-rules');
     timingBegin(postRuleLogText);
     [newText] = CapitalizeHeadings.applyIfEnabled(newText, runOptions.settings, this.disabledRules);
+
+    [newText] = BlockquoteStyle.applyIfEnabled(newText, runOptions.settings, this.disabledRules);
 
     [newText] = ForceYamlEscape.applyIfEnabled(newText, runOptions.settings, this.disabledRules, {
       defaultEscapeCharacter: runOptions.settings.commonStyles.escapeCharacter,

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -1,0 +1,116 @@
+import {updateBlockquotes} from '../utils/mdast';
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {IgnoreTypes, ignoreListOfTypes} from '../utils/ignore-types';
+
+type BlockquoteStyleValues = 'no space' | 'space';
+
+class BlockquoteStyleOptions implements Options {
+  style: BlockquoteStyleValues = 'space';
+}
+
+@RuleBuilder.register
+export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions> {
+  constructor() {
+    super({
+      nameKey: 'rules.blockquote-style.name',
+      descriptionKey: 'rules.blockquote-style.description',
+      type: RuleType.CONTENT,
+      hasSpecialExecutionOrder: true, // to make sure we run after the other rules to make sure all blockquotes are affected and follow the same style
+    });
+  }
+  get OptionsClass(): new () => BlockquoteStyleOptions {
+    return BlockquoteStyleOptions;
+  }
+  apply(text: string, options: BlockquoteStyleOptions): string {
+    return ignoreListOfTypes([IgnoreTypes.html], text, (text) => {
+      if (options.style === 'space') {
+        return updateBlockquotes(text, this.addSpaceToIndicator);
+      }
+
+      return updateBlockquotes(text, this.removeSpaceFromIndicator);
+    });
+  }
+  removeSpaceFromIndicator(blockquote: string): string {
+    return blockquote.replace(/>( |\t)+/g, '>');
+  }
+  addSpaceToIndicator(blockquote: string): string {
+    // first we add spaces to blockquote indicators that are not followed by a space and then to catch any that were not handled already
+    // we make sure to add a space between any 2 indicators that are side by side
+    return blockquote.replace(/>([^ ])/g, '> $1').replace(/>>/g, '> >');
+  }
+  get exampleBuilders(): ExampleBuilder<BlockquoteStyleOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'When style = `space`, a space is added to blockquotes missing a space after the indicator',
+        before: dedent`
+          >Blockquotes will have a space added if one is not present
+          > Will be left as is.
+          ${''}
+          > Nested blockquotes are also updated
+          >>Nesting levels are handled correctly
+          >> Even when only partially needing updates
+          > >Updated as well
+          >>>>>>> Is handled too
+          > > >>> As well
+          ${''}
+          > <strong>Note that html is not affected in blockquotes</strong>
+        `,
+        after: dedent`
+          > Blockquotes will have a space added if one is not present
+          > Will be left as is.
+          ${''}
+          > Nested blockquotes are also updated
+          > > Nesting levels are handled correctly
+          > > Even when only partially needing updates
+          > > Updated as well
+          > > > > > > > Is handled too
+          > > > > > As well
+          ${''}
+          > <strong>Note that html is not affected in blockquotes</strong>
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'When style = `no space`, spaces are removed after a blockquote indicator',
+        before: dedent`
+          >    Multiple spaces are removed
+          > > Nesting is handled
+          > > > > >  Especially when multiple levels are involved
+          > >>> > Even when partially correct already, it is handled
+        `,
+        after: dedent`
+          >Multiple spaces are removed
+          >>Nesting is handled
+          >>>>>Especially when multiple levels are involved
+          >>>>>Even when partially correct already, it is handled
+        `,
+        options: {
+          style: 'no space',
+        },
+      }),
+
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<BlockquoteStyleOptions>[] {
+    return [
+      new DropdownOptionBuilder<BlockquoteStyleOptions, BlockquoteStyleValues>({
+        OptionsClass: BlockquoteStyleOptions,
+        nameKey: 'rules.blockquote-style.style.name',
+        descriptionKey: 'rules.blockquote-style.style.description',
+        optionsKey: 'style',
+        records: [
+          {
+            value: 'space',
+            description: '> indicator is followed by a space',
+          },
+          {
+            value: 'no space',
+            description: '>indicator is not followed by a space',
+          },
+        ],
+      }),
+
+    ];
+  }
+}

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -708,6 +708,31 @@ export function updateUnorderedListItemIndicators(text: string, unorderedListSty
   return text;
 }
 
+/**
+* Updates all blockquotes in the provided text based on the function provided.
+* @param {string} text - The text to update the blockquotes in.
+* @param {function(text: string): string} func - The operation to run on each blockquote to update them.
+* @return {string} The text with the blockquotes updated based on the provided function.
+*/
+export function updateBlockquotes(text: string, func: (text: string) => string): string {
+  const positions: Position[] = getPositions(MDAstTypes.Blockquote, text);
+  for (const position of positions) {
+    // make sure to shift end to the next new line character just in case blockquotes are nested which can cause changes to move content out of the original position expected
+    let endIndex = position.end.offset;
+    while (endIndex < text.length - 1 && text.charAt(endIndex) !== '\n') {
+      endIndex++;
+    }
+
+    let blockquoteContents = text.substring(position.start.offset, endIndex);
+    blockquoteContents = func(blockquoteContents);
+
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, endIndex, blockquoteContents);
+  }
+
+  return text;
+}
+
+
 export function makeSureMathBlockIndicatorsAreOnTheirOwnLines(text: string, numberOfDollarSignsForMathBlock: number): string {
   let positions: Position[] = getPositions(MDAstTypes.Math, text);
   const mathOpeningIndicatorRegex = new RegExp('^(\\${' + numberOfDollarSignsForMathBlock + ',})(\\n*)');


### PR DESCRIPTION
Fixes #487 
Relates to #32 

Changes Made:
- Added a rule to make sure that blockquotes follow a specific style for their indicators (either no space or a single space)
- Added language support for the new text via Google Translate
- Added a new helper method for updating blockquotes that we should be able to use for other blockquote based changes down the road