### PR TITLE
Add Custom Ignore Syntax Similar to Prettier's Syntax

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 node_modules/
 docs.js
 main.js
+translation-helper.js
 .eslintrc.js
 babel.config.js

--- a/__tests__/disabled-rules.test.ts
+++ b/__tests__/disabled-rules.test.ts
@@ -1,66 +1,88 @@
 import dedent from 'ts-dedent';
 import {getDisabledRules, rules} from '../src/rules';
 
-describe('Disabled rules parsing', () => {
-  it('No YAML', () => {
-    const text = dedent`
+type disabledRulesTestCase = {
+  name: string,
+  text: string,
+  expectedDisabledRules: string[],
+};
+
+const disabledRulesTestCases: disabledRulesTestCase[] = [
+  {
+    name: 'when there is no YAML, no rules are disabled',
+    text: dedent`
       Text
-    `;
-    expect(getDisabledRules(text)).toEqual([]);
-  });
-  it('No ignored rules', () => {
-    const text = dedent`
+    `,
+    expectedDisabledRules: [],
+  },
+  {
+    name: 'when there is no YAML key for disabled rules, no rules are disabled',
+    text: dedent`
       ---
-      ---
-      Text
-    `;
-    expect(getDisabledRules(text)).toEqual([]);
-  });
-  it('Ignore one rule', () => {
-    const text = dedent`
-      ---
-      disabled rules: [ yaml-timestamp ]
-      ---
-      Text
-    `;
-    expect(getDisabledRules(text)).toEqual(['yaml-timestamp']);
-  });
-  it('Ignore some rules', () => {
-    const text = dedent`
-      ---
-      random-rule: true
-      disabled rules: [ yaml-timestamp, capitalize-headings ]
       ---
       Text
-    `;
-    expect(getDisabledRules(text)).toEqual(['yaml-timestamp', 'capitalize-headings']);
-  });
-  it('Ignored no rules', () => {
-    const text = dedent`
+    `,
+    expectedDisabledRules: [],
+  },
+  {
+    name: 'when there is no value in YAML key for disabled rules, no rules are disabled',
+    text: dedent`
       ---
       disabled rules:
       ---
       Text
-    `;
-    expect(getDisabledRules(text)).toEqual([]);
-  });
-  it('Ignored all rules', () => {
-    const text = dedent`
+    `,
+    expectedDisabledRules: [],
+  },
+  {
+    name: 'when there is one value in YAML key for disabled rules, that one rules is disabled',
+    text: dedent`
+      ---
+      disabled rules: [ yaml-timestamp ]
+      ---
+      Text
+    `,
+    expectedDisabledRules: ['yaml-timestamp'],
+  },
+  {
+    name: 'when there is more than one value in YAML key for disabled rules, those rules are disabled',
+    text: dedent`
+      ---
+      disabled rules: [ yaml-timestamp, capitalize-headings ]
+      ---
+      Text
+    `,
+    expectedDisabledRules: ['yaml-timestamp', 'capitalize-headings'],
+  },
+  {
+    name: 'when the value in YAML key for disabled rules is "all", all rules are disabled',
+    text: dedent`
       ---
       disabled rules: all
       ---
       Text
-    `;
-    expect(getDisabledRules(text)).toEqual(rules.map((r) => r.alias()));
-  });
-  it('Works with misformatted yamls', () => {
-    const text = dedent`
+    `,
+    expectedDisabledRules: rules.map((r) => r.alias),
+  },
+  {
+    name: 'when the YAML is malformed, no error occurs trying to get disabled rules',
+    text: dedent`
       ---
       tfratfrat
       ${''}
       ${''}
       ---
-    `;
-    expect(getDisabledRules(text)).toEqual([]);
-  });
+    `,
+    expectedDisabledRules: [],
+  },
+];
+
+describe('Disabled rules parsing', () => {
+  for (const testCase of disabledRulesTestCases) {
+    it(testCase.name, () => {
+      const disabledRules = getDisabledRules(testCase.text);
+
+      expect(disabledRules).toEqual(testCase.expectedDisabledRules);
+    });
+  }
 });

--- a/__tests__/get-all-custom-ignore-sections-in-text.test.ts
+++ b/__tests__/get-all-custom-ignore-sections-in-text.test.ts
@@ -22,7 +22,7 @@ const getCustomIgnoreSectionsInTextTestCases: customIgnoresInTextTestCase[] = [
     name: 'when no custom ignore start indicator is present, no positions are returned even if custom ignore end indicator is present',
     text: dedent`
       Here is some text
-      <!-- linter-ignore-end -->
+      <!-- linter-enable -->
       Here is some more text
     `,
     expectedCustomIgnoresInText: 0,
@@ -32,58 +32,58 @@ const getCustomIgnoreSectionsInTextTestCases: customIgnoresInTextTestCase[] = [
     name: 'a simple example of a start and end custom ignore indicator results in the proper start and end positions for the ignore section',
     text: dedent`
       Here is some text
-      <!-- linter-ignore-start -->
+      <!-- linter-disable -->
       This content will be ignored
       So any format put here gets to stay as is
-      <!-- linter-ignore-end -->
+      <!-- linter-enable -->
       More text here...
     `,
     expectedCustomIgnoresInText: 1,
-    expectedPositions: [{startIndex: 18, endIndex: 144}],
+    expectedPositions: [{startIndex: 18, endIndex: 135}],
   },
   {
     name: 'when a custom ignore start indicator is not followed by a custom ignore end indicator in the text, the end is considered to be the end of the text',
     text: dedent`
       Here is some text
-      <!-- linter-ignore-start -->
+      <!-- linter-disable -->
       This content will be ignored
       So any format put here gets to stay as is
       More text here...
     `,
     expectedCustomIgnoresInText: 1,
-    expectedPositions: [{startIndex: 18, endIndex: 134}],
+    expectedPositions: [{startIndex: 18, endIndex: 129}],
   },
   {
     name: 'when a custom ignore start indicator shows up midline, it ignores the part in question',
     text: dedent`
-      Here is some text<!-- linter-ignore-start -->here is some ignored text<!-- linter-ignore-end -->
+      Here is some text<!-- linter-disable -->here is some ignored text<!-- linter-enable -->
       This content will be ignored
       So any format put here gets to stay as is
       More text here...
     `,
     expectedCustomIgnoresInText: 1,
-    expectedPositions: [{startIndex: 17, endIndex: 96}],
+    expectedPositions: [{startIndex: 17, endIndex: 87}],
   },
   {
-    name: 'when a custom ignore start indicator does not follow the exact syntax, it is not counted as existing',
+    name: 'when a custom ignore start indicator does not follow the exact syntax, it is counted as existing when it is a single-line comment',
     text: dedent`
-      Here is some text<!-- linter-ignore-start-->here is some ignored text<!-- linter-ignore-end -->
+      Here is some text<!-- linter-disable-->here is some ignored text<!-------------         linter-enable ------>
       This content will be ignored
       So any format put here gets to stay as is
       More text here...
     `,
-    expectedCustomIgnoresInText: 0,
-    expectedPositions: [],
+    expectedCustomIgnoresInText: 1,
+    expectedPositions: [{startIndex: 17, endIndex: 109}],
   },
   {
     name: 'multiple matches can be returned',
     text: dedent`
-      Here is some text<!-- linter-ignore-start -->here is some ignored text<!-- linter-ignore-end -->
+      Here is some text<!-- linter-disable -->here is some ignored text<!-- linter-enable -->
       This content will be ignored
       So any format put here gets to stay as is
       More text here...
       ${''}
-      <!-- linter-ignore-start -->
+      <!-- linter-disable -->
       We want to ignore the following as we want to preserve its format
         -> level 1
           -> level 1.3
@@ -91,7 +91,7 @@ const getCustomIgnoreSectionsInTextTestCases: customIgnoresInTextTestCase[] = [
       Finish
     `,
     expectedCustomIgnoresInText: 2,
-    expectedPositions: [{startIndex: 17, endIndex: 96}, {startIndex: 187, endIndex: 330}],
+    expectedPositions: [{startIndex: 17, endIndex: 87}, {startIndex: 178, endIndex: 316}],
   },
 ];
 

--- a/__tests__/get-all-custom-ignore-sections-in-text.test.ts
+++ b/__tests__/get-all-custom-ignore-sections-in-text.test.ts
@@ -1,0 +1,107 @@
+import {getAllCustomIgnoreSectionsInText} from '../src/utils/mdast';
+import dedent from 'ts-dedent';
+
+type customIgnoresInTextTestCase = {
+  name: string,
+  text: string,
+  expectedCustomIgnoresInText: number,
+  expectedPositions: {startIndex:number, endIndex: number}[]
+};
+
+const getCustomIgnoreSectionsInTextTestCases: customIgnoresInTextTestCase[] = [
+  {
+    name: 'when no custom ignore start indicator is present, no positions are returned',
+    text: dedent`
+      Here is some text
+      Here is some more text
+    `,
+    expectedCustomIgnoresInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'when no custom ignore start indicator is present, no positions are returned even if custom ignore end indicator is present',
+    text: dedent`
+      Here is some text
+      <!-- linter-ignore-end -->
+      Here is some more text
+    `,
+    expectedCustomIgnoresInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'a simple example of a start and end custom ignore indicator results in the proper start and end positions for the ignore section',
+    text: dedent`
+      Here is some text
+      <!-- linter-ignore-start -->
+      This content will be ignored
+      So any format put here gets to stay as is
+      <!-- linter-ignore-end -->
+      More text here...
+    `,
+    expectedCustomIgnoresInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 144}],
+  },
+  {
+    name: 'when a custom ignore start indicator is not followed by a custom ignore end indicator in the text, the end is considered to be the end of the text',
+    text: dedent`
+      Here is some text
+      <!-- linter-ignore-start -->
+      This content will be ignored
+      So any format put here gets to stay as is
+      More text here...
+    `,
+    expectedCustomIgnoresInText: 1,
+    expectedPositions: [{startIndex: 18, endIndex: 134}],
+  },
+  {
+    name: 'when a custom ignore start indicator shows up midline, it ignores the part in question',
+    text: dedent`
+      Here is some text<!-- linter-ignore-start -->here is some ignored text<!-- linter-ignore-end -->
+      This content will be ignored
+      So any format put here gets to stay as is
+      More text here...
+    `,
+    expectedCustomIgnoresInText: 1,
+    expectedPositions: [{startIndex: 17, endIndex: 96}],
+  },
+  {
+    name: 'when a custom ignore start indicator does not follow the exact syntax, it is not counted as existing',
+    text: dedent`
+      Here is some text<!-- linter-ignore-start-->here is some ignored text<!-- linter-ignore-end -->
+      This content will be ignored
+      So any format put here gets to stay as is
+      More text here...
+    `,
+    expectedCustomIgnoresInText: 0,
+    expectedPositions: [],
+  },
+  {
+    name: 'multiple matches can be returned',
+    text: dedent`
+      Here is some text<!-- linter-ignore-start -->here is some ignored text<!-- linter-ignore-end -->
+      This content will be ignored
+      So any format put here gets to stay as is
+      More text here...
+      ${''}
+      <!-- linter-ignore-start -->
+      We want to ignore the following as we want to preserve its format
+        -> level 1
+          -> level 1.3
+        -> level 2
+      Finish
+    `,
+    expectedCustomIgnoresInText: 2,
+    expectedPositions: [{startIndex: 17, endIndex: 96}, {startIndex: 187, endIndex: 330}],
+  },
+];
+
+describe('Get All Custom Ignore Sections in Text', () => {
+  for (const testCase of getCustomIgnoreSectionsInTextTestCases) {
+    it(testCase.name, () => {
+      const customIgnorePositions = getAllCustomIgnoreSectionsInText(testCase.text);
+
+      expect(customIgnorePositions.length).toEqual(testCase.expectedCustomIgnoresInText);
+      expect(customIgnorePositions).toEqual(testCase.expectedPositions);
+    });
+  }
+});

