### PR TITLE
Try to Handle Math Blocks Getting Combined when 1 or More Are Malformed

### DIFF
--- a/__tests__/move-math-block-indicators-to-own-line.test.ts
+++ b/__tests__/move-math-block-indicators-to-own-line.test.ts
@@ -59,5 +59,30 @@ ruleTest({
         > $$
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/783
+      testName: 'Math indicators greater than or equal to the the starting indicator lead to a splitting of the math block if the number of qualifying math blocks is greater than 3',
+      before: dedent`
+        $$a$$
+        ${''}
+        $$
+        b$$
+        ${''}
+        $$c
+        $$
+      `,
+      after: dedent`
+        $$
+        a
+        $$
+        ${''}
+        $$
+        b
+        $$
+        ${''}
+        $$
+        c
+        $$
+      `,
+    },
   ],
 });

--- a/docs/additional-info/rules/move-math-block-indicators-to-own-line.md
+++ b/docs/additional-info/rules/move-math-block-indicators-to-own-line.md
@@ -1,0 +1,54 @@
+#### What Math Formats Does the Linter Support?
+
+The Linter uses [remark-math](https://github.com/remarkjs/remark-math) as its math block parser. This is not the one used by Obsidian.
+So it may be that Obsidian and the Linter consider different things to be math blocks or inline math.
+
+The expected format for inline math is `$MATH_HERE$`. The amount of dollar signs does not matter so long as it is less than the value being
+used to indicate a math block. Math blocks should look something like the following:
+
+``` markdown
+$$
+MATH_HERE
+$$
+```
+
+The Linter will try to break inline math blocks into math blocks when the inline math block has the minimum number of `$` at the start of
+the inline math.
+
+##### Exceptions
+
+The Linter tries to correct a couple of exceptions that seem to be weird results from the parser when the desired format is not followed for inline and math blocks.
+
+###### Splitting Simple Combined Math Blocks
+
+The Linter will try to fix some combined math blocks that the parser returns. For example the following is considered 2 math blocks even
+though it is really 3 different math blocks:
+
+``` markdown
+$$a$$
+
+$$
+b$$
+
+$$c
+$$
+```
+
+The Linter does its best to break that apart under the hood into 3 separate math blocks which can then be handled appropriately.
+!!! Warning
+    This may not be reliable to use to fix more complex math block parsing issues, so please try to conform with the block and inline
+    patterns described above for math blocks.
+
+###### Moving Text after Closing Math Block Indicator to Its Own Line
+
+The parser does not handle math block closing indicators on the same line as text as it will consider that text to be part of the math
+block even if it comes after the ending indicator. For example, the following is considered to be an entire math block according to 
+the underlying parser:
+
+``` markdown
+$$
+a
+$$b
+```
+
+The Linter does its best to make sure that the `b` is treated as not being part of the math block.

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -12,6 +12,7 @@ import {fromMarkdown} from 'mdast-util-from-markdown';
 import {gfmFootnoteFromMarkdown} from 'mdast-util-gfm-footnote';
 import {gfmTaskListItemFromMarkdown} from 'mdast-util-gfm-task-list-item';
 import QuickLRU from 'quick-lru';
+import {countInstances} from './strings';
 import {getTextInLanguage} from '../lang/helpers';
 
 const LRU = new QuickLRU({maxSize: 200});
@@ -745,7 +746,13 @@ export function makeSureMathBlockIndicatorsAreOnTheirOwnLines(text: string, numb
   const mathOpeningIndicatorRegex = new RegExp('^(\\${' + numberOfDollarSignsForMathBlock + ',})(\\n*)');
   const mathEndingIndicatorRegex = new RegExp('(\\n*)(\\${' + numberOfDollarSignsForMathBlock + ',})([^\\$]*)$');
   for (const position of positions) {
-    text = addBlankLinesAroundStartAndStopMathIndicators(text, position.start.offset, position.end.offset, mathOpeningIndicatorRegex, mathEndingIndicatorRegex);
+    const mathBlock = text.substring(position.start.offset, position.end.offset);
+    const mathBlockIndexes = breakMathBlockIntoMultipleBlocksIfNeedBe(mathBlock, numberOfDollarSignsForMathBlock, position.start.offset);
+
+    for (const blockIndexes of mathBlockIndexes) {
+      console.log(text.substring(blockIndexes.startIndex, blockIndexes.endIndex));
+      text = addBlankLinesAroundStartAndStopMathIndicators(text, blockIndexes.startIndex, blockIndexes.endIndex, mathOpeningIndicatorRegex, mathEndingIndicatorRegex);
+    }
   }
 
   positions = getPositions(MDAstTypes.InlineMath, text);
@@ -758,6 +765,54 @@ export function makeSureMathBlockIndicatorsAreOnTheirOwnLines(text: string, numb
   }
 
   return text;
+}
+
+function breakMathBlockIntoMultipleBlocksIfNeedBe(mathBlock: string, numberOfDollarSignsForMathBlock: number, startIndexOfMathBlock: number): {startIndex: number, endIndex: number}[] {
+  let mathBlockIndicator = '$'.repeat(numberOfDollarSignsForMathBlock);
+  let endOfOpeningIndicator = numberOfDollarSignsForMathBlock;
+  while (mathBlock.charAt(endOfOpeningIndicator) === '$') {
+    mathBlockIndicator += '$';
+    endOfOpeningIndicator++;
+  }
+
+  const mathBlockIndexes = [] as {startIndex: number, endIndex: number}[];
+
+  let matchCount = countInstances(mathBlock, mathBlockIndicator);
+  if (matchCount <= 3) {
+    mathBlockIndexes.unshift({
+      startIndex: startIndexOfMathBlock,
+      endIndex: startIndexOfMathBlock + mathBlock.length,
+    });
+
+    return mathBlockIndexes;
+  }
+
+  // if there is an odd amount of matches, remove one from the list so it is even
+  if (matchCount % 2 === 1) {
+    matchCount--;
+  }
+
+  // pair the earliest matches together until there are no more pairs
+  let startIndex = startIndexOfMathBlock;
+  let startSearch = mathBlockIndicator.length;
+  while (matchCount > 2 ) {
+    const endOfIndex = mathBlock.indexOf(mathBlockIndicator, startSearch) + mathBlockIndicator.length;
+    mathBlockIndexes.unshift({
+      startIndex: startIndex,
+      endIndex: startIndexOfMathBlock + endOfIndex,
+    });
+
+    startIndex = startIndexOfMathBlock + endOfIndex + 1;
+    startSearch = endOfIndex + 1;
+    matchCount -= 2;
+  }
+
+  mathBlockIndexes.unshift({
+    startIndex: startIndexOfMathBlock + mathBlock.indexOf(mathBlockIndicator, startSearch),
+    endIndex: startIndexOfMathBlock + mathBlock.length,
+  });
+
+  return mathBlockIndexes;
 }
 
 function addBlankLinesAroundStartAndStopMathIndicators(text: string, mathBlockStartIndex: number, mathBlockEndIndex: number, mathOpeningIndicatorRegex: RegExp, mathEndingIndicatorRegex: RegExp): string {

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -750,7 +750,6 @@ export function makeSureMathBlockIndicatorsAreOnTheirOwnLines(text: string, numb
     const mathBlockIndexes = breakMathBlockIntoMultipleBlocksIfNeedBe(mathBlock, numberOfDollarSignsForMathBlock, position.start.offset);
 
     for (const blockIndexes of mathBlockIndexes) {
-      console.log(text.substring(blockIndexes.startIndex, blockIndexes.endIndex));
       text = addBlankLinesAroundStartAndStopMathIndicators(text, blockIndexes.startIndex, blockIndexes.endIndex, mathOpeningIndicatorRegex, mathEndingIndicatorRegex);
     }
   }


### PR DESCRIPTION
Fixes #783 

Changes Made:
- Added some documentation around handling math blocks and what is done to special exceptions for moving math blocks to their own lines
- Added a test for the scenario referenced
- Added logic to split apart math blocks into pairs of "sub" math blocks in the event that multiple math blocks got combined