### PR TITLE
Update Alias Handling of Numeric Values for All Formatting and Handle Commas in `YAML Title Alias` Better

### DIFF
--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -1026,8 +1026,7 @@ ruleTest({
         defaultArrayStyle: NormalArrayFormats.MultiLine,
       },
     },
-    {
-      // accounts for https://github.com/platers/obsidian-linter/issues/525
+    { // accounts for https://github.com/platers/obsidian-linter/issues/525
       testName: 'Converting a single string comma separated array to a multi-line array should respect escaped entries',
       before: dedent`
         ---
@@ -1043,6 +1042,40 @@ ruleTest({
       `,
       options: {
         aliasArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+    {
+      testName: 'Numeric aliases are escaped when aliases are converted from one type to another',
+      before: dedent`
+        ---
+        aliases: 1234, alias1
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - "1234"
+          - alias1
+        ---
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+    {
+      testName: 'Numeric aliases are escaped when aliases are otherwise unchanged',
+      before: dedent`
+        ---
+        aliases: 1234, alias1
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: "1234", alias1
+        ---
+      `,
+      options: {
+        aliasArrayStyle: SpecialArrayFormats.SingleStringCommaDelimited,
       },
     },
   ],

--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1320,5 +1320,34 @@ ruleTest({
         defaultEscapeCharacter: '"',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/758
+      testName: 'Make sure commas are handled properly when found in alias',
+      before: dedent`
+        ---
+        linter-yaml-title-alias: "test, test2, test3"
+        title: test, test2, test3
+        created: 1970-01-01
+        updated: 2023-06-14
+        aliases: ["test, test2, test3"]
+        tags:${' '}
+        ---
+        # test4
+      `,
+      after: dedent`
+        ---
+        linter-yaml-title-alias: test4
+        title: test, test2, test3
+        created: 1970-01-01
+        updated: 2023-06-14
+        aliases: [test4]
+        tags:${' '}
+        ---
+        # test4
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+        defaultEscapeCharacter: '"',
+      },
+    },
   ],
 });

--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1300,6 +1300,27 @@ ruleTest({
       },
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/747
+      testName: 'Make sure old numerical alias gets removed when the alias for file changes and `linter-yaml-title-alias` is numeric and not escaped and value in alias is not escaped',
+      before: dedent`
+        ---
+        aliases: [12345678, alias1]
+        linter-yaml-title-alias: 12345678
+        ---
+        # 1234
+      `,
+      after: dedent`
+        ---
+        aliases: ["1234", alias1]
+        linter-yaml-title-alias: "1234"
+        ---
+        # 1234
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+        defaultEscapeCharacter: '"',
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/747
       testName: 'Make sure old numerical alias gets removed when the alias for file changes and `linter-yaml-title-alias` is numeric and is escaped',
       before: dedent`
         ---
@@ -1343,6 +1364,27 @@ ruleTest({
         tags:${' '}
         ---
         # test4
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+        defaultEscapeCharacter: '"',
+      },
+    },
+    {
+      testName: 'Make sure that if previous title is present, but not present in aliases, new title is still added at start of aliases',
+      before: dedent`
+        ---
+        aliases: [alias1]
+        linter-yaml-title-alias: blob
+        ---
+        # 1234
+      `,
+      after: dedent`
+        ---
+        aliases: ["1234", alias1]
+        linter-yaml-title-alias: "1234"
+        ---
+        # 1234
       `,
       options: {
         aliasArrayStyle: NormalArrayFormats.SingleLine,

--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1278,5 +1278,47 @@ ruleTest({
         fileName: '12345678',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/747
+      testName: 'Make sure old numerical alias gets removed when the alias for file changes and `linter-yaml-title-alias` is numeric and not escaped',
+      before: dedent`
+        ---
+        aliases: ["12345678", alias1]
+        linter-yaml-title-alias: 12345678
+        ---
+        # 1234
+      `,
+      after: dedent`
+        ---
+        aliases: ["1234", alias1]
+        linter-yaml-title-alias: "1234"
+        ---
+        # 1234
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+        defaultEscapeCharacter: '"',
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/747
+      testName: 'Make sure old numerical alias gets removed when the alias for file changes and `linter-yaml-title-alias` is numeric and is escaped',
+      before: dedent`
+        ---
+        aliases: ["12345678", alias1]
+        linter-yaml-title-alias: "12345678"
+        ---
+        # 1234
+      `,
+      after: dedent`
+        ---
+        aliases: ["1234", alias1]
+        linter-yaml-title-alias: "1234"
+        ---
+        # 1234
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+        defaultEscapeCharacter: '"',
+      },
+    },
   ],
 });

