### PR TITLE
Ignore Footnote Definitions for Paragraph Blank Lines

### DIFF
--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -328,5 +328,26 @@ ruleTest({
         ## Agenda
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/787
+      testName: 'Make sure that an empty list indicator does not have an extra empty line added around it',
+      before: dedent`
+        - reference to footnote 1 [^1]
+        - reference to footnote 2 [^2]
+        - reference to footnote 3 [^3]
+        ${''}
+        [^1]: [github.com](https://github.com)
+        [^2]: [github.com](https://github.com)
+        [^3]: [github.com](https://github.com)
+      `,
+      after: dedent`
+        - reference to footnote 1 [^1]
+        - reference to footnote 2 [^2]
+        - reference to footnote 3 [^3]
+        ${''}
+        [^1]: [github.com](https://github.com)
+        [^2]: [github.com](https://github.com)
+        [^3]: [github.com](https://github.com)
+      `,
+    },
   ],
 });

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -1,4 +1,4 @@
-import {obsidianMultilineCommentRegex, tagWithLeadingWhitespaceRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns, genericLinkRegex, urlRegex, anchorTagRegex, templaterCommandRegex} from './regex';
+import {obsidianMultilineCommentRegex, tagWithLeadingWhitespaceRegex, wikiLinkRegex, yamlRegex, escapeDollarSigns, genericLinkRegex, urlRegex, anchorTagRegex, templaterCommandRegex, footnoteDefinitionIndicatorAtStartOfLine} from './regex';
 import {getAllCustomIgnoreSectionsInText, getAllTablesInText, getPositions, MDAstTypes} from './mdast';
 import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
@@ -24,7 +24,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   yaml: {replaceAction: yamlRegex, placeholder: escapeDollarSigns('---\n---')},
   wikiLink: {replaceAction: wikiLinkRegex, placeholder: '{WIKI_LINK_PLACEHOLDER}'},
   obsidianMultiLineComments: {replaceAction: obsidianMultilineCommentRegex, placeholder: '{OBSIDIAN_COMMENT_PLACEHOLDER}'},
-  footnoteAtStartOfLine: {replaceAction: /^(\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AT_START_OF_LINE_PLACEHOLDER}'},
+  footnoteAtStartOfLine: {replaceAction: footnoteDefinitionIndicatorAtStartOfLine, placeholder: '{FOOTNOTE_AT_START_OF_LINE_PLACEHOLDER}'},
   footnoteAfterATask: {replaceAction: /- \[.] (\[\^\w+\]) ?([,.;!:?])/gm, placeholder: '{FOOTNOTE_AFTER_A_TASK_PLACEHOLDER}'},
   url: {replaceAction: urlRegex, placeholder: '{URL_PLACEHOLDER}'},
   anchorTag: {replaceAction: anchorTagRegex, placeholder: '{ANCHOR_PLACEHOLDER}'},

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -2,7 +2,7 @@ import {visit} from 'unist-util-visit';
 import type {Position} from 'unist';
 import type {Root} from 'mdast';
 import {hashString53Bit, makeSureContentHasEmptyLinesAddedBeforeAndAfter, replaceTextBetweenStartAndEndWithNewValue, getStartOfLineIndex, replaceAt} from './strings';
-import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator, checklistBoxStartsTextRegex} from './regex';
+import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator, checklistBoxStartsTextRegex, footnoteDefinitionIndicatorAtStartOfLine} from './regex';
 import {gfmFootnote} from 'micromark-extension-gfm-footnote';
 import {gfmTaskListItem} from 'micromark-extension-gfm-task-list-item';
 import {combineExtensions} from 'micromark-util-combine-extensions';
@@ -411,10 +411,10 @@ export function makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs(text: st
 
     const paragraphLines = text.substring(startIndex, position.end.offset).split('\n');
 
-    // exclude list items and blockquotes
+    // exclude list items, footnote definitions, and blockquotes
     const firstLine = paragraphLines[0].trimStart();
     if (firstLine.startsWith('>') || firstLine.startsWith('- ') || firstLine.startsWith('-\t') ||
-      firstLine.match(/^[0-9]+\.( |\t)+/)) {
+      firstLine.match(/^[0-9]+\.( |\t)+/) || firstLine.match(footnoteDefinitionIndicatorAtStartOfLine)) {
       continue;
     }
 

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -41,6 +41,8 @@ export const checklistBoxStartsTextRegex = new RegExp(`^${checklistBoxIndicator}
 export const indentedOrBlockquoteNestedChecklistIndicatorRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}- ${checklistBoxIndicator} `);
 export const nonBlockquoteChecklistRegex = new RegExp(`^\\s*- ${checklistBoxIndicator} `);
 
+export const footnoteDefinitionIndicatorAtStartOfLine = /^(\[\^\w+\]) ?([,.;!:?])/gm;
+
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string
 // could have user constructed dollar signs in it


### PR DESCRIPTION
Fixes #787 

Changes Made:
- Added a test for the scenario in question
- Refactored the logic around the regex for a footnote definition indicator at the start of a line
- Checked that the beginning of the first line of a paragraph is not a footnote definition