### PR TITLE
Add YAML Title Modes

### DIFF
--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -687,10 +687,14 @@ export default {
     // yaml-title.ts
     'yaml-title': {
       'name': 'YAML-Titel',
-      'description': 'Fügt den Titel der Datei in die YAML-Frontmaterie ein. Ruft den Titel aus dem ersten H1 oder Dateinamen ab, wenn kein H1 vorhanden ist.',
+      'description': 'Fügt den Titel der Datei in das YAML-Frontmatter ein. Ruft den Titel basierend auf dem ausgewählten Modus ab.',
       'title-key': {
         'name': 'Titel-Schlüssel',
         'description': 'Der YAML-Schlüssel, der für den Titel verwendet werden soll',
+      },
+      'mode': {
+        'name': 'Modus',
+        'description': 'Die zum Abrufen des Titels zu verwendende Methode',
       },
     },
   },
@@ -732,5 +736,9 @@ export default {
     'single string comma delimited': 'Komma mit Trennzeichen für eine Zeichenfolge',
     'single string space delimited': 'Einzelzeichenfolgenabstand durch Trennzeichen',
     'single-line space delimited': 'einzeiliger Abstand durch Trennzeichen',
+    // yaml-title.ts
+    'first-h1': 'erste Überschrift der Ebene 1',
+    'first-h1-or-filename-if-h1-missing': 'Erste Überschrift der Ebene 1 oder Dateiname, wenn die Überschrift der Ebene 1 fehlt',
+    'filename': 'Dateinamen',
   },
 };

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -687,7 +687,7 @@ export default {
     // yaml-title.ts
     'yaml-title': {
       'name': 'YAML Title',
-      'description': 'Fügt den Titel der Datei in das YAML-Frontmatter ein. Ruft den Titel basierend auf dem ausgewählten Modus ab.',
+      'description': 'Inserts the title of the file into the YAML frontmatter. Gets the title based on the selected mode.',
       'title-key': {
         'name': 'Title Key',
         'description': 'Which YAML key to use for title',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -687,10 +687,14 @@ export default {
     // yaml-title.ts
     'yaml-title': {
       'name': 'YAML Title',
-      'description': 'Inserts the title of the file into the YAML frontmatter. Gets the title from the first H1 or filename if there is no H1.',
+      'description': 'Fügt den Titel der Datei in das YAML-Frontmatter ein. Ruft den Titel basierend auf dem ausgewählten Modus ab.',
       'title-key': {
         'name': 'Title Key',
         'description': 'Which YAML key to use for title',
+      },
+      'mode': {
+        'name': 'Mode',
+        'description': 'The method to use to get the title',
       },
     },
   },
@@ -732,5 +736,9 @@ export default {
     'single string comma delimited': 'single string comma delimited',
     'single string space delimited': 'single string space delimited',
     'single-line space delimited': 'single-line space delimited',
+    // yaml-title.ts
+    'first-h1': 'First H1',
+    'first-h1-or-filename-if-h1-missing': 'First H1 or Filename if H1 is Missing',
+    'filename': 'Filename',
   },
 };

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -596,10 +596,14 @@ export default {
     },
     'yaml-title': {
       'name': 'Título de YAML',
-      'description': 'Inserta el título del archivo en el frontmatter del YAML. Obtiene el título del primer H1 o nombre de archivo si no hay H1.',
+      'description': 'Inserta el título del archivo en el frontmatter de YAML. Obtiene el título según el modo seleccionado.',
       'title-key': {
         'name': 'Clave de título',
-        'description': 'La clave de YAML usar para el título',
+        'description': 'La clave de YAML para usar para el título',
+      },
+      'mode': {
+        'name': 'Modo',
+        'description': 'El método a utilizar para obtener el título',
       },
     },
   },
@@ -638,5 +642,8 @@ export default {
     'single string comma delimited': 'cadena única delimitada por comas',
     'single string space delimited': 'espacio de una sola cadena delimitado',
     'single-line space delimited': 'espacio de una sola línea delimitado',
+    'first-h1': 'primer encabezado de nivel 1',
+    'first-h1-or-filename-if-h1-missing': 'primer encabezado de nivel 1 o nombre de archivo si falta el encabezado de primer nivel 1',
+    'filename': 'nombre del archivo',
   },
 };

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -687,10 +687,14 @@ export default {
     // yaml-title.ts
     'yaml-title': {
       'name': 'YAML 标题',
-      'description': '将文档的标题插入到 YAML frontmatter中。获取第一个 H1 或文档名（如果没有 H1）的标题。',
+      'description': '将文件的标题插入到 YAML frontmatter 中。 根据所选模式获取标题。',
       'title-key': {
         'name': '标题键',
         'description': '标题使用哪一个 YAML 键',
+      },
+      'mode': {
+        'name': '模式',
+        'description': '用于获取标题的方法',
       },
     },
   },
