### PR TITLE
Make Checklists Account for Custom Checklist Markers

### DIFF
--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -135,7 +135,6 @@ export class RulesRunner {
   }
 
   runCustomCommands(lintCommands: LintCommand[], commands: ObsidianCommandInterface) {
-    // execute custom commands after regular rules, but before the timestamp rules
     logDebug(getTextInLanguage('logs.running-custom-lint-command'));
     const commandsRun = new Set<string>();
     for (const commandInfo of lintCommands) {

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -2,7 +2,7 @@ import {visit} from 'unist-util-visit';
 import type {Position} from 'unist';
 import type {Root} from 'mdast';
 import {hashString53Bit, makeSureContentHasEmptyLinesAddedBeforeAndAfter, replaceTextBetweenStartAndEndWithNewValue, getStartOfLineIndex, replaceAt} from './strings';
-import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator} from './regex';
+import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator, checklistBoxStartsTextRegex} from './regex';
 import {gfmFootnote} from 'micromark-extension-gfm-footnote';
 import {gfmTaskListItem} from 'micromark-extension-gfm-task-list-item';
 import {combineExtensions} from 'micromark-util-combine-extensions';
@@ -529,7 +529,6 @@ export function updateBoldText(text: string, func:(text: string) => string): str
 
 export function updateListItemText(text: string, func:(text: string) => string): string {
   const positions: Position[] = getListItemTextPositions(text);
-  const checklistIndicatorRegex = /^\[.\] /;
 
   for (const position of positions) {
     let startIndex = position.start.offset;
@@ -544,7 +543,7 @@ export function updateListItemText(text: string, func:(text: string) => string):
 
     let listText = text.substring(startIndex, position.end.offset);
     // for some reason some checklists are not getting treated as such and this causes the task indicator to be included in the text
-    if (checklistIndicatorRegex.test(listText)) {
+    if (checklistBoxStartsTextRegex.test(listText)) {
       startIndex += 4;
       listText = listText.substring(4);
     }

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -35,6 +35,11 @@ export const smartDoubleQuoteRegex = /[“”„«»]/g;
 export const smartSingleQuoteRegex = /[‘’‚‹›]/g;
 
 export const templaterCommandRegex = /<%[^]*?%>/g;
+// checklist regex
+export const checklistBoxIndicator = '\\[.\\]';
+export const checklistBoxStartsTextRegex = new RegExp(`^${checklistBoxIndicator}`);
+export const indentedOrBlockquoteNestedChecklistIndicatorRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}- ${checklistBoxIndicator} `);
+export const nonBlockquoteChecklistRegex = new RegExp(`^\\s*- ${checklistBoxIndicator} `);
 
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string


### PR DESCRIPTION
Fixes #748 

Changes Made:
- Removed an unnecessary and incorrect comment
- Consolidated a lot of the checklist regex to be built on plugin load
  - This helps with performance so we are not building regex values more than 1 time when the value will be the same over and over again
  - This also allows for some uniformity on how checklists are found and matched as you can use a template and just have it reuse the value for the checklist box
- Broke apart and added a couple of examples to show that things were working
- Went ahead and fixed the wording on a couple of tests that I noticed was wrong
- Replaced old regex uses for checklists with the new regex that is built on load