--- a/docs/templates/readme_template.md
+++ b/docs/templates/readme_template.md
@@ -37,22 +37,21 @@ Add `disabled rules: [ all ]` to the YAML frontmatter of a file to disable all r
 
 #### Range Ignore
 
-If you are looking for a way to disable rules for a specific part of a file, that can be done with a ranged ignore. The syntax for a ranged ignore is `<!-- linter-ignore-start -->` with an optional `<!-- linter-ignore-end -->` where you want the Linter to start back up with its linting.
+If you are looking for a way to disable rules for a specific part of a file, that can be done with a ranged ignore. The syntax for a ranged ignore is `<!-- linter-disable -->` with an optional `<!-- linter-enable -->` where you want the Linter to start back up with its linting.
 Leaving off the ending of a range ignore will assume you want to ignore the file contents from the start of the range ignore to the end of the file. So be careful when not ending a range ignore.
 
 **Do note that this only prevents the values in the range ignore from being linted. It does not prevent whitespace or other additions around the ranged ignore.**
 
 ``` markdown
 Here is some text
-<!-- linter-ignore-start -->
+<!-- linter-disable -->
                           This area will not be formatted
-<!-- linter-ignore-end -->
+<!-- linter-enable -->
 More content goes here...
 ```
 
 Things to note about range ignores:
 - Paste rules are not affected by range ignores as that would require the copied text to have a range ignore in them.
-- You need to use the exact values listed above at this time.
 
 ## Rules
 

--- a/docs/templates/readme_template.md
+++ b/docs/templates/readme_template.md
@@ -21,6 +21,10 @@ When `Lint on save` is toggled on, the plugin will lint the current file on manu
 
 ### Disable rules
 