@@ -732,5 +736,9 @@ export default {
     'single string comma delimited': '字符串用逗号分隔',
     'single string space delimited': '字符串用空格分隔',
     'single-line space delimited': '单行空格分隔',
+    // yaml-title.ts
+    'first-h1': '第一级标题',
+    'first-h1-or-filename-if-h1-missing': '第一级 1 标题或文件名（如果缺少 1 级标题）',
+    'filename': '文件名',
   },
 };

--- a/src/rules/remove-space-before-or-after-characters.ts
+++ b/src/rules/remove-space-before-or-after-characters.ts
@@ -34,10 +34,7 @@ export default class RemoveSpaceBeforeOrAfterCharacters extends RuleBuilder<Remo
 
     const removeWhitespaceBeforeCharacters = new RegExp(`([ \t])+([${symbolsBefore}])`, 'g');
     const removeWhitespaceAfterCharacters = new RegExp(`([${symbolsAfter}])([ \t])+`, 'g');
-    // console.log('before: "' + removeWhitespaceBeforeCharacters.source + '"');
-    // console.log('after: "' + removeWhitespaceAfterCharacters.source + '"');
     const replaceWhitespaceBeforeOrAfterCharacters = function(text: string): string {
-      // console.log(text);
       return text.replace(removeWhitespaceBeforeCharacters, '$2').replace(removeWhitespaceAfterCharacters, '$1');
     };
 

--- a/src/rules/yaml-title.ts
+++ b/src/rules/yaml-title.ts
@@ -1,10 +1,12 @@
 import {Options, RuleType} from '../rules';
-import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextOptionBuilder} from './rule-builder';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextOptionBuilder, DropdownOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
 import {escapeStringIfNecessaryAndPossible, formatYAML, initYAML, QuoteCharacter} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {escapeDollarSigns, getFirstHeaderOneText} from '../utils/regex';
 import {insert} from '../utils/strings';
+
+type YamlTitleModeValues = 'first-h1-or-filename-if-h1-missing' | 'filename' | 'first-h1';
 
 class YamlTitleOptions implements Options {
   @RuleBuilder.noSettingControl()
@@ -14,6 +16,8 @@ class YamlTitleOptions implements Options {
     defaultEscapeCharacter?: QuoteCharacter = '"';
 
   titleKey?: string = 'title';
+
+  mode?: YamlTitleModeValues = 'first-h1-or-filename-if-h1-missing';
 }
 
 @RuleBuilder.register
@@ -30,8 +34,18 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
   }
   apply(text: string, options: YamlTitleOptions): string {
     text = initYAML(text);
-    let title = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag], text, getFirstHeaderOneText);
-    title = title || options.fileName;
+    let title = '';
+    switch (options.mode) {
+      case 'filename':
+        title = options.fileName;
+        break;
+      case 'first-h1':
+        title = this.getFirstH1Header(text);
+        break;
+      default:
+        title = this.getFirstH1Header(text);
+        title = title || options.fileName;
+    }
 
     title = escapeStringIfNecessaryAndPossible(title, options.defaultEscapeCharacter);
 
