### PR TITLE
Make Linter Compliant with Component Usage for MarkdownRenderer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ const DEFAULT_SETTINGS: Partial<LinterSettings> = {
 
 export default class LinterPlugin extends Plugin {
   settings: LinterSettings;
+  settingsTab: SettingTab;
   private eventRefs: EventRef[] = [];
   private momentLocale: string;
   private isEnabled: boolean = true;
@@ -88,7 +89,8 @@ export default class LinterPlugin extends Plugin {
 
     this.registerEventsAndSaveCallback();
 
-    this.addSettingTab(new SettingTab(this.app, this));
+    this.settingsTab = new SettingTab(this.app, this);
+    this.addSettingTab(this.settingsTab);
   }
 
   async onunload() {

--- a/src/option.ts
+++ b/src/option.ts
@@ -42,9 +42,9 @@ export abstract class Option {
     settings.ruleConfigs[this.ruleAlias][this.configKey] = value;
   }
 
-  protected parseNameAndDescriptionAndRemoveSettingBorder(setting: Setting) {
-    parseTextToHTMLWithoutOuterParagraph(this.getName(), setting.nameEl);
-    parseTextToHTMLWithoutOuterParagraph(this.getDescription(), setting.descEl);
+  protected parseNameAndDescriptionAndRemoveSettingBorder(setting: Setting, plugin: LinterPlugin) {
+    parseTextToHTMLWithoutOuterParagraph(this.getName(), setting.nameEl, plugin.settingsTab.component);
+    parseTextToHTMLWithoutOuterParagraph(this.getDescription(), setting.descEl, plugin.settingsTab.component);
 
     // remove border around every setting item
     setting.settingEl.style.border = 'none';
@@ -65,7 +65,7 @@ export class BooleanOption extends Option {
           });
         });
 
-    this.parseNameAndDescriptionAndRemoveSettingBorder(setting);
+    this.parseNameAndDescriptionAndRemoveSettingBorder(setting, plugin);
   }
 }
 
@@ -83,7 +83,7 @@ export class TextOption extends Option {
           });
         });
 
-    this.parseNameAndDescriptionAndRemoveSettingBorder(setting);
+    this.parseNameAndDescriptionAndRemoveSettingBorder(setting, plugin);
   }
 }
 
@@ -101,7 +101,7 @@ export class TextAreaOption extends Option {
           });
         });
 
-    this.parseNameAndDescriptionAndRemoveSettingBorder(setting);
+    this.parseNameAndDescriptionAndRemoveSettingBorder(setting, plugin);
   }
 }
 
@@ -120,7 +120,7 @@ export class MomentFormatOption extends Option {
           });
         });
 
-    this.parseNameAndDescriptionAndRemoveSettingBorder(setting);
+    this.parseNameAndDescriptionAndRemoveSettingBorder(setting, plugin);
   }
 }
 
@@ -169,6 +169,6 @@ export class DropdownOption extends Option {
           });
         });
 
-    this.parseNameAndDescriptionAndRemoveSettingBorder(setting);
+    this.parseNameAndDescriptionAndRemoveSettingBorder(setting, plugin);
   }
 }