+#### YAML Frontmatter
+
+If you would like to disable all rules, one rule, or some set of rules for an entire file, you can add a key to the YAML frontmatter of the file. The expected key is `disabled rules`.
+
 ```markdown
 ---
 disabled rules: [capitalize-headings]
@@ -30,6 +34,25 @@ disabled rules: [capitalize-headings]
 Add `disabled rules: [ ... ]` to the YAML frontmatter of a file to disable those rules when linting that file.
 
 Add `disabled rules: [ all ]` to the YAML frontmatter of a file to disable all rules.
+
+#### Range Ignore
+
+If you are looking for a way to disable rules for a specific part of a file, that can be done with a ranged ignore. The syntax for a ranged ignore is `<!-- linter-ignore-start -->` with an optional `<!-- linter-ignore-end -->` where you want the Linter to start back up with its linting.
+Leaving off the ending of a range ignore will assume you want to ignore the file contents from the start of the range ignore to the end of the file. So be careful when not ending a range ignore.
+
+**Do note that this only prevents the values in the range ignore from being linted. It does not prevent whitespace or other additions around the ranged ignore.**
+
+``` markdown
+Here is some text
+<!-- linter-ignore-start -->
+                          This area will not be formatted
+<!-- linter-ignore-end -->
+More content goes here...
+```
+
+Things to note about range ignores:
+- Paste rules are not affected by range ignores as that would require the copied text to have a range ignore in them.
+- You need to use the exact values listed above at this time.
 
 ## Rules
 

--- a/src/rules/_rule-template.ts.txt
+++ b/src/rules/_rule-template.ts.txt
@@ -1,6 +1,9 @@
 // Basic Rule template
 //
-// Simply perform text replace `RuleTemplate` with your rule, e.g. `MyNewRule`
+// Perform text replace `RuleTemplate` with your rule, e.g. `MyNewRule`
+// Then decided on the keys for the rule in the en.ts locale and add those values to it.
+// Once the values are present in the locale file, replace `RULE_NAME_IN_EN_LOCALE_FILE` with the key in the locale file.
+// Then do the same for any properties replacing `PROPERTY_NAME_IN_LOCALE_FILE` with the associated value.
 // And save the file as `my-new-rule.ts`
 
 import {Options, RuleType} from '../rules';
@@ -16,17 +19,15 @@ class RuleTemplateOptions implements Options {
 
 @RuleBuilder.register
 export default class RuleTemplate extends RuleBuilder<RuleTemplateOptions> {
+  constructor() {
+    super({
+      nameKey: 'rules.RULE_NAME_IN_EN_LOCALE_FILE.name',
+      descriptionKey: 'rules.RULE_NAME_IN_EN_LOCALE_FILE.description',
+      type: RuleType.TYPE_HERE,
+    });
+  }
   get OptionsClass(): new () => RuleTemplateOptions {
     return RuleTemplateOptions;
-  }
-  get name(): string {
-    return '{CHOOSE_PROPER_NAME}';
-  }
-  get description(): string {
-    return '{CHOOSE_PROPER_DESCRIPTION}';
-  }
-  get type(): RuleType {
-    return RuleType.CHOOSE_PROPER_TYPE;
   }
   apply(text: string, options: RuleTemplateOptions): string {
     return '{PUT_PROPER_IMPLEMENTATION}';
@@ -48,8 +49,8 @@ export default class RuleTemplate extends RuleBuilder<RuleTemplateOptions> {
     return [
       new TextOptionBuilder({
         OptionsClass: RuleTemplateOptions,
-        name: 'option 1',
-        description: 'description 1',
+        nameKey: 'rules.RULE_NAME_IN_EN_LOCALE_FILE.PROPERTY_NAME_IN_LOCALE_FILE.name',
+        descriptionKey: 'rules.RULE_NAME_IN_EN_LOCALE_FILE.PROPERTY_NAME_IN_LOCALE_FILE.description',
         optionsKey: 'someProperty'
       })
     ];

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -2,7 +2,7 @@ import {updateBlockquotes} from '../utils/mdast';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {IgnoreTypes, ignoreListOfTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 
 type BlockquoteStyleValues = 'no space' | 'space';
 
@@ -18,19 +18,18 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
       descriptionKey: 'rules.blockquote-style.description',
       type: RuleType.CONTENT,
       hasSpecialExecutionOrder: true, // to make sure we run after the other rules to make sure all blockquotes are affected and follow the same style
+      ruleIgnoreTypes: [IgnoreTypes.html],
     });
   }
   get OptionsClass(): new () => BlockquoteStyleOptions {
     return BlockquoteStyleOptions;
   }
   apply(text: string, options: BlockquoteStyleOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.html], text, (text) => {
-      if (options.style === 'space') {
-        return updateBlockquotes(text, this.addSpaceToIndicator);
-      }
+    if (options.style === 'space') {
+      return updateBlockquotes(text, this.addSpaceToIndicator);
+    }
 
-      return updateBlockquotes(text, this.removeSpaceFromIndicator);
-    });
+    return updateBlockquotes(text, this.removeSpaceFromIndicator);
   }
   removeSpaceFromIndicator(blockquote: string): string {
     return blockquote.replace(/>( |\t)+/g, '>');

--- a/src/rules/consecutive-blank-lines.ts
+++ b/src/rules/consecutive-blank-lines.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -12,17 +12,16 @@ export default class ConsecutiveBlankLines extends RuleBuilder<ConsecutiveBlankL
       nameKey: 'rules.consecutive-blank-lines.name',
       descriptionKey: 'rules.consecutive-blank-lines.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => ConsecutiveBlankLinesOptions {
     return ConsecutiveBlankLinesOptions;
   }
   apply(text: string, options: ConsecutiveBlankLinesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      // make sure to account for lines that are purely whitespace as well https://stackoverflow.com/a/3873354/8353749
-      // make sure that the match ends in a newline
-      return text.replace(/(\n([\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?){2,}\n/g, '\n\n');
-    });
+    // make sure to account for lines that are purely whitespace as well https://stackoverflow.com/a/3873354/8353749
+    // make sure that the match ends in a newline
+    return text.replace(/(\n([\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?){2,}\n/g, '\n\n');
   }
   get exampleBuilders(): ExampleBuilder<ConsecutiveBlankLinesOptions>[] {
     return [

--- a/src/rules/convert-bullet-list-markers.ts
+++ b/src/rules/convert-bullet-list-markers.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -12,16 +12,15 @@ export default class ConvertBulletListMarkers extends RuleBuilder<ConvertBulletL
       nameKey: 'rules.convert-bullet-list-markers.name',
       descriptionKey: 'rules.convert-bullet-list-markers.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => ConvertBulletListMarkersOptions {
     return ConvertBulletListMarkersOptions;
   }
   apply(text: string, options: ConvertBulletListMarkersOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      // Convert [•, §] to - if it's the first non space character on the line
-      return text.replace(/^([^\S\n]*)([•§])([^\S\n]*)/gm, '$1-$3');
-    });
+    // Convert [•, §] to - if it's the first non space character on the line
+    return text.replace(/^([^\S\n]*)([•§])([^\S\n]*)/gm, '$1-$3');
   }
   get exampleBuilders(): ExampleBuilder<ConvertBulletListMarkersOptions>[] {
     return [

--- a/src/rules/convert-spaces-to-tabs.ts
+++ b/src/rules/convert-spaces-to-tabs.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, NumberOptionBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -14,24 +14,24 @@ export default class ConvertSpacesToTabs extends RuleBuilder<ConvertSpacesToTabs
       nameKey: 'rules.convert-spaces-to-tabs.name',
       descriptionKey: 'rules.convert-spaces-to-tabs.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => ConvertSpacesToTabsOptions {
     return ConvertSpacesToTabsOptions;
   }
   apply(text: string, options: ConvertSpacesToTabsOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      const tabsize = String(options.tabsize);
-      const tabsize_regex = new RegExp(
-          '^(\t*) {' + String(tabsize) + '}',
-          'gm',
-      );
+    const tabsize = String(options.tabsize);
+    const tabsize_regex = new RegExp(
+        '^(\t*) {' + String(tabsize) + '}',
+        'gm',
+    );
 
-      while (text.match(tabsize_regex) != null) {
-        text = text.replace(tabsize_regex, '$1\t');
-      }
-      return text;
-    });
+    while (text.match(tabsize_regex) != null) {
+      text = text.replace(tabsize_regex, '$1\t');
+    }
+
+    return text;
   }
   get exampleBuilders(): ExampleBuilder<ConvertSpacesToTabsOptions>[] {
     return [

--- a/src/rules/emphasis-style.ts
+++ b/src/rules/emphasis-style.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -17,15 +17,14 @@ export default class EmphasisStyle extends RuleBuilder<EmphasisStyleOptions> {
       nameKey: 'rules.emphasis-style.name',
       descriptionKey: 'rules.emphasis-style.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.math, IgnoreTypes.inlineMath],
     });
   }
   get OptionsClass(): new () => EmphasisStyleOptions {
     return EmphasisStyleOptions;
   }
   apply(text: string, options: EmphasisStyleOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.math, IgnoreTypes.inlineMath], text, (text) => {
-      return makeEmphasisOrBoldConsistent(text, options.style, MDAstTypes.Italics);
-    });
+    return makeEmphasisOrBoldConsistent(text, options.style, MDAstTypes.Italics);
   }
   get exampleBuilders(): ExampleBuilder<EmphasisStyleOptions>[] {
     return [

--- a/src/rules/empty-line-around-math-block.ts
+++ b/src/rules/empty-line-around-math-block.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {IgnoreTypes, ignoreListOfTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {ensureEmptyLinesAroundMathBlock} from '../utils/mdast';
 
 class EmptyLineAroundMathBlockOptions implements Options {
@@ -16,15 +16,14 @@ export default class EmptyLineAroundMathBlock extends RuleBuilder<EmptyLineAroun
       nameKey: 'rules.empty-line-around-math-blocks.name',
       descriptionKey: 'rules.empty-line-around-math-blocks.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.yaml, IgnoreTypes.code],
     });
   }
   get OptionsClass(): new () => EmptyLineAroundMathBlockOptions {
     return EmptyLineAroundMathBlockOptions;
   }
   apply(text: string, options: EmptyLineAroundMathBlockOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.yaml, IgnoreTypes.code], text, (text: string) => {
-      return ensureEmptyLinesAroundMathBlock(text, options.minimumNumberOfDollarSignsToBeAMathBlock);
-    });
+    return ensureEmptyLinesAroundMathBlock(text, options.minimumNumberOfDollarSignsToBeAMathBlock);
   }
   get exampleBuilders(): ExampleBuilder<EmptyLineAroundMathBlockOptions>[] {
     return [

--- a/src/rules/empty-line-around-tables.ts
+++ b/src/rules/empty-line-around-tables.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {IgnoreTypes, ignoreListOfTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {ensureEmptyLinesAroundTables} from '../utils/regex';
 
 class EmptyLineAroundTablesOptions implements Options {}
@@ -13,15 +13,14 @@ export default class EmptyLineAroundTables extends RuleBuilder<EmptyLineAroundTa
       nameKey: 'rules.empty-line-around-tables.name',
       descriptionKey: 'rules.empty-line-around-tables.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.yaml, IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.wikiLink, IgnoreTypes.link],
     });
   }
   get OptionsClass(): new () => EmptyLineAroundTablesOptions {
     return EmptyLineAroundTablesOptions;
   }
   apply(text: string, options: EmptyLineAroundTablesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.yaml, IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.wikiLink, IgnoreTypes.link], text, (text: string) => {
-      return ensureEmptyLinesAroundTables(text);
-    });
+    return ensureEmptyLinesAroundTables(text);
   }
   get exampleBuilders(): ExampleBuilder<EmptyLineAroundTablesOptions>[] {
     return [

--- a/src/rules/file-name-heading.ts
+++ b/src/rules/file-name-heading.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {insert} from '../utils/strings';
 
 class FileNameHeadingOptions implements Options {
@@ -16,32 +16,31 @@ export default class FileNameHeading extends RuleBuilder<FileNameHeadingOptions>
       nameKey: 'rules.file-name-heading.name',
       descriptionKey: 'rules.file-name-heading.description',
       type: RuleType.HEADING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => FileNameHeadingOptions {
     return FileNameHeadingOptions;
   }
   apply(text: string, options: FileNameHeadingOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      // check if there is a H1 heading
-      const hasH1 = text.match(/^#\s.*/m);
-      if (hasH1) {
-        return text;
-      }
+    // check if there is a H1 heading
+    const hasH1 = text.match(/^#\s.*/m);
+    if (hasH1) {
+      return text;
+    }
 
-      const fileName = options.fileName;
-      // insert H1 heading after front matter
-      let yaml_end = text.indexOf('\n---');
-      yaml_end =
+    const fileName = options.fileName;
+    // insert H1 heading after front matter
+    let yaml_end = text.indexOf('\n---');
+    yaml_end =
         yaml_end == -1 || !text.startsWith('---\n') ? 0 : yaml_end + 5;
 
-      let header = `# ${fileName}\n`;
-      if (text.length < yaml_end) {
-        header = '\n' + header;
-      }
+    let header = `# ${fileName}\n`;
+    if (text.length < yaml_end) {
+      header = '\n' + header;
+    }
 