@@ -51,10 +65,13 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
       return text;
     });
   }
+  getFirstH1Header(text: string): string {
+    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag], text, getFirstHeaderOneText);
+  }
   get exampleBuilders(): ExampleBuilder<YamlTitleOptions>[] {
     return [
       new ExampleBuilder({
-        description: 'Adds a header with the title from heading.',
+        description: 'Adds a header with the title from heading when `mode = \'First H1 or Filename if H1 Missing\'`.',
         before: dedent`
           # Obsidian
         `,
@@ -69,7 +86,7 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
         },
       }),
       new ExampleBuilder({
-        description: 'Adds a header with the title.',
+        description: 'Adds a header with the title when `mode = \'First H1 or Filename if H1 Missing\'`.',
         before: dedent`
           ${''}
         `,
@@ -84,7 +101,7 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
         },
       }),
       new ExampleBuilder({ // accounts for https://github.com/platers/obsidian-linter/issues/470
-        description: 'Make sure that markdown links in headings are properly copied to the yaml as just the text',
+        description: 'Make sure that markdown links in headings are properly copied to the YAML as just the text when `mode = \'First H1 or Filename if H1 Missing\'`',
         before: dedent`
           # This is a [Heading](test heading.md)
         `,
@@ -95,6 +112,38 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
           # This is a [Heading](test heading.md)
         `,
       }),
+      new ExampleBuilder({
+        description: 'When `mode = \'First H1\'`, title does not have a value if no H1 is present',
+        before: dedent`
+          ## This is a Heading
+        `,
+        after: dedent`
+          ---
+          title: ""
+          ---
+          ## This is a Heading
+        `,
+        options: {
+          mode: 'first-h1',
+          fileName: 'Filename',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'When `mode = \'Filename\'`, title uses the filename ignoring all H1s. Note: the filename is "Filename" in this example.',
+        before: dedent`
+          # This is a Heading
+        `,
+        after: dedent`
+          ---
+          title: Filename
+          ---
+          # This is a Heading
+        `,
+        options: {
+          mode: 'filename',
+          fileName: 'Filename',
+        },
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<YamlTitleOptions>[] {
@@ -104,6 +153,26 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
         nameKey: 'rules.yaml-title.title-key.name',
         descriptionKey: 'rules.yaml-title.title-key.description',
         optionsKey: 'titleKey',
+      }),
+      new DropdownOptionBuilder<YamlTitleOptions, YamlTitleModeValues>({
+        OptionsClass: YamlTitleOptions,
+        nameKey: 'rules.yaml-title.mode.name',
+        descriptionKey: 'rules.yaml-title.mode.description',
+        optionsKey: 'mode',
+        records: [
+          {
+            value: 'first-h1-or-filename-if-h1-missing',
+            description: 'Uses the first H1 in the file or the filename of the file if there is not H1',
+          },
+          {
+            value: 'filename',
+            description: 'Uses the filename as the title',
+          },
+          {
+            value: 'first-h1',
+            description: 'Uses the first H1 in the file as the title',
+          },
+        ],
       }),
     ];
   }

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -896,7 +896,6 @@ export function getAllCustomIgnoreSectionsInText(text: string): {startIndex: num
 
   const positions: {startIndex: number, endIndex: number}[] = [];
   const startMatches = [...text.matchAll(customIgnoreAllStartIndicator)];
-  console.log(customIgnoreAllStartIndicator.source);
   if (!startMatches || startMatches.length === 0) {
     return positions;
   }


### PR DESCRIPTION
Fixes #712 
Fixes #205 
Fixes #578 

Changes Made:
- Added modes to `YAML Title`: first H1 or filename if H1 is missing, first H1, or filename
- Added a couple of examples
- Updated description of `YAML Title` and added language text in currently available languages for the Linter
- Removed console logs that should not be there