### PR TITLE
fix npm dependencies issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
     "typescript": "^5.0.4",
-    "unified-lint-rule": "^2.1.1"
+    "unified-lint-rule": "^2.1.1",
+    "@jest/types": "^29.5.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
@@ -63,6 +64,7 @@
     "micromark-util-combine-extensions": "^1.0.0",
     "moment-parseformat": "^4.0.0",
     "quick-lru": "^6.1.1",
-    "ts-dedent": "^2.2.0"
+    "ts-dedent": "^2.2.0",
+    "unist-util-visit": "^4.1.2"
   }
 }


### PR DESCRIPTION
unist-util-visit is `src/utils/mdast.ts` and @jest/types is need for jest

I'm not sure this is intentional or by accident, but I need this two dependencies to work. 

Not sure if this is needed. Feel free to close it.