-      return insert(text, yaml_end, header);
-    });
+    return insert(text, yaml_end, header);
   }
   get exampleBuilders(): ExampleBuilder<FileNameHeadingOptions>[] {
     return [

--- a/src/rules/footnote-after-punctuation.ts
+++ b/src/rules/footnote-after-punctuation.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 
 class FootnoteAfterPunctuationOptions implements Options {}
 
@@ -12,15 +12,14 @@ export default class FootnoteAfterPunctuation extends RuleBuilder<FootnoteAfterP
       nameKey: 'rules.footnote-after-punctuation.name',
       descriptionKey: 'rules.footnote-after-punctuation.description',
       type: RuleType.FOOTNOTE,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.footnoteAtStartOfLine, IgnoreTypes.footnoteAfterATask],
     });
   }
   get OptionsClass(): new () => FootnoteAfterPunctuationOptions {
     return FootnoteAfterPunctuationOptions;
   }
   apply(text: string, options: FootnoteAfterPunctuationOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.footnoteAtStartOfLine, IgnoreTypes.footnoteAfterATask], text, (text) => {
-      return text.replace(/(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
-    });
+    return text.replace(/(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
   }
   get exampleBuilders(): ExampleBuilder<FootnoteAfterPunctuationOptions>[] {
     return [

--- a/src/rules/force-yaml-escape.ts
+++ b/src/rules/force-yaml-escape.ts
@@ -16,7 +16,7 @@ export default class ForceYamlEscape extends RuleBuilder<ForceYamlEscapeOptions>
       nameKey: 'rules.force-yaml-escape.name',
       descriptionKey: 'rules.force-yaml-escape.description',
       type: RuleType.YAML,
-      hasSpecialExecutionOrder: true,
+      hasSpecialExecutionOrder: true, // runs before other rules to help cleanup the YAML before it can throw errors on it
     });
   }
   get OptionsClass(): new () => ForceYamlEscapeOptions {

--- a/src/rules/format-tags-in-yaml.ts
+++ b/src/rules/format-tags-in-yaml.ts
@@ -12,7 +12,7 @@ export default class FormatTagsInYaml extends RuleBuilder<FormatTagsInYamlOption
       nameKey: 'rules.format-tags-in-yaml.name',
       descriptionKey: 'rules.format-tags-in-yaml.description',
       type: RuleType.YAML,
-      hasSpecialExecutionOrder: true,
+      hasSpecialExecutionOrder: true, // runs before other rules to help cleanup the YAML before other rules try to have it parsed and hit errors
     });
   }
   get OptionsClass(): new () => FormatTagsInYamlOptions {

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -10,6 +10,7 @@ import {convertAliasValueToStringOrStringArray,
   NormalArrayFormats,
   OBSIDIAN_ALIASES_KEYS,
   OBSIDIAN_TAG_KEYS,
+  QuoteCharacter,
   setYamlSection,
   SpecialArrayFormats,
   splitValueIfSingleOrMultilineArray,
@@ -27,7 +28,7 @@ class FormatYamlArrayOptions implements Options {
   forceSingleLineArrayStyle?: string[] = [];
   forceMultiLineArrayStyle?: string[] = [];
   @RuleBuilder.noSettingControl()
-    defaultEscapeCharacter?: string = '"';
+    defaultEscapeCharacter?: QuoteCharacter = '"';
   @RuleBuilder.noSettingControl()
     removeUnnecessaryEscapeCharsForMultiLineArrays?: boolean = false;
 }

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -16,31 +16,30 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
       nameKey: 'rules.heading-blank-lines.name',
       descriptionKey: 'rules.heading-blank-lines.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink],
     });
   }
   get OptionsClass(): new () => HeadingBlankLinesOptions {
     return HeadingBlankLinesOptions;
   }
   apply(text: string, options: HeadingBlankLinesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink], text, (text) => {
-      if (!options.bottom) {
-        text = text.replace(/(^#+\s.*)\n+/gm, '$1\n'); // trim blank lines after headings
-        text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
-      } else {
-        text = text.replace(/^(#+\s.*)/gm, '\n\n$1\n\n'); // add blank line before and after headings
-        text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
-        text = text.replace(/(^#+\s.*)\n+/gm, '$1\n\n'); // trim blank lines after headings
-      }
+    if (!options.bottom) {
+      text = text.replace(/(^#+\s.*)\n+/gm, '$1\n'); // trim blank lines after headings
+      text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
+    } else {
+      text = text.replace(/^(#+\s.*)/gm, '\n\n$1\n\n'); // add blank line before and after headings
+      text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
+      text = text.replace(/(^#+\s.*)\n+/gm, '$1\n\n'); // trim blank lines after headings
+    }
 
-      text = text.replace(/^\n+(#+\s.*)/, '$1'); // remove blank lines before first heading
-      text = text.replace(/(#+\s.*)\n+$/, '$1'); // remove blank lines after last heading
+    text = text.replace(/^\n+(#+\s.*)/, '$1'); // remove blank lines before first heading
+    text = text.replace(/(#+\s.*)\n+$/, '$1'); // remove blank lines after last heading
 
-      if (!options.emptyLineAfterYaml) {
-        text = text.replace(new RegExp('(' + yamlRegex.source + ')\\n+(#+\\s.*)'), '$1\n$5');
-      }
+    if (!options.emptyLineAfterYaml) {
+      text = text.replace(new RegExp('(' + yamlRegex.source + ')\\n+(#+\\s.*)'), '$1\n$5');
+    }
 
-      return text;
-    });
+    return text;
   }
   get exampleBuilders(): ExampleBuilder<HeadingBlankLinesOptions>[] {
     return [

--- a/src/rules/headings-start-line.ts
+++ b/src/rules/headings-start-line.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {allHeadersRegex} from '../utils/regex';
 
 class HeadingStartLineOptions implements Options {}
@@ -13,16 +13,15 @@ export default class HeadingStartLine extends RuleBuilder<HeadingStartLineOption
       nameKey: 'rules.headings-start-line.name',
       descriptionKey: 'rules.headings-start-line.description',
       type: RuleType.HEADING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml],
     });
   }
   get OptionsClass(): new () => HeadingStartLineOptions {
     return HeadingStartLineOptions;
   }
   apply(text: string, options: HeadingStartLineOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml], text, (text) => {
-      return text.replaceAll(allHeadersRegex, (heading: string) => {
-        return heading.trimStart();
-      });
+    return text.replaceAll(allHeadersRegex, (heading: string) => {
+      return heading.trimStart();
     });
   }
   get exampleBuilders(): ExampleBuilder<HeadingStartLineOptions>[] {

--- a/src/rules/move-footnotes-to-the-bottom.ts
+++ b/src/rules/move-footnotes-to-the-bottom.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {moveFootnotesToEnd} from '../utils/mdast';
 
 class MoveFootnotesToTheBottomOptions implements Options {}
@@ -13,15 +13,14 @@ export default class MoveFootnotesToTheBottom extends RuleBuilder<MoveFootnotesT
       nameKey: 'rules.move-footnotes-to-the-bottom.name',
       descriptionKey: 'rules.move-footnotes-to-the-bottom.description',
       type: RuleType.FOOTNOTE,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml],
     });
   }
   get OptionsClass(): new () => MoveFootnotesToTheBottomOptions {
     return MoveFootnotesToTheBottomOptions;
   }
   apply(text: string, options: MoveFootnotesToTheBottomOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml], text, (text) => {
-      return moveFootnotesToEnd(text);
-    });
+    return moveFootnotesToEnd(text);
   }
   get exampleBuilders(): ExampleBuilder<MoveFootnotesToTheBottomOptions>[] {
     return [

--- a/src/rules/move-math-block-indicators-to-own-line.ts
+++ b/src/rules/move-math-block-indicators-to-own-line.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {makeSureMathBlockIndicatorsAreOnTheirOwnLines} from '../utils/mdast';
 
 class MoveMathBlockIndicatorsToOwnLineOptions implements Options {
@@ -16,15 +16,14 @@ export default class MoveMathBlockIndicatorsToOwnLine extends RuleBuilder<MoveMa
       nameKey: 'rules.move-math-block-indicators-to-their-own-line.name',
       descriptionKey: 'rules.move-math-block-indicators-to-their-own-line.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode],
     });
   }
   get OptionsClass(): new () => MoveMathBlockIndicatorsToOwnLineOptions {
     return MoveMathBlockIndicatorsToOwnLineOptions;
   }
   apply(text: string, options: MoveMathBlockIndicatorsToOwnLineOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode], text, (text) => {
-      return makeSureMathBlockIndicatorsAreOnTheirOwnLines(text, options.minimumNumberOfDollarSignsToBeAMathBlock);
-    });
+    return makeSureMathBlockIndicatorsAreOnTheirOwnLines(text, options.minimumNumberOfDollarSignsToBeAMathBlock);
   }
   get exampleBuilders(): ExampleBuilder<MoveMathBlockIndicatorsToOwnLineOptions>[] {
     return [

--- a/src/rules/no-bare-urls.ts
+++ b/src/rules/no-bare-urls.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {replaceTextBetweenStartAndEndWithNewValue} from '../utils/strings';
 import {urlRegex} from '../utils/regex';
 
@@ -16,58 +16,57 @@ export default class NoBareUrls extends RuleBuilder<NoBareUrlsOptions> {
       nameKey: 'rules.no-bare-urls.name',
       descriptionKey: 'rules.no-bare-urls.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.image, IgnoreTypes.inlineCode, IgnoreTypes.anchorTag],
     });
   }
   get OptionsClass(): new () => NoBareUrlsOptions {
     return NoBareUrlsOptions;
   }
   apply(text: string, options: NoBareUrlsOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.image, IgnoreTypes.inlineCode, IgnoreTypes.anchorTag], text, (text) => {
-      const URLMatches = text.match(urlRegex);
+    const URLMatches = text.match(urlRegex);
 
-      if (!URLMatches) {
-        return text;
-      }
-
-      // make sure you do not match on the same thing more than once by keeping track of the last position you checked up to
-      let startSearch = 0;
-      const numMatches = URLMatches.length;
-      for (let i = 0; i < numMatches; i++) {
-        const urlMatch = URLMatches[i];
-        const urlStart = text.indexOf(urlMatch, startSearch);
-        const urlEnd = urlStart + urlMatch.length;
-
-        const previousChar = urlStart === 0 ? undefined : text.charAt(urlStart - 1);
-        const nextChar = urlEnd >= text.length ? undefined : text.charAt(urlEnd);
-        if (previousChar != undefined && specialCharsToNotEscapeContentsWithin.includes(previousChar) &&
-          nextChar != undefined && specialCharsToNotEscapeContentsWithin.includes(nextChar)) {
-          startSearch = urlStart + urlMatch.length;
-          continue;
-        }
-
-        if (previousChar != undefined && previousChar === '<' && nextChar != undefined && nextChar === '>') {
-          let startOfOpeningChevrons = urlStart - 1;
-          while (startOfOpeningChevrons > 0 && text.charAt(startOfOpeningChevrons-1) === '<') {
-            startOfOpeningChevrons--;
-          }
-
-          let endOfClosingChevrons = urlEnd;
-          while (endOfClosingChevrons < text.length -1 && text.charAt(endOfClosingChevrons+1) === '>') {
-            endOfClosingChevrons++;
-          }
-
-          text = replaceTextBetweenStartAndEndWithNewValue(text, startOfOpeningChevrons, endOfClosingChevrons+1, '<' + urlMatch + '>');
-
-          startSearch = urlStart + urlMatch.length;
-          continue;
-        }
-
-        text = replaceTextBetweenStartAndEndWithNewValue(text, urlStart, urlStart + urlMatch.length, '<' + urlMatch + '>');
-        startSearch = urlStart + urlMatch.length + 2;
-      }
-
+    if (!URLMatches) {
       return text;
-    });
+    }
+
+    // make sure you do not match on the same thing more than once by keeping track of the last position you checked up to
+    let startSearch = 0;
+    const numMatches = URLMatches.length;
+    for (let i = 0; i < numMatches; i++) {
+      const urlMatch = URLMatches[i];
+      const urlStart = text.indexOf(urlMatch, startSearch);
+      const urlEnd = urlStart + urlMatch.length;
+
+      const previousChar = urlStart === 0 ? undefined : text.charAt(urlStart - 1);
+      const nextChar = urlEnd >= text.length ? undefined : text.charAt(urlEnd);
+      if (previousChar != undefined && specialCharsToNotEscapeContentsWithin.includes(previousChar) &&
+          nextChar != undefined && specialCharsToNotEscapeContentsWithin.includes(nextChar)) {
+        startSearch = urlStart + urlMatch.length;
+        continue;
+      }
+
+      if (previousChar != undefined && previousChar === '<' && nextChar != undefined && nextChar === '>') {
+        let startOfOpeningChevrons = urlStart - 1;
+        while (startOfOpeningChevrons > 0 && text.charAt(startOfOpeningChevrons-1) === '<') {
+          startOfOpeningChevrons--;
+        }
+
+        let endOfClosingChevrons = urlEnd;
+        while (endOfClosingChevrons < text.length -1 && text.charAt(endOfClosingChevrons+1) === '>') {
+          endOfClosingChevrons++;
+        }
+
+        text = replaceTextBetweenStartAndEndWithNewValue(text, startOfOpeningChevrons, endOfClosingChevrons+1, '<' + urlMatch + '>');
+
+        startSearch = urlStart + urlMatch.length;
+        continue;
+      }
+
+      text = replaceTextBetweenStartAndEndWithNewValue(text, urlStart, urlStart + urlMatch.length, '<' + urlMatch + '>');
+      startSearch = urlStart + urlMatch.length + 2;
+    }
+
+    return text;
   }
   get exampleBuilders(): ExampleBuilder<NoBareUrlsOptions>[] {
     return [

--- a/src/rules/ordered-list-style.ts
+++ b/src/rules/ordered-list-style.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -16,15 +16,14 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
       nameKey: 'rules.ordered-list-style.name',
       descriptionKey: 'rules.ordered-list-style.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => OrderedListStyleOptions {
     return OrderedListStyleOptions;
   }
   apply(text: string, options: OrderedListStyleOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag], text, (text) => {
-      return updateOrderedListItemIndicators(text, options.numberStyle, options.listEndStyle);
-    });
+    return updateOrderedListItemIndicators(text, options.numberStyle, options.listEndStyle);
   }
   get exampleBuilders(): ExampleBuilder<OrderedListStyleOptions>[] {
     return [

--- a/src/rules/paragraph-blank-lines.ts
+++ b/src/rules/paragraph-blank-lines.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs} from '../utils/mdast';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
@@ -13,13 +13,14 @@ export default class ParagraphBlankLines extends RuleBuilder<ParagraphBlankLines
       nameKey: 'rules.paragraph-blank-lines.name',
       descriptionKey: 'rules.paragraph-blank-lines.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml, IgnoreTypes.table],
     });
   }
   get OptionsClass(): new () => ParagraphBlankLinesOptions {
     return ParagraphBlankLinesOptions;
   }
   apply(text: string, options: ParagraphBlankLinesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml, IgnoreTypes.table], text, makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs);
+    return makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs(text);
   }
   get exampleBuilders(): ExampleBuilder<ParagraphBlankLinesOptions>[] {
     return [

--- a/src/rules/re-index-footnotes.ts
+++ b/src/rules/re-index-footnotes.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {reIndexFootnotes} from '../utils/mdast';
 
 class ReIndexFootnotesOptions implements Options {}
@@ -13,13 +13,14 @@ export default class ReIndexFootnotes extends RuleBuilder<ReIndexFootnotesOption
       nameKey: 'rules.re-index-footnotes.name',
       descriptionKey: 'rules.re-index-footnotes.description',
       type: RuleType.FOOTNOTE,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => ReIndexFootnotesOptions {
     return ReIndexFootnotesOptions;
   }
   apply(text: string, options: ReIndexFootnotesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, reIndexFootnotes);
+    return reIndexFootnotes(text);
   }
   get exampleBuilders(): ExampleBuilder<ReIndexFootnotesOptions>[] {
     return [

--- a/src/rules/remove-consecutive-list-markers.ts
+++ b/src/rules/remove-consecutive-list-markers.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 
 class RemoveConsecutiveListMarkersOptions implements Options {}
 
@@ -12,15 +12,14 @@ export default class RemoveConsecutiveListMarkers extends RuleBuilder<RemoveCons
       nameKey: 'rules.remove-consecutive-list-markers.name',
       descriptionKey: 'rules.remove-consecutive-list-markers.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => RemoveConsecutiveListMarkersOptions {
     return RemoveConsecutiveListMarkersOptions;
   }
   apply(text: string, options: RemoveConsecutiveListMarkersOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      return text.replace(/^([ |\t]*)- - \b/gm, '$1- ');
-    });
+    return text.replace(/^([ |\t]*)- - \b/gm, '$1- ');
   }
   get exampleBuilders(): ExampleBuilder<RemoveConsecutiveListMarkersOptions>[] {
     return [

--- a/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
+++ b/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -12,49 +12,47 @@ export default class RemoveEmptyLinesBetweenListMarkersAndChecklists extends Rul
       nameKey: 'rules.remove-empty-lines-between-list-markers-and-checklists.name',
       descriptionKey: 'rules.remove-empty-lines-between-list-markers-and-checklists.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.thematicBreak],
     });
   }
   get OptionsClass(): new () => RemoveEmptyLinesBetweenListMarkersAndChecklistsOptions {
     return RemoveEmptyLinesBetweenListMarkersAndChecklistsOptions;
   }
   apply(text: string, options: RemoveEmptyLinesBetweenListMarkersAndChecklistsOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.thematicBreak], text, (text) => {
-      const replaceEmptyLinesBetweenList = function(text: string, listIndicatorRegexText: string, replaceWith: string): string {
-        const listRegex = new RegExp(`^${listIndicatorRegexText}\n{2,}${listIndicatorRegexText}$`, 'gm');
-        let match;
-        let newText = text;
+    /* eslint-disable no-useless-escape */
+    // account for '- [x]' and  '- [ ]' checkbox markers
+    const checkBoxMarkerRegexText = '(( |\\t)*- \\[( |x)\\]( |\\t)+.+)';
+    text = this.replaceEmptyLinesBetweenList(text, checkBoxMarkerRegexText, '$1\n$5');
 
-        do {
-          match = newText.match(listRegex);
-          newText = newText.replaceAll(listRegex, replaceWith);
-        } while (match);
+    // account for ordered list marker
+    const orderedMarkerRegexText = '(( |\\t)*\\d+\\.( |\\t)+.+)';
+    text = this.replaceEmptyLinesBetweenList(text, orderedMarkerRegexText, '$1\n$4');
 
-        return newText;
-      };
+    // account for '+' list marker
+    const plusMarkerRegexText = '(( |\\t)*\\+( |\\t)+.+)';
+    text = this.replaceEmptyLinesBetweenList(text, plusMarkerRegexText, '$1\n$4');
 
-      /* eslint-disable no-useless-escape */
-      // account for '- [x]' and  '- [ ]' checkbox markers
-      const checkBoxMarkerRegexText = '(( |\\t)*- \\[( |x)\\]( |\\t)+.+)';
-      text = replaceEmptyLinesBetweenList(text, checkBoxMarkerRegexText, '$1\n$5');
+    // account for '-' list marker
+    const dashMarkerRegexText = '(( |\\t)*-(?! \\[( |x)\\])( |\\t)+.+)';
+    text = this.replaceEmptyLinesBetweenList(text, dashMarkerRegexText, '$1\n$5');
 
-      // account for ordered list marker
-      const orderedMarkerRegexText = '(( |\\t)*\\d+\\.( |\\t)+.+)';
-      text = replaceEmptyLinesBetweenList(text, orderedMarkerRegexText, '$1\n$4');
-
-      // account for '+' list marker
-      const plusMarkerRegexText = '(( |\\t)*\\+( |\\t)+.+)';
-      text = replaceEmptyLinesBetweenList(text, plusMarkerRegexText, '$1\n$4');
-
-      // account for '-' list marker
-      const dashMarkerRegexText = '(( |\\t)*-(?! \\[( |x)\\])( |\\t)+.+)';
-      text = replaceEmptyLinesBetweenList(text, dashMarkerRegexText, '$1\n$5');
-
-      // account for '*' list marker
-      const splatMarkerRegexText = '(( |\\t)*\\*( |\\t)+.+)';
-      return replaceEmptyLinesBetweenList(text, splatMarkerRegexText, '$1\n$4');
-      /* eslint-enable no-useless-escape */
-    });
+    // account for '*' list marker
+    const splatMarkerRegexText = '(( |\\t)*\\*( |\\t)+.+)';
+    return this.replaceEmptyLinesBetweenList(text, splatMarkerRegexText, '$1\n$4');
+    /* eslint-enable no-useless-escape */
   }
