### PR TITLE
Update Chinese Translation of `Quote Style`'s Name

### DIFF
--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -479,7 +479,7 @@ export default {
     },
     // quote-style.ts
     'quote-style': {
-      'name': '报价风格',
+      'name': '引用样式',
       'description': '更新正文内容中的引号以更新为指定的单引号和双引号样式。',
       'single-quote-enabled': {
         'name': '启用`单引号样式`',


### PR DESCRIPTION
Relates to #769 

Changes Made:
- Updated Chinese translation of Quote Style's name to be `citation style` instead of `quote style`