### PR TITLE
Fix `YAML Title Alias` Not Escaping Commas

### DIFF
--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1156,5 +1156,62 @@ ruleTest({
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/630
+      testName: 'Make sure alias is escaped when a comma is present and the array style is single-line',
+      before: dedent`
+        ---
+        aliases: [alias1]
+        ---
+        # Header, with comma
+      `,
+      after: dedent`
+        ---
+        aliases: ["Header, with comma", alias1]
+        ---
+        # Header, with comma
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/630
+      testName: 'Make sure alias is escaped when a comma is present and the array style is single string to single-line',
+      before: dedent`
+        ---
+        aliases: alias1
+        ---
+        # Header, with comma
+      `,
+      after: dedent`
+        ---
+        aliases: ["Header, with comma", alias1]
+        ---
+        # Header, with comma
+      `,
+      options: {
+        aliasArrayStyle: SpecialArrayFormats.SingleStringToSingleLine,
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/630
+      testName: 'Make sure alias is escaped when a comma is present and the array style is a comma delimited string',
+      before: dedent`
+        ---
+        aliases: alias1
+        ---
+        # Header, with comma
+      `,
+      after: dedent`
+        ---
+        aliases: "Header, with comma", alias1
+        ---
+        # Header, with comma
+      `,
+      options: {
+        aliasArrayStyle: SpecialArrayFormats.SingleStringCommaDelimited,
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
   ],
 });

--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1213,5 +1213,28 @@ ruleTest({
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
+    { // relates to https://github.com/platers/obsidian-linter/issues/630
+      testName: 'Make sure alias is not escaped when a comma is present and the array style is multi-line',
+      before: dedent`
+        ---
+        aliases:
+          - alias1
+        ---
+        # Header, with comma
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Header, with comma
+          - alias1
+        ---
+        # Header, with comma
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+      },
+    },
+
   ],
 });

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -53,7 +53,8 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
 
     previousTitle = loadYAML(getYamlSectionValue(yaml, LINTER_ALIASES_HELPER_KEY));
 
-    title = escapeStringIfNecessaryAndPossible(title, options.defaultEscapeCharacter);
+    const forceEscape = title.includes(',') && (options.aliasArrayStyle === NormalArrayFormats.SingleLine || options.aliasArrayStyle === SpecialArrayFormats.SingleStringToSingleLine || options.aliasArrayStyle === SpecialArrayFormats.SingleStringCommaDelimited);
+    title = escapeStringIfNecessaryAndPossible(title, options.defaultEscapeCharacter, forceEscape);
     const getNewAliasValue = function(originalValue: string |string[], shouldRemoveTitle: boolean): string |string[] {
       if (originalValue == null) {
         return shouldRemoveTitle ? '' : title;


### PR DESCRIPTION
Fixes #630 

Changes Made:
- Added tests for the scenarios where headers with a comma should be escaped due to comma delimited aliases being used
- Added a test to make sure multi-line arrays were not getting escaped by the new logic as well
- Updated the logic to force the escaping of a value if the title has a comma and the alias style uses commas to delimit the alias list