+  replaceEmptyLinesBetweenList = function(text: string, listIndicatorRegexText: string, replaceWith: string): string {
+    const listRegex = new RegExp(`^${listIndicatorRegexText}\n{2,}${listIndicatorRegexText}$`, 'gm');
+    let match;
+    let newText = text;
+
+    do {
+      match = newText.match(listRegex);
+      newText = newText.replaceAll(listRegex, replaceWith);
+    } while (match);
+
+    return newText;
+  };
   get exampleBuilders(): ExampleBuilder<RemoveEmptyLinesBetweenListMarkersAndChecklistsOptions>[] {
     return [
       new ExampleBuilder({

--- a/src/rules/remove-empty-list-markers.ts
+++ b/src/rules/remove-empty-list-markers.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -13,21 +13,20 @@ export default class RemoveEmptyListMarkers extends RuleBuilder<RemoveEmptyListM
       nameKey: 'rules.remove-empty-list-markers.name',
       descriptionKey: 'rules.remove-empty-list-markers.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => RemoveEmptyListMarkersOptions {
     return RemoveEmptyListMarkersOptions;
   }
   apply(text: string, options: RemoveEmptyListMarkersOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      const emptyListMarkerRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}(-|\\*|\\+|\\d+[.)]|- (\\[( |x)\\]))\\s*?$`, 'gm');
-      // remove all empty list markers followed by a new line
-      text = text.replace(new RegExp(emptyListMarkerRegex.source + '\\n', 'gm'), '');
-      // remove all empty list markers proceeded by a new line
-      text = text.replace(new RegExp('\\n' + emptyListMarkerRegex.source, 'gm'), '');
-      // remove all empty list markers where they are the only line in the file
-      return text.replace(emptyListMarkerRegex, '');
-    });
+    const emptyListMarkerRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}(-|\\*|\\+|\\d+[.)]|- (\\[( |x)\\]))\\s*?$`, 'gm');
+    // remove all empty list markers followed by a new line
+    text = text.replace(new RegExp(emptyListMarkerRegex.source + '\\n', 'gm'), '');
+    // remove all empty list markers proceeded by a new line
+    text = text.replace(new RegExp('\\n' + emptyListMarkerRegex.source, 'gm'), '');
+    // remove all empty list markers where they are the only line in the file
+    return text.replace(emptyListMarkerRegex, '');
   }
   get exampleBuilders(): ExampleBuilder<RemoveEmptyListMarkersOptions>[] {
     return [

--- a/src/rules/remove-hyphenated-line-breaks.ts
+++ b/src/rules/remove-hyphenated-line-breaks.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 
 class RemoveHyphenatedLineBreaksOptions implements Options {}
 
@@ -12,15 +12,14 @@ export default class RemoveHyphenatedLineBreaks extends RuleBuilder<RemoveHyphen
       nameKey: 'rules.remove-hyphenated-line-breaks.name',
       descriptionKey: 'rules.remove-hyphenated-line-breaks.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => RemoveHyphenatedLineBreaksOptions {
     return RemoveHyphenatedLineBreaksOptions;
   }
   apply(text: string, options: RemoveHyphenatedLineBreaksOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      return text.replace(/\b[-‐] \b/g, '');
-    });
+    return text.replace(/\b[-‐] \b/g, '');
   }
   get exampleBuilders(): ExampleBuilder<RemoveHyphenatedLineBreaksOptions>[] {
     return [

--- a/src/rules/remove-multiple-spaces.ts
+++ b/src/rules/remove-multiple-spaces.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 
 class RemoveMultipleSpacesOptions implements Options {}
 
@@ -12,17 +12,16 @@ export default class RemoveMultipleSpaces extends RuleBuilder<RemoveMultipleSpac
       nameKey: 'rules.remove-multiple-spaces.name',
       descriptionKey: 'rules.remove-multiple-spaces.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.table],
     });
   }
   get OptionsClass(): new () => RemoveMultipleSpacesOptions {
     return RemoveMultipleSpacesOptions;
   }
   apply(text: string, options: RemoveMultipleSpacesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.table], text, (text) => {
-      text = text.replace(/(?!^>)([^\s])( ){2,}([^\s])/gm, '$1 $3');
+    text = text.replace(/(?!^>)([^\s])( ){2,}([^\s])/gm, '$1 $3');
 
-      return text;
-    });
+    return text;
   }
   get exampleBuilders(): ExampleBuilder<RemoveMultipleSpacesOptions>[] {
     return [

--- a/src/rules/remove-space-around-characters.ts
+++ b/src/rules/remove-space-around-characters.ts
@@ -19,6 +19,7 @@ export default class RemoveSpaceAroundCharacters extends RuleBuilder<RemoveSpace
       nameKey: 'rules.remove-space-around-characters.name',
       descriptionKey: 'rules.remove-space-around-characters.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => RemoveSpaceAroundCharactersOptions {
@@ -52,7 +53,7 @@ export default class RemoveSpaceAroundCharacters extends RuleBuilder<RemoveSpace
       return text.replace(fullwidthCharacterWithTextAtStart, '$2').replace(fullwidthCharacterWithTextAtEnd, '$1');
     };
 
-    let newText = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.list], text, replaceWhitespaceAroundFullwidthCharacters);
+    let newText = ignoreListOfTypes([IgnoreTypes.list], text, replaceWhitespaceAroundFullwidthCharacters);
 
     newText = updateListItemText(newText, replaceWhitespaceAroundFullwidthCharacters);
 

