### PR TITLE
Add Rule for Smart Versus Dumb Quotes

### DIFF
--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -82,6 +82,9 @@ export default {
     // rules.ts
     'wrapper-yaml-error': 'Fehler in der YAML: {ERROR_MESSAGE}',
     'wrapper-unknown-error': 'Unbekannter Fehler: {ERROR_MESSAGE}',
+
+    // quote-style.ts
+    'uneven-amount-of-quotes': 'Die Vorkommen des Anführungszeichens `{QUOTE}` in der Datei sind nicht gerade, daher können wir gerade Anführungszeichen nicht in intelligente Anführungszeichen umwandeln',
   },
 
   'notice-text': {
@@ -472,6 +475,27 @@ export default {
       'name': 'Richtige Auslassungspunkte',
       'description': 'Ersetzt drei aufeinanderfolgende Punkte durch Auslassungspunkte.',
     },
+    // quote-style.ts
+    'quote-style': {
+      'name': 'Zitatstil',
+      'description': 'Aktualisiert die Anführungszeichen im Textkörperinhalt, sodass sie auf die angegebenen einfachen und doppelten Anführungszeichenstile aktualisiert werden.',
+      'single-quote-enabled': {
+        'name': 'Aktivieren Sie `Stil für einfache Anführungszeichen`',
+        'description': 'Gibt an, dass der ausgewählte einfache Anführungszeichenstil verwendet werden soll.',
+      },
+      'single-quote-style': {
+        'name': 'Stil für einfache Anführungszeichen',
+        'description': 'Der Stil der zu verwendenden einfachen Anführungszeichen.',
+      },
+      'double-quote-enabled': {
+        'name': 'Aktivieren Sie `Stil für doppelte Anführungszeichen`',
+        'description': 'Gibt an, dass der ausgewählte doppelte Anführungszeichenstil verwendet werden soll.',
+      },
+      'double-quote-style': {
+        'name': 'Stil für doppelte Anführungszeichen',
+        'description': 'Der zu verwendende Stil der doppelten Anführungszeichen.',
+      },
+    },
     // re-index-footnotes.ts
     're-index-footnotes': {
       'name': 'Fußnoten neu indizieren',
@@ -740,5 +764,10 @@ export default {
     'first-h1': 'erste Überschrift der Ebene 1',
     'first-h1-or-filename-if-h1-missing': 'Erste Überschrift der Ebene 1 oder Dateiname, wenn die Überschrift der Ebene 1 fehlt',
     'filename': 'Dateinamen',
+    // quote-style.ts
+    '\'\'': '\'\'', // leave as is
+    '‘’': '‘’', // leave as is
+    '""': '""', // leave as is
+    '“”': '“”', // leave as is
   },
 };

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -82,6 +82,9 @@ export default {
     // rules.ts
     'wrapper-yaml-error': 'error in the yaml: {ERROR_MESSAGE}',
     'wrapper-unknown-error': 'unknown error: {ERROR_MESSAGE}',
+
+    // quote-style.ts
+    'uneven-amount-of-quotes': 'The instances of the `{QUOTE}` quote in the file is not even, so we cannot convert straight quotes to smart quotes',
   },
 
   'notice-text': {
@@ -472,6 +475,27 @@ export default {
       'name': 'Proper Ellipsis',
       'description': 'Replaces three consecutive dots with an ellipsis.',
     },
+    // quote-style.ts
+    'quote-style': {
+      'name': 'Quote Style',
+      'description': 'Updates the quotes in the body content to be updated to the specified single and double quote styles.',
+      'single-quote-enabled': {
+        'name': 'Enable `Single Quote Style`',
+        'description': 'Specifies that the selected single quote style should be used.',
+      },
+      'single-quote-style': {
+        'name': 'Single Quote Style',
+        'description': 'The style of single quotes to use.',
+      },
+      'double-quote-enabled': {
+        'name': 'Enable `Double Quote Style`',
+        'description': 'Specifies that the selected double quote style should be used.',
+      },
+      'double-quote-style': {
+        'name': 'Double Quote Style',
+        'description': 'The style of double quotes to use.',
+      },
+    },
     // re-index-footnotes.ts
     're-index-footnotes': {
       'name': 'Re-Index Footnotes',
@@ -740,5 +764,10 @@ export default {
     'first-h1': 'First H1',
     'first-h1-or-filename-if-h1-missing': 'First H1 or Filename if H1 is Missing',
     'filename': 'Filename',
+    // quote-style.ts
+    '\'\'': '\'\'', // leave as is
+    '‘’': '‘’', // leave as is
+    '""': '""', // leave as is
+    '“”': '“”', // leave as is
   },
 };

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -66,6 +66,7 @@ export default {
     'too-many-footnotes-error-message': `La clave de nota al pie '{FOOTNOTE_KEY}' tiene más de 1 nota al pie que hace referencia a ella. Actualice las notas al pie para que solo haya una nota al pie por clave de nota al pie.`,
     'wrapper-yaml-error': 'hubo un error en el yaml: {ERROR_MESSAGE}',
     'wrapper-unknown-error': 'huno un error desconocido: {ERROR_MESSAGE}',
+    'uneven-amount-of-quotes': 'Las instancias de la cita `{QUOTE}` en el archivo no son pares, por lo que no podemos convertir las comillas rectas en comillas tipográficas.',
   },
   'notice-text': {
     'empty-clipboard': 'No hay contenido del portapapeles.',
@@ -406,6 +407,26 @@ export default {
       'name': 'Puntos suspensivos propios',
       'description': 'Reemplaza tres puntos consecutivos con puntos suspensivos.',
     },
+    'quote-style': {
+      'name': 'Estilo de cotización',
+      'description': 'Actualiza las comillas en el contenido del cuerpo para que se actualicen a los estilos de comillas simples y dobles especificados.',
+      'single-quote-enabled': {
+        'name': 'Habilitar `Estilo de comillas simples`',
+        'description': 'Especifica que se debe utilizar el estilo de comillas simples seleccionado.',
+      },
+      'single-quote-style': {
+        'name': 'Estilo de comillas simples',
+        'description': 'El estilo de las comillas simples a utilizar.',
+      },
+      'double-quote-enabled': {
+        'name': 'Habilitar `Estilo de comillas dobles`',
+        'description': 'Especifica que se debe utilizar el estilo de comillas dobles seleccionado.',
+      },
+      'double-quote-style': {
+        'name': 'Estilo de comillas dobles',
+        'description': 'El estilo de comillas dobles a utilizar.',
+      },
+    },
     're-index-footnotes': {
       'name': 'Volver a indexar notas al pie',
       'description': 'Vuelve a indexar las notas al pie de página y las notas al pie, según el orden de aparición (NOTA: esta regla *no* funciona si hay más de una nota al pie para una clave).',
@@ -645,5 +666,9 @@ export default {
     'first-h1': 'primer encabezado de nivel 1',
     'first-h1-or-filename-if-h1-missing': 'primer encabezado de nivel 1 o nombre de archivo si falta el encabezado de primer nivel 1',
     'filename': 'nombre del archivo',
+    '\'\'': '\'\'', // leave as is
+    '‘’': '‘’', // leave as is
+    '""': '""', // leave as is
+    '“”': '“”', // leave as is
   },
 };

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -82,6 +82,9 @@ export default {
     // rules.ts
     'wrapper-yaml-error': 'yaml出现错误: {ERROR_MESSAGE}',
     'wrapper-unknown-error': '未知错误: {ERROR_MESSAGE}',
+
+    // quote-style.ts
+    'uneven-amount-of-quotes': '`{QUOTE}` 引号在文件中的实例不是偶数，所以我们无法将直引号转换为弯引号',
   },
 
   'notice-text': {
@@ -472,6 +475,27 @@ export default {
       'name': '正确的省略号',
       'description': '用省略号替换三个连续的点。',
     },
+    // quote-style.ts
+    'quote-style': {
+      'name': '报价风格',
+      'description': '更新正文内容中的引号以更新为指定的单引号和双引号样式。',
+      'single-quote-enabled': {
+        'name': '启用`单引号样式`',
+        'description': '指定应使用选定的单引号样式。',
+      },
+      'single-quote-style': {
+        'name': '单引号样式',
+        'description': '要使用的单引号样式。',
+      },
+      'double-quote-enabled': {
+        'name': '启用`双引号样式`',
+        'description': '指定应使用选定的双引号样式。',
+      },
+      'double-quote-style': {
+        'name': '双引号样式',
+        'description': '要使用的双引号样式。',
+      },
+    },
     // re-index-footnotes.ts
     're-index-footnotes': {
       'name': '重新索引脚注',
@@ -740,5 +764,9 @@ export default {
     'first-h1': '第一级标题',
     'first-h1-or-filename-if-h1-missing': '第一级 1 标题或文件名（如果缺少 1 级标题）',
     'filename': '文件名',
+    '\'\'': '\'\'', // leave as is
+    '‘’': '‘’', // leave as is
+    '""': '""', // leave as is
+    '“”': '“”', // leave as is
   },
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,8 @@ const langToMomentLocale = {
   'ja': 'ja',
 };
 
+const userClickTimeout = 0;
+
 const DEFAULT_SETTINGS: Partial<LinterSettings> = {
   ruleConfigs: {},
   lintOnSave: false,
@@ -294,7 +296,6 @@ export default class LinterPlugin extends Plugin {
       }
     }));
 
-    const userClickTimeout = 0;
     if (numberOfErrors === 0) {
       new Notice(getTextInLanguage('commands.lint-all-files.success-message'), userClickTimeout);
     } else {
@@ -323,7 +324,6 @@ export default class LinterPlugin extends Plugin {
       }
     }));
 
-    const userClickTimeout = 0;
     if (numberOfErrors === 0) {
       new Notice(getTextInLanguage('commands.lint-all-files-in-folder.success-message').replace('{NUM}', lintedFiles.toString()).replace('{FOLDER_NAME}', folder.name), userClickTimeout);
     } else {
@@ -419,7 +419,7 @@ export default class LinterPlugin extends Plugin {
         ${charsAdded} ${getTextInLanguage('notice-text.characters-added')}
         ${charsRemoved} ${getTextInLanguage('notice-text.characters-removed')}
       `;
-      new Notice(message);
+      new Notice(message, userClickTimeout);
     }
   }
 
@@ -429,12 +429,12 @@ export default class LinterPlugin extends Plugin {
 
     if (error instanceof LinterError) {
       if (useLogTemplateInNotice) {
-        new Notice(`${errorMessage} ${error.message}.\n${seeConsoleText}`);
+        new Notice(`${errorMessage} ${error.message}.\n${seeConsoleText}`, userClickTimeout);
       } else {
-        new Notice(`${error.message}.\n${seeConsoleText}`);
+        new Notice(`${error.message}.\n${seeConsoleText}`, userClickTimeout);
       }
     } else {
-      new Notice(`${getTextInLanguage('logs.unknown-error')} ${seeConsoleText}`);
+      new Notice(`${getTextInLanguage('logs.unknown-error')} ${seeConsoleText}`, userClickTimeout);
     }
 
     logError(errorMessage, error);
@@ -540,7 +540,7 @@ export default class LinterPlugin extends Plugin {
   async pasteAsPlainText(editor: Editor): Promise<void> {
     const clipboardContent = await navigator.clipboard.readText();
     if (!clipboardContent) {
-      new Notice(getTextInLanguage('notice-text.empty-clipboard'));
+      new Notice(getTextInLanguage('notice-text.empty-clipboard'), userClickTimeout);
       return;
     }
 

--- a/src/rules/quote-style.ts
+++ b/src/rules/quote-style.ts
@@ -211,7 +211,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
       nameKey: 'rules.quote-style.name',
       descriptionKey: 'rules.quote-style.description',
       type: RuleType.CONTENT,
-      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html],
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html, IgnoreTypes.templaterCommand],
     });
   }
   get OptionsClass(): new () => QuoteStyleOptions {
@@ -348,6 +348,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
           "Nesting a quote in a quote like so: 'here I am' is handled correctly"
           'Single quotes by themselves are handled correctly'
           Possessives are handled correctly: Pam's dog is really cool!
+          Templater commands are ignored: <% tp.date.now("YYYY-MM-DD", 7) %>
           ${''}
           Be careful as converting straight quotes to smart quotes requires you to have an even amount of quotes
           once possessives and common contractions have been dealt with. If not, it will throw an error.
@@ -358,6 +359,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
           “Nesting a quote in a quote like so: ‘here I am’ is handled correctly”
           ‘Single quotes by themselves are handled correctly’
           Possessives are handled correctly: Pam’s dog is really cool!
+          Templater commands are ignored: <% tp.date.now("YYYY-MM-DD", 7) %>
           ${''}
           Be careful as converting straight quotes to smart quotes requires you to have an even amount of quotes
           once possessives and common contractions have been dealt with. If not, it will throw an error.

--- a/src/rules/quote-style.ts
+++ b/src/rules/quote-style.ts
@@ -1,0 +1,420 @@
+import {IgnoreTypes} from '../utils/ignore-types';
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import dedent from 'ts-dedent';
+import {smartDoubleQuoteRegex, smartSingleQuoteRegex} from '../utils/regex';
+import {countInstances} from '../utils/strings';
+import {getTextInLanguage} from '../lang/helpers';
+
+export enum SingleQuoteStyles {
+  Straight = '\'\'',
+  SmartQuote = '‘’',
+}
+
+export enum DoubleQuoteStyles {
+  Straight = '""',
+  SmartQuote = '“”',
+}
+
+// from https://en.wikipedia.org/wiki/Wikipedia:List_of_English_contractions with any contractions
+// missing a single quote removed
+const englishContractions = [
+  'a\'ight',
+  'ain\'t',
+  'amn\'t',
+  '\'n\'',
+  'aren\'t',
+  '\'bout',
+  'boy\'s',
+  'can\'t',
+  'cap\'n',
+  '\'cause',
+  '\'cept',
+  'could\'ve',
+  'couldn\'t',
+  'couldn\'t\'ve',
+  'daren\'t',
+  'daresn\'t',
+  'dasn\'t',
+  'didn\'t',
+  'doesn\'t',
+  'don\'t',
+  'd\'ye',
+  'd\'ya',
+  'e\'en',
+  'e\'er',
+  '\'em',
+  'everybody\'s',
+  'everyone\'s',
+  'everything\'s',
+  'fo\'c\'sle',
+  '\'gainst',
+  'g\'day',
+  'girl\'s',
+  'giv\'n',
+  'gi\'z',
+  'gon\'t',
+  'guy\'s',
+  'hadn\'t',
+  'had\'ve',
+  'hasn\'t',
+  'haven\'t',
+  'he\'d',
+  'he\'ll',
+  'he\'s',
+  'here\'s',
+  'how\'d',
+  'how\'ll',
+  'how\'re',
+  'how\'s',
+  'I\'d',
+  'I\'d\'ve',
+  'I\'d\'nt',
+  'I\'d\'nt\'ve',
+  'If\'n',
+  'I\'ll',
+  'I\'m',
+  'I\'m\'o',
+  'I\'ve',
+  'isn\'t',
+  'it\'d',
+  'it\'ll',
+  'it\'s',
+  'let\'s',
+  'loven\'t',
+  'ma\'am',
+  'mayn\'t',
+  'may\'ve',
+  'mightn\'t',
+  'might\'ve',
+  'mine\'s',
+  'mustn\'t',
+  'mustn\'t\'ve',
+  'must\'ve',
+  '\'neath',
+  'needn\'t',
+  'ne\'er',
+  'o\'clock',
+  'o\'er',
+  'ol\'',
+  'ought\'ve',
+  'oughtn\'t',
+  'oughtn\'t\'ve',
+  '\'round',
+  'shalln\'t',
+  'shan\'',
+  'shan\'t',
+  'she\'d',
+  'she\'ll',
+  'she\'s',
+  'should\'ve',
+  'shouldn\'t',
+  'shouldn\'t\'ve',
+  'somebody\'s',
+  'someone\'s',
+  'something\'s',
+  'so\'re',
+  'so\'s',
+  'so\'ve',
+  'that\'ll',
+  'that\'re',
+  'that\'s',
+  'that\'d',
+  'there\'d',
+  'there\'ll',
+  'there\'re',
+  'there\'s',
+  'these\'re',
+  'these\'ve',
+  'they\'d',
+  'they\'d\'ve',
+  'they\'ll',
+  'they\'re',
+  'they\'ve',
+  'this\'s',
+  'those\'re',
+  'those\'ve',
+  '\'thout',
+  '\'til',
+  '\'tis',
+  'to\'ve',
+  '\'twas',
+  '\'tween',
+  '\'twere',
+  'w\'all',
+  'w\'at',
+  'wasn\'t',
+  'we\'d',
+  'we\'d\'ve',
+  'we\'ll',
+  'we\'re',
+  'we\'ve',
+  'weren\'t',
+  'what\'d',
+  'what\'ll',
+  'what\'re',
+  'what\'s',
+  'what\'ve',
+  'when\'s',
+  'where\'d',
+  'where\'ll',
+  'where\'re',
+  'where\'s',
+  'where\'ve',
+  'which\'d',
+  'which\'ll',
+  'which\'re',
+  'which\'s',
+  'which\'ve',
+  'who\'d',
+  'who\'d\'ve',
+  'who\'ll',
+  'who\'re',
+  'who\'s',
+  'who\'ve',
+  'why\'d',
+  'why\'re',
+  'why\'s',
+  'willn\'t',
+  'won\'t',
+  'would\'ve',
+  'wouldn\'t',
+  'wouldn\'t\'ve',
+  'y\'ain\'t',
+  'y\'all',
+  'y\'all\'d\'ve',
+  'y\'all\'d\'n\'t\'ve',
+  'y\'all\'re',
+  'y\'all\'ren\'t',
+  'y\'at',
+  'yes\'m',
+  'y\'know',
+  'you\'d',
+  'you\'ll',
+  'you\'re',
+  'you\'ve',
+  'when\'d',
+  'willn\'t',
+];
+
+class QuoteStyleOptions implements Options {
+  singleQuoteStyleEnabled?: boolean = true;
+  singleQuoteStyle?: SingleQuoteStyles = SingleQuoteStyles.Straight;
+  doubleQuoteStyleEnabled?: boolean = true;
+  doubleQuoteStyle?: DoubleQuoteStyles = DoubleQuoteStyles.Straight;
+}
+
+@RuleBuilder.register
+export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
+  constructor() {
+    super({
+      nameKey: 'rules.quote-style.name',
+      descriptionKey: 'rules.quote-style.description',
+      type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html],
+    });
+  }
+  get OptionsClass(): new () => QuoteStyleOptions {
+    return QuoteStyleOptions;
+  }
+  apply(text: string, options: QuoteStyleOptions): string {
+    let newText = text;
+    if (options.doubleQuoteStyleEnabled) {
+      if (options.doubleQuoteStyle === DoubleQuoteStyles.Straight) {
+        newText = this.convertSmartDoubleQuotesToStraightQuotes(newText);
+      } else {
+        newText = this.convertStraightDoubleQuotesToDoubleSmartQuotes(newText);
+      }
+    }
+
+    if (options.singleQuoteStyleEnabled) {
+      if (options.singleQuoteStyle === SingleQuoteStyles.Straight) {
+        newText = this.convertSmartSingleQuotesToStraightQuotes(newText);
+      } else {
+        newText = this.convertStraightSingleQuotesToSingleSmartQuotes(newText);
+      }
+    }
+
+    return newText;
+  }
+  convertSmartSingleQuotesToStraightQuotes(text: string): string {
+    return text.replace(smartSingleQuoteRegex, '\'');
+  }
+  convertSmartDoubleQuotesToStraightQuotes(text: string): string {
+    return text.replace(smartDoubleQuoteRegex, '"');
+  }
+  // based on https://inkplant.com/tools/smart-quotes-converter
+  convertStraightDoubleQuotesToDoubleSmartQuotes(text: string): string {
+    this.throwErrorIfNotEqualNumberOfQuotes(text, '"');
+    const openingDoubleQuote = DoubleQuoteStyles.SmartQuote[0];
+    const endingDoubleQuote = DoubleQuoteStyles.SmartQuote[1];
+
+    let numReplacementsMade = 0;
+    text = text.replaceAll('"', () => {
+      let doubleQuote = openingDoubleQuote;
+      if (numReplacementsMade % 2 === 1) {
+        doubleQuote = endingDoubleQuote;
+      }
+
+      numReplacementsMade++;
+
+      return doubleQuote;
+    });
+
+    return text;
+  }
+  // based on https://inkplant.com/tools/smart-quotes-converter
+  convertStraightSingleQuotesToSingleSmartQuotes(text: string): string {
+    const openingSingleQuote = SingleQuoteStyles.SmartQuote[0];
+    const endingSingleQuote = SingleQuoteStyles.SmartQuote[1];
+
+    text = this.convertContractionStraightQuotesToSmartQuotes(text, openingSingleQuote, endingSingleQuote);
+
+    text = this.convertPossessiveStraightQuotesToSmartQuotes(text, endingSingleQuote);
+
+    this.throwErrorIfNotEqualNumberOfQuotes(text, '\'');
+
+    let numReplacementsMade = 0;
+    text = text.replaceAll('\'', () => {
+      let singleQuote = openingSingleQuote;
+      if (numReplacementsMade % 2 === 1) {
+        singleQuote = endingSingleQuote;
+      }
+
+      numReplacementsMade++;
+
+      return singleQuote;
+    });
+
+    return text;
+  }
+  convertContractionStraightQuotesToSmartQuotes(text: string, openingSmartQuote: string, closingSmartQuote: string): string {
+    const replaceMatchQuotes = function(match: string) {
+      if (match[0] === '\'') {
+        match = openingSmartQuote + match.substring(1);
+      }
+
+      return match.replaceAll('\'', closingSmartQuote);
+    };
+
+    for (const contraction of englishContractions) {
+      text = text.replace(new RegExp(contraction, 'gi'), replaceMatchQuotes);
+    }
+
+    return text;
+  }
+  convertPossessiveStraightQuotesToSmartQuotes(text: string, smartQuote: string): string {
+    return text.replace(/([a-zA-Z0-9]'s|s')/g, (match: string) => {
+      return match.replace('\'', smartQuote);
+    });
+  }
+  throwErrorIfNotEqualNumberOfQuotes(text: string, quote: string) {
+    const numInstances = countInstances(text, quote);
+
+    if (numInstances % 2 !== 0) {
+      throw new Error(getTextInLanguage('logs.uneven-amount-of-quotes').replace('{QUOTE}', quote));
+    }
+  }
+  get exampleBuilders(): ExampleBuilder<QuoteStyleOptions>[] {
+    return [
+      new ExampleBuilder<QuoteStyleOptions>({
+        description: 'Smart quotes used in file are converted to straight quotes when styles are set to `Straight`',
+        before: dedent`
+          # Double Quote Cases
+          “There are a bunch of different kinds of smart quote indicators”
+          „More than you would think”
+          «Including this one for Spanish»
+          # Single Quote Cases
+          ‘Simple smart quotes get replaced’
+          ‚Another single style smart quote also gets replaced’
+          ‹Even this style of single smart quotes is replaced›
+        `,
+        after: dedent`
+          # Double Quote Cases
+          "There are a bunch of different kinds of smart quote indicators"
+          "More than you would think"
+          "Including this one for Spanish"
+          # Single Quote Cases
+          'Simple smart quotes get replaced'
+          'Another single style smart quote also gets replaced'
+          'Even this style of single smart quotes is replaced'
+        `,
+      }),
+      new ExampleBuilder<QuoteStyleOptions>({
+        description: 'Straight quotes used in file are converted to smart quotes when styles are set to `Smart`',
+        before: dedent`
+          "As you can see, these double quotes will be converted to smart quotes"
+          "Common contractions are handled as well. For example can't is updated to smart quotes."
+          "Nesting a quote in a quote like so: 'here I am' is handled correctly"
+          'Single quotes by themselves are handled correctly'
+          Possessives are handled correctly: Pam's dog is really cool!
+          ${''}
+          Be careful as converting straight quotes to smart quotes requires you to have an even amount of quotes
+          once possessives and common contractions have been dealt with. If not, it will throw an error.
+        `,
+        after: dedent`
+          “As you can see, these double quotes will be converted to smart quotes”
+          “Common contractions are handled as well. For example can’t is updated to smart quotes.”
+          “Nesting a quote in a quote like so: ‘here I am’ is handled correctly”
+          ‘Single quotes by themselves are handled correctly’
+          Possessives are handled correctly: Pam’s dog is really cool!
+          ${''}
+          Be careful as converting straight quotes to smart quotes requires you to have an even amount of quotes
+          once possessives and common contractions have been dealt with. If not, it will throw an error.
+        `,
+        options: {
+          singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+          doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<QuoteStyleOptions>[] {
+    return [
+      new BooleanOptionBuilder({
+        OptionsClass: QuoteStyleOptions,
+        nameKey: 'rules.quote-style.single-quote-enabled.name',
+        descriptionKey: 'rules.quote-style.single-quote-enabled.description',
+        optionsKey: 'singleQuoteStyleEnabled',
+      }),
+      new DropdownOptionBuilder<QuoteStyleOptions, SingleQuoteStyles>({
+        OptionsClass: QuoteStyleOptions,
+        nameKey: 'rules.quote-style.single-quote-style.name',
+        descriptionKey: 'rules.quote-style.single-quote-style.description',
+        optionsKey: 'singleQuoteStyle',
+        records: [
+          {
+            value: SingleQuoteStyles.Straight,
+            description: 'Uses "\'" instead of smart single quotes',
+          },
+          {
+            value: SingleQuoteStyles.SmartQuote,
+            description: 'Uses "‘" and "’" instead of straight single quotes',
+          },
+        ],
+      }),
+      new BooleanOptionBuilder({
+        OptionsClass: QuoteStyleOptions,
+        nameKey: 'rules.quote-style.double-quote-enabled.name',
+        descriptionKey: 'rules.quote-style.double-quote-enabled.description',
+        optionsKey: 'doubleQuoteStyleEnabled',
+      }),
+      new DropdownOptionBuilder<QuoteStyleOptions, DoubleQuoteStyles>({
+        OptionsClass: QuoteStyleOptions,
+        nameKey: 'rules.quote-style.double-quote-style.name',
+        descriptionKey: 'rules.quote-style.double-quote-style.description',
+        optionsKey: 'doubleQuoteStyle',
+        records: [
+          {
+            value: DoubleQuoteStyles.Straight,
+            description: 'Uses \'"\' instead of smart double quotes',
+          },
+          {
+            value: DoubleQuoteStyles.SmartQuote,
+            description: 'Uses \'“\' and \'”\' instead of straight double quotes',
+          },
+        ],
+      }),
+    ];
+  }
+}

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -1,4 +1,4 @@
-import {obsidianMultilineCommentRegex, tagWithLeadingWhitespaceRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns, genericLinkRegex, urlRegex, anchorTagRegex} from './regex';
+import {obsidianMultilineCommentRegex, tagWithLeadingWhitespaceRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns, genericLinkRegex, urlRegex, anchorTagRegex, templaterCommandRegex} from './regex';
 import {getAllCustomIgnoreSectionsInText, getAllTablesInText, getPositions, MDAstTypes} from './mdast';
 import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
@@ -28,6 +28,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   footnoteAfterATask: {replaceAction: /- \[.] (\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AFTER_A_TASK_PLACEHOLDER}'},
   url: {replaceAction: urlRegex, placeholder: '{URL_PLACEHOLDER}'},
   anchorTag: {replaceAction: anchorTagRegex, placeholder: '{ANCHOR_PLACEHOLDER}'},
+  templaterCommand: {replaceAction: templaterCommandRegex, placeholder: '{TEMPLATER_PLACEHOLDER}'},
   // custom functions
   link: {replaceAction: replaceMarkdownLinks, placeholder: '{REGULAR_LINK_PLACEHOLDER}'},
   tag: {replaceAction: replaceTags, placeholder: '#tag-placeholder'},

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -31,6 +31,9 @@ export const htmlEntitiesRegex = /&[^\s]+;$/mi;
 export const customIgnoreAllStartIndicator = generateHTMLLinterCommentWithSpecificTextAndWhitespaceRegexMatch(true);
 export const customIgnoreAllEndIndicator = generateHTMLLinterCommentWithSpecificTextAndWhitespaceRegexMatch(false);
 
+export const smartDoubleQuoteRegex = /[“”„«»]/g;
+export const smartSingleQuoteRegex = /[‘’‚‹›]/g;
+
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string
 // could have user constructed dollar signs in it

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -34,6 +34,8 @@ export const customIgnoreAllEndIndicator = generateHTMLLinterCommentWithSpecific
 export const smartDoubleQuoteRegex = /[“”„«»]/g;
 export const smartSingleQuoteRegex = /[‘’‚‹›]/g;
 
+export const templaterCommandRegex = /<%[^]*?%>/g;
+
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string
 // could have user constructed dollar signs in it

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -325,3 +325,19 @@ export function replaceAt(text: string, search: string, replace: string, start: 
   return text.slice(0, start) +
       text.slice(start, text.length).replace(search, replace);
 }
+
+// based on https://stackoverflow.com/a/21730166/8353749
+export function countInstances(text: string, instancesOf: string): number {
+  let counter = 0;
+
+  for (let i = 0, input_length = text.length; i < input_length; i++) {
+    const index_of_sub = text.indexOf(instancesOf, i);
+
+    if (index_of_sub > -1) {
+      counter++;
+      i = index_of_sub;
+    }
+  }
+
+  return counter;
+}


### PR DESCRIPTION
Fixes #399 
Fixes #707 

Changes Made:
- Added a rule to allow the user to specify the types of single and double quotes to use in the content of a file
- Added a function for helping count the number of instances of a substring in a string
- Added examples of how this rule works when converting to and from smart quotes
- Added regex for smart quotes
- Added an ignore for Templater blocks
- Added Google translate translations for Spanish, German, and Simplified Chinese
- Updated error message notices to require a user's click to make them go away
