### PR TITLE
Fixed Issue with Custom Ignore Replacement Order

### DIFF
--- a/__tests__/get-all-custom-ignore-sections-in-text.test.ts
+++ b/__tests__/get-all-custom-ignore-sections-in-text.test.ts
@@ -91,7 +91,37 @@ const getCustomIgnoreSectionsInTextTestCases: customIgnoresInTextTestCase[] = [
       Finish
     `,
     expectedCustomIgnoresInText: 2,
-    expectedPositions: [{startIndex: 17, endIndex: 87}, {startIndex: 178, endIndex: 316}],
+    expectedPositions: [{startIndex: 178, endIndex: 316}, {startIndex: 17, endIndex: 87}],
+  },
+  { // relates to https://github.com/platers/obsidian-linter/issues/733
+    name: 'multiple matches can be returned',
+    text: dedent`
+      content
+      ${''}
+      <!-- linter-disable -->
+      ${''}
+      $$
+      abc
+      $$
+      {#eq:a}
+      ${''}
+      <!-- linter-enable -->
+      ${''}
+      content
+      ${''}
+      <!-- linter-disable -->
+      ${''}
+      $$
+      abc
+      $$
+      {#eq:b}
+      ${''}
+      <!-- linter-enable -->
+      ${''}
+      content
+    `,
+    expectedCustomIgnoresInText: 2,
+    expectedPositions: [{startIndex: 86, endIndex: 152}, {startIndex: 9, endIndex: 75}],
   },
 ];
 

--- a/__tests__/ignore-list-of-types.test.ts
+++ b/__tests__/ignore-list-of-types.test.ts
@@ -1,0 +1,76 @@
+import {IgnoreType, IgnoreTypes, ignoreListOfTypes} from '../src/utils/ignore-types';
+import dedent from 'ts-dedent';
+
+type customIgnoresInTextTestCase = {
+  name: string,
+  text: string,
+  expectedTextAfterIgnore: string,
+  ignoreTypes: IgnoreType[];
+};
+
+const ignoreListOfTypesTestCases: customIgnoresInTextTestCase[] = [
+  {
+    name: 'when no ignore type is provided, the text stays the same',
+    text: dedent`
+      Here is some text
+      Here is some more text
+    `,
+    expectedTextAfterIgnore: dedent`
+      Here is some text
+      Here is some more text
+    `,
+    ignoreTypes: [],
+  },
+  { // accounts for https://github.com/platers/obsidian-linter/issues/733
+    name: 'when no custom ignore ranges are used and multiple times, the text is properly replaced and put back together',
+    text: dedent`
+      content
+      ${''}
+      <!-- linter-disable -->
+      ${''}
+      $$
+      abc
+      $$
+      ${''}
+      <!-- linter-enable -->
+      ${''}
+      content
+      ${''}
+      <!-- linter-disable -->
+      ${''}
+      $$
+      abc
+      $$
+      ${''}
+      <!-- linter-enable -->
+      ${''}
+      content
+    `,
+    expectedTextAfterIgnore: dedent`
+      content
+      ${''}
+      {CUSTOM_IGNORE_PLACEHOLDER}
+      ${''}
+      content
+      ${''}
+      {CUSTOM_IGNORE_PLACEHOLDER}
+      ${''}
+      content
+    `,
+    ignoreTypes: [IgnoreTypes.customIgnore],
+  },
+];
+
+describe('Ignore List of Types', () => {
+  for (const testCase of ignoreListOfTypesTestCases) {
+    it(testCase.name, () => {
+      const text = ignoreListOfTypes(testCase.ignoreTypes, testCase.text, (text: string) => {
+        expect(text).toEqual(testCase.expectedTextAfterIgnore);
+
+        return text;
+      } );
+
+      expect(text).toEqual(testCase.text);
+    });
+  }
+});

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -53,8 +53,8 @@ esbuild.build({
         'import {moment} from \'obsidian\';': 'import moment from \'moment\';',
         // remove the use of obsidian in the options to allow for docs.js to run
         'import {Setting} from \'obsidian\';': '',
-        // remove the use of obsidian in settings helper to allow for dovs.js to run
-        'import {MarkdownRenderer} from \'obsidian\';': '',
+        // remove the use of obsidian in settings helper to allow for docs.js to run
+        'import {Component, MarkdownRenderer} from \'obsidian\';': '',
       },
       delimiters: ['', ''],
     }),

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -929,5 +929,5 @@ export function getAllCustomIgnoreSectionsInText(text: string): {startIndex: num
     }
   });
 
-  return positions;
+  return positions.reverse();
 }


### PR DESCRIPTION
Fixes #733 

Changes Made:
- Reversed the order of the custom ignore ranges found to make sure they are replaced from the last instance back to the first to prevent issues like the one reported with incorrect ignoring of text
- Added tests to help reproduce and narrow down the issue
- Added the `esbuild` file that was supposed to be a part of #735 