--- a/src/rules/remove-space-around-characters.ts
+++ b/src/rules/remove-space-around-characters.ts
@@ -6,10 +6,10 @@ import {updateListItemText} from '../utils/mdast';
 import {escapeRegExp} from '../utils/regex';
 
 class RemoveSpaceAroundCharactersOptions implements Options {
-  includeFullwidthForms: boolean = true;
-  includeCJKSymbolsAndPunctuation: boolean = true;
-  includeDashes: boolean = true;
-  otherSymbols: string = '';
+  includeFullwidthForms?: boolean = true;
+  includeCJKSymbolsAndPunctuation?: boolean = true;
+  includeDashes?: boolean = true;
+  otherSymbols?: string = '';
 }
 
 @RuleBuilder.register

--- a/src/rules/remove-space-before-or-after-characters.ts
+++ b/src/rules/remove-space-before-or-after-characters.ts
@@ -17,7 +17,7 @@ export default class RemoveSpaceBeforeOrAfterCharacters extends RuleBuilder<Remo
       nameKey: 'rules.remove-space-before-or-after-characters.name',
       descriptionKey: 'rules.remove-space-before-or-after-characters.description',
       type: RuleType.SPACING,
-      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.html],
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => RemoveSpaceBeforeOrAfterCharactersOptions {
@@ -34,12 +34,14 @@ export default class RemoveSpaceBeforeOrAfterCharacters extends RuleBuilder<Remo
 
     const removeWhitespaceBeforeCharacters = new RegExp(`([ \t])+([${symbolsBefore}])`, 'g');
     const removeWhitespaceAfterCharacters = new RegExp(`([${symbolsAfter}])([ \t])+`, 'g');
-
+    // console.log('before: "' + removeWhitespaceBeforeCharacters.source + '"');
+    // console.log('after: "' + removeWhitespaceAfterCharacters.source + '"');
     const replaceWhitespaceBeforeOrAfterCharacters = function(text: string): string {
+      // console.log(text);
       return text.replace(removeWhitespaceBeforeCharacters, '$2').replace(removeWhitespaceAfterCharacters, '$1');
     };
 
-    let newText = ignoreListOfTypes([IgnoreTypes.list], text, replaceWhitespaceBeforeOrAfterCharacters);
+    let newText = ignoreListOfTypes([IgnoreTypes.list, IgnoreTypes.html], text, replaceWhitespaceBeforeOrAfterCharacters);
 
     newText = updateListItemText(newText, replaceWhitespaceBeforeOrAfterCharacters);
 

--- a/src/rules/remove-space-before-or-after-characters.ts
+++ b/src/rules/remove-space-before-or-after-characters.ts
@@ -17,6 +17,7 @@ export default class RemoveSpaceBeforeOrAfterCharacters extends RuleBuilder<Remo
       nameKey: 'rules.remove-space-before-or-after-characters.name',
       descriptionKey: 'rules.remove-space-before-or-after-characters.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.html],
     });
   }
   get OptionsClass(): new () => RemoveSpaceBeforeOrAfterCharactersOptions {
@@ -38,7 +39,7 @@ export default class RemoveSpaceBeforeOrAfterCharacters extends RuleBuilder<Remo
       return text.replace(removeWhitespaceBeforeCharacters, '$2').replace(removeWhitespaceAfterCharacters, '$1');
     };
 
