### PR TITLE
Fix an Infinite Loop for `re-index-footnotes` and `move-footnote-to-the-bottom`

### DIFF
--- a/__tests__/move-footnotes-to-the-bottom.test.ts
+++ b/__tests__/move-footnotes-to-the-bottom.test.ts
@@ -188,5 +188,21 @@ ruleTest({
         [^2]: Second reference
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/784
+      testName: 'A footnote reference wrapped by 2 references with one at the start of a file should not cause an infinite loop and should move each reference to the end of the file',
+      before: dedent`
+        [^2]: a
+        ${''}
+        a[^2]
+        ${''}
+        [^2]: b
+      `,
+      after: dedent`
+        a[^2]
+        ${''}
+        [^2]: a
+        [^2]: b
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -161,7 +161,7 @@ export function moveFootnotesToEnd(text: string): string {
       footnoteReferenceLocations.push(footnoteReferenceLocation);
 
       startOfFootnoteReferenceSearch = footnoteReferenceLocation - 1;
-    } while (footnoteReferenceLocation > -1);
+    } while (footnoteReferenceLocation > 0);
 
     const keyInfo: footnoteKeyInfo = {
       key: footnoteReference,
@@ -243,7 +243,7 @@ export function reIndexFootnotes(text: string): string {
       footnoteReferenceLocationInfo.push({key: footnoteReference, position: footnoteReferenceLocation});
       firstFootnoteReferenceIndex = footnoteReferenceLocation;
       startOfFootnoteReferenceSearch = footnoteReferenceLocation - 1;
-    } while (footnoteReferenceLocation > -1);
+    } while (footnoteReferenceLocation > 0);
 
     footnoteKeys.add(footnoteReference);
 


### PR DESCRIPTION
Fixes #784 

Changes Made:
- Accounted for starting a file with a footnote reference in the while loops which was caused by the condition being greater than -1 when it should be 0 since that is the lowest valid value that we should stop looking after we find
- Added a test to `move-footnote-to-the-bottom` to make sure the issue does not get reintroduced