### PR TITLE
Escape Numeric Aliases & Refactor `YAML Title Alias` Logic

### DIFF
--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1235,6 +1235,48 @@ ruleTest({
         useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
       },
     },
-
+    { // accounts for https://github.com/platers/obsidian-linter/issues/747
+      testName: 'Make sure numerical header gets escaped with quotes when converted to alias',
+      before: dedent`
+        ---
+        aliases:
+          - alias1
+        ---
+        # 12456378
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - '12456378'
+          - alias1
+        ---
+        # 12456378
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+        defaultEscapeCharacter: '\'',
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/747
+      testName: 'Make sure numerical filename gets escaped with quotes when converted to alias due to not having a header in the file',
+      before: dedent`
+        ---
+        aliases: [alias1]
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: ["12345678", alias1]
+        ---
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+        useYamlKeyToKeepTrackOfOldFilenameOrHeading: false,
+        keepAliasThatMatchesTheFilename: true,
+        defaultEscapeCharacter: '"',
+        fileName: '12345678',
+      },
+    },
   ],
 });

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -80,7 +80,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
 
       const currentAliasValue = convertAliasValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(aliasesValue));
       const newAliasValue = this.getNewAliasValue(currentAliasValue, shouldRemoveTitleAlias, title, previousTitle);
-      
+
       if (newAliasValue === '') {
         newYaml = removeYamlSection(newYaml, aliasKeyForFile);
       } else if (options.preserveExistingAliasesSectionStyle) {
@@ -110,7 +110,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     let unescapedTitle = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag], text, getFirstHeaderOneText);
     unescapedTitle = unescapedTitle || fileName;
     
-    const forceEscape = unescapedTitle.includes(',') && (aliasArrayStyle === NormalArrayFormats.SingleLine || aliasArrayStyle === SpecialArrayFormats.SingleStringToSingleLine || aliasArrayStyle === SpecialArrayFormats.SingleStringCommaDelimited) || isNumeric(unescapedTitle);
+    const forceEscape = (unescapedTitle.includes(',') && (aliasArrayStyle === NormalArrayFormats.SingleLine || aliasArrayStyle === SpecialArrayFormats.SingleStringToSingleLine || aliasArrayStyle === SpecialArrayFormats.SingleStringCommaDelimited)) || isNumeric(unescapedTitle);
     const escapedTitle = escapeStringIfNecessaryAndPossible(unescapedTitle, defaultEscapeCharacter, forceEscape);
 
     return [unescapedTitle, escapedTitle];

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -38,7 +38,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
   }
   apply(text: string, options: YamlTitleAliasOptions): string {
     text = initYAML(text);
-    const [unescapedTitle, title] = this.getTitleInfo(text, options.fileName, options.aliasArrayStyle, options.defaultEscapeCharacter)
+    const [unescapedTitle, title] = this.getTitleInfo(text, options.fileName, options.aliasArrayStyle, options.defaultEscapeCharacter);
 
     let previousTitle: string = null;
     const yaml = text.match(yamlRegex)[1];
@@ -109,7 +109,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
   getTitleInfo(text: string, fileName: string, aliasArrayStyle: NormalArrayFormats | SpecialArrayFormats, defaultEscapeCharacter: QuoteCharacter): [string, string] {
     let unescapedTitle = ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag], text, getFirstHeaderOneText);
     unescapedTitle = unescapedTitle || fileName;
-    
+
     const forceEscape = (unescapedTitle.includes(',') && (aliasArrayStyle === NormalArrayFormats.SingleLine || aliasArrayStyle === SpecialArrayFormats.SingleStringToSingleLine || aliasArrayStyle === SpecialArrayFormats.SingleStringCommaDelimited)) || isNumeric(unescapedTitle);
     const escapedTitle = escapeStringIfNecessaryAndPossible(unescapedTitle, defaultEscapeCharacter, forceEscape);
 
@@ -155,7 +155,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     }
 
     return originalValue;
-  };
+  }
   get exampleBuilders(): ExampleBuilder<YamlTitleAliasOptions>[] {
     return [
       new ExampleBuilder({

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -80,6 +80,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
 
       const currentAliasValue = convertAliasValueToStringOrStringArray(splitValueIfSingleOrMultilineArray(aliasesValue));
       const newAliasValue = this.getNewAliasValue(currentAliasValue, shouldRemoveTitleAlias, title, previousTitle);
+      
       if (newAliasValue === '') {
         newYaml = removeYamlSection(newYaml, aliasKeyForFile);
       } else if (options.preserveExistingAliasesSectionStyle) {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -341,3 +341,10 @@ export function countInstances(text: string, instancesOf: string): number {
 
   return counter;
 }
+
+// based on https://stackoverflow.com/a/175787/8353749
+export function isNumeric(str: string) {
+  if (typeof str != "string") return false // we only process strings!  
+  return !isNaN(str as unknown as number) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
+         !isNaN(parseFloat(str)) // ...and ensure strings of whitespace fail
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -344,7 +344,7 @@ export function countInstances(text: string, instancesOf: string): number {
 
 // based on https://stackoverflow.com/a/175787/8353749
 export function isNumeric(str: string) {
-  if (typeof str != "string") return false // we only process strings!  
+  if (typeof str != 'string') return false; // we only process strings!
   return !isNaN(str as unknown as number) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
-         !isNaN(parseFloat(str)) // ...and ensure strings of whitespace fail
+         !isNaN(parseFloat(str)); // ...and ensure strings of whitespace fail
 }


### PR DESCRIPTION
Fixes #747 

Changes Made:
- Refactored logic in the `YAML Title Alias` rule to make things easier to work with in the future
  - The title retrieval and new alias value creation logic were moved to their own methods 
- Added tests for 2 scenarios in question to make sure they get escaped
- Added an `isNumeric` method for checking if a string is a number