--- a/src/rules/format-yaml-arrays.ts
+++ b/src/rules/format-yaml-arrays.ts
@@ -61,6 +61,7 @@ export default class RuleTemplate extends RuleBuilder<FormatYamlArrayOptions> {
                   options.aliasArrayStyle,
                   options.defaultEscapeCharacter,
                   options.removeUnnecessaryEscapeCharsForMultiLineArrays,
+                  true, // escape numeric aliases see https://github.com/platers/obsidian-linter/issues/747
               ),
           );
 

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {convertAliasValueToStringOrStringArray, escapeStringIfNecessaryAndPossible, formatYamlArrayValue, getYamlSectionValue, initYAML, LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEYS, OBSIDIAN_ALIAS_KEY_PLURAL, QuoteCharacter, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray} from '../utils/yaml';
+import {convertAliasValueToStringOrStringArray, escapeStringIfNecessaryAndPossible, formatYamlArrayValue, getYamlSectionValue, initYAML, LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEYS, OBSIDIAN_ALIAS_KEY_PLURAL, QuoteCharacter, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray, isValueEscapedAlready} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {getFirstHeaderOneText, yamlRegex} from '../utils/regex';
 import {isNumeric} from '../utils/strings';
@@ -137,13 +137,19 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
         originalValue = [title, originalValue];
       }
     } else if (previousTitle !== null) {
-      const previousTitleIndex = originalValue.indexOf(previousTitle);
+      let previousTitleIndex = originalValue.indexOf(previousTitle);
+      if (previousTitleIndex === -1 && isValueEscapedAlready(previousTitle)) {
+        previousTitleIndex = originalValue.indexOf(previousTitle.substring(1, previousTitle.length - 1));
+      }
+
       if (previousTitleIndex !== -1) {
         if (shouldRemoveTitle) {
           originalValue.splice(previousTitleIndex, 1);
         } else {
           originalValue[previousTitleIndex] = title;
         }
+      } else {
+        originalValue = [title, ...originalValue];
       }
     } else {
       const currentTitleIndex = originalValue.indexOf(title);

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -344,7 +344,8 @@ export function countInstances(text: string, instancesOf: string): number {
 
 // based on https://stackoverflow.com/a/175787/8353749
 export function isNumeric(str: string) {
-  if (typeof str != 'string') return false; // we only process strings!
+  const type = typeof str;
+  if (type != 'string') return type === 'number'; // we only process strings so if the value is not already a number the result is false
   return !isNaN(str as unknown as number) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
          !isNaN(parseFloat(str)); // ...and ensure strings of whitespace fail
 }


### PR DESCRIPTION
Fixes #758 
Fixes #747 

Changes Made:
- Added more tests for the 2 issues above
- Added an extra boolean to help know when values need to be escaped that are numeric when dealing with formatting YAML arrays
- Refactored formatting of YAML arrays to be easier to account for scenarios in a more general form
- Updated `isNumeric` to consider numbers to be numeric just in case the function is called for them
- Made sure to escape the previous title for `YAML Title Alias` if it should be
- Made sure to check for an unescaped version of the previous title if it was not found and was escaped (just to cover that scenario if it ever comes up in the wild)
- Moved `forceEscape` to a method to better help with uniformity as to when a value should be escaped for `YAML Title Alias`
