### PR TITLE
Fix Retention of Created Date Causing `YAML Timestamp` to Always Update Date Modified and Fix Logging of Timing Info

### DIFF
--- a/__tests__/yaml-timestamp.test.ts
+++ b/__tests__/yaml-timestamp.test.ts
@@ -332,5 +332,44 @@ ruleTest({
         alreadyModified: false,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/745
+      testName: 'When no changes are made, and force retention of creation date is active, do not update date modified when no change in modification time has been made',
+      before: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:00 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      after: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:00 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      options: {
+        dateCreatedKey: 'created',
+        dateModifiedKey: 'modified',
+        fileCreatedTime: '2020-01-01T00:00:00-00:00',
+        currentTime: moment('Tuesday, February 4th 2020, 6:00:07 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
+        alreadyModified: false,
+        forceRetentionOfCreatedValue: true,
+      },
+    },
   ],
 });
+
+/**
+ * "yaml-timestamp": {
+      "enabled": true,
+      "date-created": true,
+      "date-created-key": "created",
+      "force-retention-of-create-value": true,
+      "date-modified": true,
+      "date-modified-key": "modified",
+      "format": "YYYY-MM-DDTHH:mm:ssZ"
+    },
+ */

--- a/__tests__/yaml-timestamp.test.ts
+++ b/__tests__/yaml-timestamp.test.ts
@@ -354,6 +354,7 @@ ruleTest({
         dateCreatedKey: 'created',
         dateModifiedKey: 'modified',
         fileCreatedTime: '2020-01-01T00:00:00-00:00',
+        fileModifiedTime: '2020-02-04T18:00:00-00:00',
         currentTime: moment('Tuesday, February 4th 2020, 6:00:07 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
         alreadyModified: false,
         forceRetentionOfCreatedValue: true,
@@ -361,15 +362,3 @@ ruleTest({
     },
   ],
 });
-
-/**
- * "yaml-timestamp": {
-      "enabled": true,
-      "date-created": true,
-      "date-created-key": "created",
-      "force-retention-of-create-value": true,
-      "date-modified": true,
-      "date-modified-key": "modified",
-      "format": "YYYY-MM-DDTHH:mm:ssZ"
-    },
- */

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -101,27 +101,31 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
       textModified = true;
     } else if (keyWithValueFound) {
       const createdDateString = this.getYAMLTimestampString(text, created_match, options.dateCreatedKey);
-      const createdDateTime = moment(createdDateString, options.format, options.locale, true);
-      if (createdDateTime == undefined || (!createdDateTime.isValid() && !options.forceRetentionOfCreatedValue)) {
-        text = text.replace(
-            created_match,
-            escapeDollarSigns(created_date_line) + '\n',
-        );
-
-        textModified = true;
-      } else if (options.forceRetentionOfCreatedValue) {
+      if (options.forceRetentionOfCreatedValue) {
         const yamlCreatedDateTime = this.parseValueToCurrentFormatIfPossible(createdDateString, options.format, options.locale);
         if (yamlCreatedDateTime == null) {
           throw new Error(getTextInLanguage('logs.invalid-date-format-error').replace('{DATE}', createdDateString).replace('{FILE_NAME}', options.fileName));
         }
 
-        const created_date_yaml_line = `\n${options.dateCreatedKey}: ${yamlCreatedDateTime.format(options.format)}`;
-        text = text.replace(
-            created_match,
-            escapeDollarSigns(created_date_yaml_line) + '\n',
-        );
+        if (yamlCreatedDateTime.format(options.format) !== createdDateString) {
+          const created_date_yaml_line = `\n${options.dateCreatedKey}: ${yamlCreatedDateTime.format(options.format)}`;
+          text = text.replace(
+              created_match,
+              escapeDollarSigns(created_date_yaml_line) + '\n',
+          );
 
-        textModified = true;
+          textModified = true;
+        }
+      } else {
+        const createdDateTime = moment(createdDateString, options.format, options.locale, true);
+        if (createdDateTime == undefined || !createdDateTime.isValid()) {
+          text = text.replace(
+              created_match,
+              escapeDollarSigns(created_date_line) + '\n',
+          );
+
+          textModified = true;
+        }
       }
     }
 
@@ -139,7 +143,6 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
     // than 5 seconds prior to the time the linter will finish with the file (i.e. helps prevent accidental infinite loops on updating the date modified value)
     const formatted_modified_date = options.currentTime.format(options.format);
     const modified_date_line = `\n${options.dateModifiedKey}: ${formatted_modified_date}`;
-
     const keyWithValueFound = modified_match.test(text);
     if (keyWithValueFound) {
       const modifiedDateTime = moment(text.match(modified_match)[0].replace(options.dateModifiedKey + ':', '').trim(), options.format, options.locale, true);

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -143,6 +143,7 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
     // than 5 seconds prior to the time the linter will finish with the file (i.e. helps prevent accidental infinite loops on updating the date modified value)
     const formatted_modified_date = options.currentTime.format(options.format);
     const modified_date_line = `\n${options.dateModifiedKey}: ${formatted_modified_date}`;
+
     const keyWithValueFound = modified_match.test(text);
     if (keyWithValueFound) {
       const modifiedDateTime = moment(text.match(modified_match)[0].replace(options.dateModifiedKey + ':', '').trim(), options.format, options.locale, true);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -75,7 +75,7 @@ export function logWarn(message: string) {
 }
 
 export function timingBegin(timingKey: string) {
-  if (log.getLevel() <= log.levels.DEBUG) {
+  if (log.getLevel() > log.levels.DEBUG) {
     return;
   }
 
@@ -87,7 +87,7 @@ export function timingBegin(timingKey: string) {
  * @param {string} timingKey - The timing key for the start time that should end.
  */
 export function timingEnd(timingKey: string) {
-  if (log.getLevel() <= log.levels.DEBUG) {
+  if (log.getLevel() > log.levels.DEBUG) {
     return;
   } else if (!timingInfo.has(timingKey)) {
     logWarn(getTextInLanguage('logs.timing-key-not-found').replace('{TIMING_KEY}', timingKey));


### PR DESCRIPTION
Fixes #745 

Changes Made:
- Added UT to reproduce the scenario in question
- Updated the logic for handling date created updates to make sure that it only updates the date created if the value is missing or is in the wrong format
  - Previously it assumed that if you had the retention of the current value set, it always needed to do an update
  - This is actually incorrect, so I updated the logic to only update the value if the format changed
- Updated time logging logic to reflect the fact that it should only log timing info if debug or lower is set 