### PR TITLE
Fix `Heading Blank Lines` with `Bottom=False` Removing Blank Lines

### DIFF
--- a/__tests__/heading-blank-lines.test.ts
+++ b/__tests__/heading-blank-lines.test.ts
@@ -103,5 +103,29 @@ ruleTest({
         blah blah blah
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/751
+      testName: 'Make sure that blank lines after a heading are left alone when `bottom = false`',
+      before: dedent`
+        ## diary
+        ${''}
+        ${''}
+        Content here
+        ## entry 2
+        blah blah blah
+      `,
+      after: dedent`
+        ## diary
+        ${''}
+        ${''}
+        Content here
+        ${''}
+        ## entry 2
+        blah blah blah
+      `,
+      options: {
+        bottom: false,
+        emptyLineAfterYaml: false,
+      },
+    },
   ],
 });

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -24,7 +24,6 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
   }
   apply(text: string, options: HeadingBlankLinesOptions): string {
     if (!options.bottom) {
-      text = text.replace(/(^#+\s.*)\n+/gm, '$1\n'); // trim blank lines after headings
       text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
     } else {
       text = text.replace(/^(#+\s.*)/gm, '\n\n$1\n\n'); // add blank line before and after headings


### PR DESCRIPTION
Fixes #751 
Replaces #755 

Changes Made:
- Added a UT for not removing blank lines after a heading
- Updated logic to remove the attempt to remove blank lines after the heading