### PR TITLE
Update Logic to Allow Custom Regex Replacement to Change Order Via Buttons

### DIFF
--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -199,6 +199,8 @@ export default {
       'regex-to-find-placeholder-text': 'Regex zu finden',
       'flags-placeholder-text': 'Flaggen',
       'regex-to-replace-placeholder-text': 'Regex zu ersetzen',
+      'move-up-tooltip': 'Aufrücken',
+      'move-down-tooltip': 'Bewegen Sie sich nach unten',
       'delete-tooltip': 'Löschen',
     },
   },

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -199,6 +199,8 @@ export default {
       'regex-to-find-placeholder-text': 'regex to find',
       'flags-placeholder-text': 'flags',
       'regex-to-replace-placeholder-text': 'regex to replace',
+      'move-up-tooltip': 'Move up',
+      'move-down-tooltip': 'Move down',
       'delete-tooltip': 'Delete',
     },
   },

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -167,6 +167,8 @@ export default {
       'regex-to-find-placeholder-text': 'Regex para encontrar',
       'flags-placeholder-text': 'Marcas',
       'regex-to-replace-placeholder-text': 'Regex para reemplazar',
+      'move-up-tooltip': 'Desplazar hacia arriba',
+      'move-down-tooltip': 'Desplazar hacia abajo',
       'delete-tooltip': 'Borrar',
     },
   },

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -199,6 +199,8 @@ export default {
       'regex-to-find-placeholder-text': '正则查找',
       'flags-placeholder-text': 'flags',
       'regex-to-replace-placeholder-text': '正则替换',
+      'move-up-tooltip': '上移',
+      'move-down-tooltip': '下移',
       'delete-tooltip': '删除',
     },
   },

--- a/src/ui/linter-components/custom-replace-option.ts
+++ b/src/ui/linter-components/custom-replace-option.ts
@@ -31,7 +31,7 @@ export class CustomReplaceOption extends AddCustomRow {
   }
 
   private addRegex(regex: CustomReplace, index: number, focusOnCommand: boolean = false) {
-    new Setting(this.inputElDiv).addText((cb) => {
+    const setting = new Setting(this.inputElDiv).addText((cb) => {
       cb.setPlaceholder(getTextInLanguage('options.custom-replace.regex-to-find-placeholder-text'))
           .setValue(regex.find)
           .onChange((value) => {
@@ -58,6 +58,22 @@ export class CustomReplaceOption extends AddCustomRow {
             this.regexes[index].replace = value;
             this.saveSettings();
           });
+    }).addExtraButton((cb) => {
+      cb.setIcon('up-chevron-glyph')
+          .setTooltip(getTextInLanguage('options.custom-replace.move-up-tooltip'))
+          .onClick(() => {
+            this.arrayMove(index, index - 1);
+            this.saveSettings();
+            this.resetInputEls();
+          });
+    }).addExtraButton((cb) => {
+      cb.setIcon('down-chevron-glyph')
+          .setTooltip(getTextInLanguage('options.custom-replace.move-down-tooltip'))
+          .onClick(() => {
+            this.arrayMove(index, index + 1);
+            this.saveSettings();
+            this.resetInputEls();
+          });
     }).addExtraButton((cb)=>{
       cb.setIcon('cross')
           .setTooltip(getTextInLanguage('options.custom-replace.delete-tooltip'))
@@ -67,5 +83,18 @@ export class CustomReplaceOption extends AddCustomRow {
             this.resetInputEls();
           });
     });
+
+    setting.settingEl.style.flexWrap = 'wrap';
+  }
+
+  // TODO: swap this out for something that actually swaps the values of the html elements as well to avoid the need for a refresh of these settings on swap and delete
+  private arrayMove(fromIndex: number, toIndex: number) {
+    if (toIndex < 0 || toIndex === this.regexes.length) {
+      return;
+    }
+
+    const element = this.regexes[fromIndex];
+    this.regexes[fromIndex] = this.regexes[toIndex];
+    this.regexes[toIndex] = element;
   }
 }


### PR DESCRIPTION
Fixes #584

Changes Made:
- Had to add flex to setting to make it show up somewhat nicely on desktop
- Added new language string for Linter for custom regex replacement
- Added buttons for moving custom regex replacement up and down