-    let newText = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.list, IgnoreTypes.html], text, replaceWhitespaceBeforeOrAfterCharacters);
+    let newText = ignoreListOfTypes([IgnoreTypes.list], text, replaceWhitespaceBeforeOrAfterCharacters);
 
     newText = updateListItemText(newText, replaceWhitespaceBeforeOrAfterCharacters);
 

--- a/src/rules/space-after-list-markers.ts
+++ b/src/rules/space-after-list-markers.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -12,21 +12,20 @@ export default class SpaceAfterListMarkers extends RuleBuilder<SpaceAfterListMar
       nameKey: 'rules.space-after-list-markers.name',
       descriptionKey: 'rules.space-after-list-markers.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => SpaceAfterListMarkersOptions {
     return SpaceAfterListMarkersOptions;
   }
   apply(text: string, options: SpaceAfterListMarkersOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      // Space after marker
-      text = text.replace(/^(\s*\d+\.|\s*[-+*])[^\S\r\n]+/gm, '$1 ');
-      // Space after checkbox
-      return text.replace(
-          /^(\s*\d+\.|\s*[-+*]\s+\[[ xX]\])[^\S\r\n]+/gm,
-          '$1 ',
-      );
-    });
+    // Space after marker
+    text = text.replace(/^(\s*\d+\.|\s*[-+*])[^\S\r\n]+/gm, '$1 ');
+    // Space after checkbox
+    return text.replace(
+        /^(\s*\d+\.|\s*[-+*]\s+\[[ xX]\])[^\S\r\n]+/gm,
+        '$1 ',
+    );
   }
   get exampleBuilders(): ExampleBuilder<SpaceAfterListMarkersOptions>[] {
     return [

--- a/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
@@ -13,6 +13,7 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
       nameKey: 'rules.space-between-chinese-japanese-or-korean-and-english-or-numbers.name',
       descriptionKey: 'rules.space-between-chinese-japanese-or-korean-and-english-or-numbers.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.yaml, IgnoreTypes.image, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html],
     });
   }
   get OptionsClass(): new () => SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions {
@@ -24,34 +25,23 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
   ): string {
     const head = /(\p{sc=Han}|\p{sc=Katakana}|\p{sc=Hiragana}|\p{sc=Hangul})( *)(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+'"([¥$]|\*[^*])/gmu;
     const tail = /(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+;:'"°%$)\]]|[^*]\*)( *)(\p{sc=Han}|\p{sc=Katakana}|\p{sc=Hiragana}|\p{sc=Hangul})/gmu;
-    // inline math, inline code, makrdown links, and wiki links are an exception in that even though they are to be ignored we want to keep a space around these types when surrounded by CJK characters
+    // inline math, inline code, markdown links, and wiki links are an exception in that even though they are to be ignored we want to keep a space around these types when surrounded by CJK characters
     const regexEscapedIgnoreExceptionPlaceHolders = `${IgnoreTypes.link.placeholder}|${IgnoreTypes.inlineMath.placeholder}|${IgnoreTypes.inlineCode.placeholder}|${IgnoreTypes.wikiLink.placeholder}`.replaceAll('{', '\\{').replaceAll('}', '\\}');
     const ignoreExceptionsHead = new RegExp(`(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})( *)(${regexEscapedIgnoreExceptionPlaceHolders})`, 'gmu');
     const ignoreExceptionsTail = new RegExp(`(${regexEscapedIgnoreExceptionPlaceHolders})( *)(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})`, 'gmu');
-    const addSpaceAroundChineseJapaneseKoreanAndEnglish = function(
-        text: string,
-    ): string {
+    const addSpaceAroundChineseJapaneseKoreanAndEnglish = function(text: string): string {
       return text.replace(head, '$1 $3').replace(tail, '$1 $3');
     };
 
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.yaml, IgnoreTypes.image, IgnoreTypes.link,
-      IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html], text, (text: string) => {
-      let newText = ignoreListOfTypes([IgnoreTypes.italics, IgnoreTypes.bold], text, addSpaceAroundChineseJapaneseKoreanAndEnglish);
+    let newText = ignoreListOfTypes([IgnoreTypes.italics, IgnoreTypes.bold], text, addSpaceAroundChineseJapaneseKoreanAndEnglish);
 
-      newText = newText.replace(ignoreExceptionsHead, '$1 $3').replace(ignoreExceptionsTail, '$1 $3');
+    newText = newText.replace(ignoreExceptionsHead, '$1 $3').replace(ignoreExceptionsTail, '$1 $3');
 
-      newText = updateItalicsText(
-          newText,
-          addSpaceAroundChineseJapaneseKoreanAndEnglish,
-      );
+    newText = updateItalicsText(newText, addSpaceAroundChineseJapaneseKoreanAndEnglish);
 
-      newText = updateBoldText(
-          newText,
-          addSpaceAroundChineseJapaneseKoreanAndEnglish,
-      );
+    newText = updateBoldText(newText, addSpaceAroundChineseJapaneseKoreanAndEnglish);
 
-      return newText;
-    });
+    return newText;
   }
   get exampleBuilders(): ExampleBuilder<SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions>[] {
     return [

--- a/src/rules/strong-style.ts
+++ b/src/rules/strong-style.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -17,15 +17,14 @@ export default class StrongStyle extends RuleBuilder<StrongStyleOptions> {
       nameKey: 'rules.strong-style.name',
       descriptionKey: 'rules.strong-style.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.math, IgnoreTypes.inlineMath],
     });
   }
   get OptionsClass(): new () => StrongStyleOptions {
     return StrongStyleOptions;
   }
   apply(text: string, options: StrongStyleOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.math, IgnoreTypes.inlineMath], text, (text) => {
-      return makeEmphasisOrBoldConsistent(text, options.style, MDAstTypes.Bold);
-    });
+    return makeEmphasisOrBoldConsistent(text, options.style, MDAstTypes.Bold);
   }
   get exampleBuilders(): ExampleBuilder<StrongStyleOptions>[] {
     return [

--- a/src/rules/trailing-spaces.ts
+++ b/src/rules/trailing-spaces.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -14,22 +14,21 @@ export default class TrailingSpaces extends RuleBuilder<TrailingSpacesOptions> {
       nameKey: 'rules.trailing-spaces.name',
       descriptionKey: 'rules.trailing-spaces.description',
       type: RuleType.SPACING,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => TrailingSpacesOptions {
     return TrailingSpacesOptions;
   }
   apply(text: string, options: TrailingSpacesOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag], text, (text) => {
-      if (!options.twoSpaceLineBreak) {
-        return text.replace(/[ \t]+$/gm, '');
-      } else {
-        text = text.replace(/(\S)[ \t]$/gm, '$1'); // one whitespace
-        text = text.replace(/(\S)[ \t]{3,}$/gm, '$1'); // three or more whitespaces
-        text = text.replace(/(\S)( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
-        return text;
-      }
-    });
+    if (!options.twoSpaceLineBreak) {
+      return text.replace(/[ \t]+$/gm, '');
+    } else {
+      text = text.replace(/(\S)[ \t]$/gm, '$1'); // one whitespace
+      text = text.replace(/(\S)[ \t]{3,}$/gm, '$1'); // three or more whitespaces
+      text = text.replace(/(\S)( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
+      return text;
+    }
   }
   get exampleBuilders(): ExampleBuilder<TrailingSpacesOptions>[] {
     return [

--- a/src/rules/two-spaces-between-lines-with-content.ts
+++ b/src/rules/two-spaces-between-lines-with-content.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent} from '../utils/mdast';
 
 class TwoSpacesBetweenLinesWithContentOptions implements Options {}
@@ -13,13 +13,14 @@ export default class TwoSpacesBetweenLinesWithContent extends RuleBuilder<TwoSpa
       nameKey: 'rules.two-spaces-between-lines-with-content.name',
       descriptionKey: 'rules.two-spaces-between-lines-with-content.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml, IgnoreTypes.table],
     });
   }
   get OptionsClass(): new () => TwoSpacesBetweenLinesWithContentOptions {
     return TwoSpacesBetweenLinesWithContentOptions;
   }
   apply(text: string, options: TwoSpacesBetweenLinesWithContentOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml, IgnoreTypes.table], text, addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent);
+    return addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent(text);
   }
   get exampleBuilders(): ExampleBuilder<TwoSpacesBetweenLinesWithContentOptions>[] {
     return [

--- a/src/rules/unordered-list-style.ts
+++ b/src/rules/unordered-list-style.ts
@@ -1,4 +1,4 @@
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -15,15 +15,14 @@ export default class UnorderedListStyle extends RuleBuilder<UnorderedListStyleOp
       nameKey: 'rules.unordered-list-style.name',
       descriptionKey: 'rules.unordered-list-style.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => UnorderedListStyleOptions {
     return UnorderedListStyleOptions;
   }
   apply(text: string, options: UnorderedListStyleOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag], text, (text) => {
-      return updateUnorderedListItemIndicators(text, options.listStyle);
-    });
+    return updateUnorderedListItemIndicators(text, options.listStyle);
   }
   get exampleBuilders(): ExampleBuilder<UnorderedListStyleOptions>[] {
     return [

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -108,25 +108,7 @@ function getListItemTextPositions(text: string): Position[] {
     // @ts-ignore the fact that not all nodes have a children property since I have already exited the function if that is the case
     for (const childNode of node.children) {
       if (childNode.type === (MDAstTypes.Paragraph as string)) {
-        const position = { // make a deep copy of the value to prevent changing the generated AST
-          start: {
-            line: childNode.position.start.line,
-            column: childNode.position.start.column,
-            offset: childNode.position.start.offset,
-          },
-          end: {
-            line: childNode.position.end.line,
-            column: childNode.position.end.column,
-            offset: childNode.position.end.offset,
-          },
-        };
-        // tasks need a slight shift to account for the task completion indicator
-        // @ts-ignore the fact that not all nodes have a checked property since all list items should have it
-        if (node.checked !== null) {
-          position.start.offset += 4;
-        }
-
-        positions.push(position);
+        positions.push(childNode.position);
       }
     }
   });
@@ -547,6 +529,7 @@ export function updateBoldText(text: string, func:(text: string) => string): str
 
 export function updateListItemText(text: string, func:(text: string) => string): string {
   const positions: Position[] = getListItemTextPositions(text);
+  const checklistIndicatorRegex = /^\[.\] /;
 
   for (const position of positions) {
     let startIndex = position.start.offset;
@@ -560,6 +543,11 @@ export function updateListItemText(text: string, func:(text: string) => string):
     }
 
     let listText = text.substring(startIndex, position.end.offset);
+    // for some reason some checklists are not getting treated as such and this causes the task indicator to be included in the text
+    if (checklistIndicatorRegex.test(listText)) {
+      startIndex += 4;
+      listText = listText.substring(4);
+    }
     listText = func(listText);
 
     text = replaceTextBetweenStartAndEndWithNewValue(text, startIndex, position.end.offset, listText);

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -902,3 +902,40 @@ function isInvalidTableSeparatorRow(fullRow: string, separatorMatch: string): bo
   const nonSeparatorContent = fullRow.replace(separatorMatch, '');
   return /[^\s>]/.test(nonSeparatorContent);
 }
+
+const customIgnoreStart = '<!-- linter-ignore-start -->';
+const customIgnoreEnd = '<!-- linter-ignore-end -->';
+
+export function getAllCustomIgnoreSectionsInText(text: string): {startIndex: number, endIndex: number}[] {
+  let iteratorIndex = 0;
+
+  const positions: {startIndex: number, endIndex: number}[] = [];
+  do {
+    iteratorIndex = text.indexOf(customIgnoreStart, iteratorIndex);
+    if (iteratorIndex === -1) {
+      break;
+    }
+
+    let endOfIgnoreSection = text.indexOf(customIgnoreEnd, iteratorIndex + customIgnoreStart.length);
+    if (endOfIgnoreSection === -1) {
+      positions.push({
+        startIndex: iteratorIndex,
+        endIndex: text.length - 1,
+      });
+
+      break;
+    }
+
+    endOfIgnoreSection += customIgnoreEnd.length;
+
+    positions.push({
+      startIndex: iteratorIndex,
+      endIndex: endOfIgnoreSection,
+    });
+
+    iteratorIndex = endOfIgnoreSection;
+  }
+  while (iteratorIndex !== -1 && iteratorIndex < text.length -1);
+
+  return positions;
+}

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -24,6 +24,7 @@ export const tableStartingPipe = /^(((>[ ]?)*)|([ ]{0,3}))\|/m;
 export const tableRow = /[^\n]*?\|[^\n]*?(\n|$)/m;
 export const urlRegex = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"‘’“”>]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"‘’“”>]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'"‘’“”>]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'"‘’“”>]{2,})/gi;
 export const anchorTagRegex = /<a[\s]+([^>]+)>((?:.(?!<\/a>))*.)<\/a>/g;