--- a/src/ui/components/add-custom-row.ts
+++ b/src/ui/components/add-custom-row.ts
@@ -1,4 +1,4 @@
-import {Setting} from 'obsidian';
+import {Component, Setting} from 'obsidian';
 import {parseTextToHTMLWithoutOuterParagraph} from '../helpers';
 
 /**
@@ -10,6 +10,7 @@ export abstract class AddCustomRow {
 
   constructor(
     public containerEl: HTMLElement,
+    public parentComponent: Component,
     public name: string,
     public description: string,
     public warning: string,
@@ -22,7 +23,7 @@ export abstract class AddCustomRow {
   display() {
     this.containerEl.createEl(this.isMobile ? 'h4' : 'h3', {text: this.name});
 
-    parseTextToHTMLWithoutOuterParagraph(this.description, this.containerEl);
+    parseTextToHTMLWithoutOuterParagraph(this.description, this.containerEl, this.parentComponent);
     if (this.warning != null) {
       this.containerEl.createEl('p', {text: this.warning, cls: 'mod-warning'});
     }

--- a/src/ui/helpers.ts
+++ b/src/ui/helpers.ts
@@ -1,7 +1,7 @@
-import {MarkdownRenderer} from 'obsidian';
+import {Component, MarkdownRenderer} from 'obsidian';
 
-export function parseTextToHTMLWithoutOuterParagraph(text: string, containerEl: HTMLElement) {
-  MarkdownRenderer.renderMarkdown(text, containerEl, '', null);
+export function parseTextToHTMLWithoutOuterParagraph(text: string, containerEl: HTMLElement, component: Component) {
+  MarkdownRenderer.renderMarkdown(text, containerEl, '', component);
 
   let htmlString = containerEl.innerHTML.trim();
   if (htmlString.startsWith('<p>')) {

--- a/src/ui/linter-components/custom-command-option.ts
+++ b/src/ui/linter-components/custom-command-option.ts
@@ -1,4 +1,4 @@
-import {Setting, App} from 'obsidian';
+import {Setting, App, Component} from 'obsidian';
 import {getTextInLanguage} from 'src/lang/helpers';
 import {AddCustomRow} from '../components/add-custom-row';
 import CommandSuggester from '../suggesters/command-suggester';
@@ -6,8 +6,9 @@ import CommandSuggester from '../suggesters/command-suggester';
 export type LintCommand = { id: string, name: string };
 
 export class CustomCommandOption extends AddCustomRow {
-  constructor(containerEl: HTMLElement, public lintCommands: LintCommand[], isMobile: boolean, private app: App, saveSettings: () => void) {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public lintCommands: LintCommand[], isMobile: boolean, private app: App, saveSettings: () => void) {
     super(containerEl,
+        parentComponent,
         getTextInLanguage('options.custom-command.name'),
         getTextInLanguage('options.custom-command.description'),
         getTextInLanguage('options.custom-command.warning'),

--- a/src/ui/linter-components/custom-replace-option.ts
+++ b/src/ui/linter-components/custom-replace-option.ts
@@ -1,4 +1,4 @@
-import {Setting} from 'obsidian';
+import {Setting, Component} from 'obsidian';
 import {getTextInLanguage} from 'src/lang/helpers';
 import {AddCustomRow} from '../components/add-custom-row';
 export type CustomReplace = {find: string, replace: string, flags: string};
@@ -6,9 +6,10 @@ export type CustomReplace = {find: string, replace: string, flags: string};
 const defaultFlags = 'gm';
 
 export class CustomReplaceOption extends AddCustomRow {
-  constructor(containerEl: HTMLElement, public regexes: CustomReplace[], isMobile: boolean, saveSettings: () => void) {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public regexes: CustomReplace[], isMobile: boolean, saveSettings: () => void) {
     super(
         containerEl,
+        parentComponent,
         getTextInLanguage('options.custom-replace.name'),
         getTextInLanguage('options.custom-replace.description'),
         getTextInLanguage('options.custom-replace.warning'),

--- a/src/ui/linter-components/tab-components/custom-tab.ts
+++ b/src/ui/linter-components/tab-components/custom-tab.ts
@@ -12,13 +12,13 @@ export class CustomTab extends Tab {
 
   display(): void {
     const customCommandEl = this.contentEl.createDiv();
-    const customCommands = new CustomCommandOption(customCommandEl, this.plugin.settings.lintCommands, this.isMobile, this.app, () => {
+    const customCommands = new CustomCommandOption(customCommandEl, this.plugin.settingsTab.component, this.plugin.settings.lintCommands, this.isMobile, this.app, () => {
       this.plugin.saveSettings();
     });
     this.addSettingSearchInfo(customCommandEl, customCommands.name, customCommands.description.replaceAll('\n', ' ') + customCommands.warning.replaceAll('\n', ' '));
 
     const customReplaceEl = this.contentEl.createDiv();
-    const customRegexes = new CustomReplaceOption(customReplaceEl, this.plugin.settings.customRegexes, this.isMobile, () => {
+    const customRegexes = new CustomReplaceOption(customReplaceEl, this.plugin.settingsTab.component, this.plugin.settings.customRegexes, this.isMobile, () => {
       this.plugin.saveSettings();
     });
     this.addSettingSearchInfo(customReplaceEl, customRegexes.name, customRegexes.description.replaceAll('\n', ' ') + customRegexes.warning.replaceAll('\n', ' '));

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -65,7 +65,7 @@ export class DebugTab extends Tab {
               });
         });
 
-    parseTextToHTMLWithoutOuterParagraph(settingDesc, setting.descEl);
+    parseTextToHTMLWithoutOuterParagraph(settingDesc, setting.descEl, this.plugin.settingsTab.component);
 
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
 
@@ -75,7 +75,7 @@ export class DebugTab extends Tab {
     const logDisplay = new TextBoxFull(tempDiv, settingName, '');
     logDisplay.inputEl.setText(logsFromLastRun.join('\n'));
 
-    parseTextToHTMLWithoutOuterParagraph(settingDesc, logDisplay.descEl);
+    parseTextToHTMLWithoutOuterParagraph(settingDesc, logDisplay.descEl, this.plugin.settingsTab.component);
 
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
   }

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -27,7 +27,7 @@ export class GeneralTab extends Tab {
               });
         });
 
-    parseTextToHTMLWithoutOuterParagraph(settingDesc, setting.descEl);
+    parseTextToHTMLWithoutOuterParagraph(settingDesc, setting.descEl, this.plugin.settingsTab.component);
 
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
 

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -1,4 +1,4 @@
-import {App, Platform, PluginSettingTab} from 'obsidian';
+import {App, Component, Platform, PluginSettingTab} from 'obsidian';
 import LinterPlugin from 'src/main';
 import {RuleType, ruleTypeToRules} from 'src/rules';
 import {hideEl} from './helpers';
@@ -11,23 +11,24 @@ import {DebugTab} from './linter-components/tab-components/debug-tab';
 import {getTextInLanguage} from 'src/lang/helpers';
 
 export class SettingTab extends PluginSettingTab {
-  plugin: LinterPlugin;
   navContainer: HTMLElement;
   tabNavEl: HTMLDivElement;
   settingsContentEl: HTMLDivElement;
+  component: Component;
   private tabNameToTab: Map<string, Tab> = new Map<string, Tab>();
   private selectedTab: string = 'General';
   private searchZeroState: HTMLDivElement;
   private tabSearcher: TabSearcher;
 
-  constructor(app: App, plugin: LinterPlugin) {
+  constructor(app: App, public plugin: LinterPlugin) {
     super(app, plugin);
-    this.plugin = plugin;
+    this.component = new Component();
   }
 
   display(): void {
     const {containerEl} = this;
 
+    this.component.load();
     containerEl.empty();
     const linterHeader = containerEl.createDiv('linter-setting-title');
     if (Platform.isMobile) {
@@ -46,6 +47,10 @@ export class SettingTab extends PluginSettingTab {
     if (this.selectedTab == '') {
       this.tabSearcher.focusOnInput();
     }
+  }
+
+  hide(): void {
+    this.component.unload();
   }
 
   private addTabs(isMobile: boolean) {


### PR DESCRIPTION
Fixes #734 

There was a change in the most recent update of Obsidian that helps prevent memory leaks and other issues. It added a warning for not using a component when using `renderMarkdown`. To make sure we are compliant and prevent the risk of a memory leak, a component (a settings tab component) is used to make sure things are loaded and unloaded properly for UI components which are used form the settings page.

Changes Made:
- Updated `renderMarkdown` to now get a the component to control the existence of the markdown on
- Populated the change to params up
- Updated `esbuild` to make sure it ignored the proper import for generating docs.