+export const wordRegex = /[\p{L}\p{N}\p{Pc}\p{M}\-'’`]+/gu;
 
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -28,6 +28,9 @@ export const wordRegex = /[\p{L}\p{N}\p{Pc}\p{M}\-'’`]+/gu;
 // regex from https://stackoverflow.com/a/26128757/8353749
 export const htmlEntitiesRegex = /&[^\s]+;$/mi;
 
+export const customIgnoreAllStartIndicator = generateHTMLLinterCommentWithSpecificTextAndWhitespaceRegexMatch(true);
+export const customIgnoreAllEndIndicator = generateHTMLLinterCommentWithSpecificTextAndWhitespaceRegexMatch(false);
+
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string
 // could have user constructed dollar signs in it
@@ -104,4 +107,17 @@ export function getFirstHeaderOneText(text: string): string {
 
 export function matchTagRegex(text: string): string[] {
   return [...text.matchAll(tagWithLeadingWhitespaceRegex)].map((match) => match[2]);
+}
+
+export function generateHTMLLinterCommentWithSpecificTextAndWhitespaceRegexMatch(isStart: boolean): RegExp {
+  const regexTemplate = '<!-{2,} *linter-{ENDING_TEXT} *-{2,}>';
+  let endingText = '';
+
+  if (isStart) {
+    endingText += 'disable';
+  } else {
+    endingText += 'enable';
+  }
+
+  return new RegExp(regexTemplate.replace('{ENDING_TEXT}', endingText), 'g');
 }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -25,6 +25,8 @@ export const tableRow = /[^\n]*?\|[^\n]*?(\n|$)/m;
 export const urlRegex = /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"‘’“”>]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s`\]'"‘’“”>]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s`\]'"‘’“”>]{2,}|www\.[a-zA-Z0-9]+\.[^\s`\]'"‘’“”>]{2,})/gi;
 export const anchorTagRegex = /<a[\s]+([^>]+)>((?:.(?!<\/a>))*.)<\/a>/g;
 export const wordRegex = /[\p{L}\p{N}\p{Pc}\p{M}\-'’`]+/gu;
+// regex from https://stackoverflow.com/a/26128757/8353749
+export const htmlEntitiesRegex = /&[^\s]+;$/mi;
 
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string


### PR DESCRIPTION
Fixes #701 
Fixes #334 

Adds an exact syntax for turning off the Linter for certain parts of the document that you do not want linted.

Changes Made:
- Added a new property to the initialization of a rule for options to ignore for the rule which should NOT include custom ignore as that is added under the hood by default
- Custom ignore does not affect paste type rules
- Added eslint ignore pattern for the translation helper that is generated by build
- Added tests for finding custom ignore sections in text
- Updated existing rules to use the new rule ignore type property where possible
- Moved local functions to their own methods in the rules where it seemed easy and feasible to help out with performance as well
- Added some comments to rules with special rule running set to true to give some context as to why they get to run at a special time
- Moved regex to `regex.ts` where it seemed feasible and good to do so
- Swapped `defaultEscapeCharacter` from a string to `QuoteCharacter` where possible since it has a proper type to use now