### PR TITLE
Add Options to Lint on File Change and Show a Message Saying which File Was Linted on File Change

### DIFF
--- a/docs/docs/usage/running-rules.md
+++ b/docs/docs/usage/running-rules.md
@@ -9,6 +9,13 @@ You will need to turn on the setting for `Lint on save` for this to work.
 
 Enabling this setting keeps you from having to manually run the Obsidian Command to a lint a file whenever you want to lint the current file.
 
+## On File Close or File Change
+
+There is an option to lint a file when a user either closes it or swaps to a different file. In order to activate this rule,
+you will need to turn on the setting for `Lint on File Change`.
+
+This way of linting a file can help out if you forget to run the Linter on files before changing to a new file or closing it.
+
 ## Obsidian Commands
 
 | Obsidian Command | Description | Default Keybinding |

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -49,6 +49,7 @@ export default {
     'see-console': 'Weitere Informationen finden Sie unter Konsole.',
     'unknown-error': 'Beim Flusen ist ein unbekannter Fehler aufgetreten.',
     'moment-locale-not-found': 'Beim Versuch, Moment.js locale auf {MOMENT_LOCALE} umzustellen, wurde {CURRENT_LOCALE} angezeigt',
+    'file-change-lint-message-start': 'Fusselig',
 
     // rules-runner.ts
     'pre-rules': 'Regeln vor regulären Regeln',
@@ -128,6 +129,14 @@ export default {
       'display-message': {
         'name': 'Meldung auf Flusen anzeigen',
         'description': 'Zeigen Sie die Anzahl der Zeichen an, die sich nach dem Linsen geändert haben',
+      },
+      'lint-on-file-change': {
+        'name': 'Flusen bei Dateiänderungen',
+        'description': 'Wenn eine Datei geschlossen oder eine neue Datei ausgelagert wird, wird die vorherige Datei mit Flusen versehen.',
+      },
+      'display-lint-on-file-change-message': {
+        'name': 'Lint auf Dateiänderungsmeldung anzeigen',
+        'description': 'Zeigt eine Meldung an, wenn `Flusen bei Dateiänderungen` auftritt',
       },
       'folders-to-ignore': {
         'name': 'Ordner, die ignoriert werden sollen',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -49,6 +49,7 @@ export default {
     'see-console': 'See console for more details.',
     'unknown-error': 'An unknown error occurred during linting.',
     'moment-locale-not-found': 'Trying to switch Moment.js locale to {MOMENT_LOCALE}, got {CURRENT_LOCALE}',
+    'file-change-lint-message-start': 'Linted',
 
     // rules-runner.ts
     'pre-rules': 'rules before regular rules',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -130,6 +130,14 @@ export default {
         'name': 'Display message on lint',
         'description': 'Display the number of characters changed after linting',
       },
+      'lint-on-file-change': {
+        'name': 'Lint on File Change',
+        'description': 'When the a file is closed or a new file is swapped to, the previous file is linted.',
+      },
+      'display-lint-on-file-change-message': {
+        'name': 'Display Lint on File Change Message',
+        'description': 'Displays a message when `Lint on File Change` occurs',
+      },
       'folders-to-ignore': {
         'name': 'Folders to ignore',
         'description': 'Folders to ignore when linting all files or linting on save. Enter folder paths separated by newlines',

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -48,6 +48,7 @@ export default {
     'see-console': 'Consulte la consola para obtener más detalles.',
     'unknown-error': 'Se ha producido un error desconocido durante el linting.',
     'moment-locale-not-found': 'Intentando cambiar la zona de Moment.js a {MOMENT_LOCALE}, el resulto fue {CURRENT_LOCALE}',
+    'file-change-lint-message-start': 'Analizó',
     'pre-rules': 'Las reglas antes de las reglas normales',
     'post-rules': 'las reglas después de las reglas normales',
     'rule-running': 'usando las reglas',
@@ -103,6 +104,14 @@ export default {
       'folders-to-ignore': {
         'name': 'Carpetas para omitir',
         'description': 'Carpetas que se deben omitir al analizar todos los archivos o al guardar en línea. Introducir rutas de carpeta separadas por nuevas líneas',
+      },
+      'lint-on-file-change': {
+        'name': 'Analizar archivo en cambiar',
+        'description': 'Cuando se cierra un archivo o se cambia a un nuevo archivo, el archivo anterior se analiza.',
+      },
+      'display-lint-on-file-change-message': {
+        'name': 'Mostrar mensaje en cambiar el archivo',
+        'description': 'Muestra un mensaje cuando se produce `Analizar archivo en cambiar`',
       },
       'override-locale': {
         'name': 'Anular configuración regional',

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -49,6 +49,7 @@ export default {
     'see-console': '请查看控制台以获取更多信息',
     'unknown-error': '格式化过程发生未知错误',
     'moment-locale-not-found': '尝试通过 Moment.js 切换到 {MOMENT_LOCALE}, 实际切换到 {CURRENT_LOCALE}',
+    'file-change-lint-message-start': '棉绒',
 
     // rules-runner.ts
     'pre-rules': '比正常规则优先级更高的规则',
@@ -128,6 +129,14 @@ export default {
       'display-message': {
         'name': '格式化后显示消息',
         'description': '格式化后显示修改了多少字符',
+      },
+      'lint-on-file-change': {
+        'name': '文件更改时的 Lint',
+        'description': '当文件关闭或交换到新文件时，前一个文件将被检查。',
+      },
+      'display-lint-on-file-change-message': {
+        'name': '在文件更改消息上显示 Lint',
+        'description': '当发生`在文件更改消息上显示 Lint`时显示一条消息',
       },
       'folders-to-ignore': {
         'name': '忽略文件夹',

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,8 @@ const DEFAULT_SETTINGS: Partial<LinterSettings> = {
   lintOnSave: false,
   recordLintOnSaveLogs: false,
   displayChanged: true,
+  lintOnFileChange: false,
+  displayLintOnFileChangeNotice: false,
   settingsConvertedToConfigKeyValues: false,
   foldersToIgnore: [],
   linterLocale: 'system-default',
@@ -213,7 +215,7 @@ export default class LinterPlugin extends Plugin {
     this.registerEvent(eventRef);
     this.eventRefs.push(eventRef);
 
-    this.lastActiveFile = this.app.workspace.getActiveFile()
+    this.lastActiveFile = this.app.workspace.getActiveFile();
     eventRef = this.app.workspace.on('active-leaf-change', () => this.onActiveLeafChange());
     this.registerEvent(eventRef);
     this.eventRefs.push(eventRef);
@@ -280,7 +282,8 @@ export default class LinterPlugin extends Plugin {
     }
 
     const currentActiveFile = this.app.workspace.getActiveFile();
-    if (this.lastActiveFile  == null || this.lastActiveFile  === currentActiveFile) {
+    if (!this.settings.lintOnFileChange || this.lastActiveFile == null || this.lastActiveFile === currentActiveFile) {
+      this.lastActiveFile = currentActiveFile;
       return;
     }
 
@@ -289,8 +292,8 @@ export default class LinterPlugin extends Plugin {
     } catch (error) {
       this.handleLintError(this.lastActiveFile, error, getTextInLanguage('commands.lint-file.error-message') + ' \'{FILE_PATH}\'', false);
     } finally {
-      this.lastActiveFile  = currentActiveFile;
       console.log(this.lastActiveFile.path);
+      this.lastActiveFile = currentActiveFile;
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -212,6 +212,17 @@ export default class LinterPlugin extends Plugin {
     this.registerEvent(eventRef);
     this.eventRefs.push(eventRef);
 
+    eventRef = this.app.workspace.on('active-leaf-change', () => {
+      const lastOpenFiles = this.app.workspace.getLastOpenFiles();
+      if (lastOpenFiles.length < 2) {
+        return;
+      }
+      console.log(lastOpenFiles[1], lastOpenFiles);
+    });
+    this.registerEvent(eventRef);
+    this.eventRefs.push(eventRef);
+
+
     // Source for save setting
     // https://github.com/hipstersmoothie/obsidian-plugin-prettier/blob/main/src/main.ts
     const saveCommandDefinition = this.app.commands?.commands?.[

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,8 +1,8 @@
 import {Setting} from 'obsidian';
 import {getTextInLanguage, LanguageStringKey} from './lang/helpers';
 import LinterPlugin from './main';
-import {LinterSettings} from './rules';
 import {parseTextToHTMLWithoutOuterParagraph} from './ui/helpers';
+import {LinterSettings} from './settings-data';
 
 export type SearchOptionInfo = {name: string, description: string, options?: DropdownRecord[]}
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -14,10 +14,9 @@ import {
   SpecialArrayFormats,
   TagSpecificArrayFormats,
 } from './utils/yaml';
-import {LintCommand} from './ui/linter-components/custom-command-option';
-import {CustomReplace} from './ui/linter-components/custom-replace-option';
 import {getTextInLanguage, LanguageStringKey} from './lang/helpers';
 import {ignoreListOfTypes, IgnoreType} from './utils/ignore-types';
+import {LinterSettings} from './settings-data';
 
 // CommonStyles are settings that are used in multiple places and thus need to be external to rules themselves to help facilitate their use
 export type CommonStyles = {
@@ -31,24 +30,6 @@ export type CommonStyles = {
 export type Options = { [optionName: string]: any};
 
 type ApplyFunction = (text: string, options?: Options) => string;
-
-export interface LinterSettings {
-  ruleConfigs: {
-    [ruleName: string]: Options;
-  };
-  lintOnSave: boolean;
-  displayChanged: boolean;
-  settingsConvertedToConfigKeyValues: boolean;
-  recordLintOnSaveLogs: boolean;
-  lintOnFileChange: boolean,
-  displayLintOnFileChangeNotice: boolean,
-  foldersToIgnore: string[];
-  linterLocale: string;
-  logLevel: number;
-  lintCommands: LintCommand[];
-  customRegexes: CustomReplace[];
-  commonStyles: CommonStyles;
-}
 
 export enum RuleType {
   YAML = 'YAML',

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -40,6 +40,8 @@ export interface LinterSettings {
   displayChanged: boolean;
   settingsConvertedToConfigKeyValues: boolean;
   recordLintOnSaveLogs: boolean;
+  lintOnFileChange: boolean,
+  displayLintOnFileChangeNotice: boolean,
   foldersToIgnore: string[];
   linterLocale: string;
   logLevel: number;

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -1,0 +1,45 @@
+import {CommonStyles, Options} from './rules';
+import {LintCommand} from './ui/linter-components/custom-command-option';
+import {CustomReplace} from './ui/linter-components/custom-replace-option';
+import {NormalArrayFormats} from './utils/yaml';
+import log from 'loglevel';
+
+export interface LinterSettings {
+  ruleConfigs: {
+    [ruleName: string]: Options;
+  };
+  lintOnSave: boolean;
+  displayChanged: boolean;
+  settingsConvertedToConfigKeyValues: boolean;
+  recordLintOnSaveLogs: boolean;
+  lintOnFileChange: boolean,
+  displayLintOnFileChangeNotice: boolean,
+  foldersToIgnore: string[];
+  linterLocale: string;
+  logLevel: number;
+  lintCommands: LintCommand[];
+  customRegexes: CustomReplace[];
+  commonStyles: CommonStyles;
+}
+
+export const DEFAULT_SETTINGS: Partial<LinterSettings> = {
+  ruleConfigs: {},
+  lintOnSave: false,
+  recordLintOnSaveLogs: false,
+  displayChanged: true,
+  lintOnFileChange: false,
+  displayLintOnFileChangeNotice: false,
+  settingsConvertedToConfigKeyValues: false,
+  foldersToIgnore: [],
+  linterLocale: 'system-default',
+  logLevel: log.levels.ERROR,
+  lintCommands: [],
+  customRegexes: [],
+  commonStyles: {
+    aliasArrayStyle: NormalArrayFormats.SingleLine,
+    tagArrayStyle: NormalArrayFormats.SingleLine,
+    minimumNumberOfDollarSignsToBeAMathBlock: 2,
+    escapeCharacter: '"',
+    removeUnnecessaryEscapeCharsForMultiLineArrays: false,
+  },
+};

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -16,7 +16,7 @@ export class GeneralTab extends Tab {
     let tempDiv = this.contentEl.createDiv();
     let settingName = getTextInLanguage('tabs.general.lint-on-save.name');
     let settingDesc = getTextInLanguage('tabs.general.lint-on-save.description');
-    const setting = new Setting(tempDiv)
+    let setting = new Setting(tempDiv)
         .setName(settingName)
         .addToggle((toggle) => {
           toggle
@@ -49,8 +49,8 @@ export class GeneralTab extends Tab {
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
 
     tempDiv = this.contentEl.createDiv();
-    settingName = 'Lint on File Change';
-    settingDesc = 'When the a file is closed or a new file is swapped to, the previous file is linted.';
+    settingName = getTextInLanguage('tabs.general.lint-on-file-change.name');
+    settingDesc = getTextInLanguage('tabs.general.lint-on-file-change.description');
     new Setting(tempDiv)
         .setName(settingName)
         .setDesc(settingDesc)
@@ -66,9 +66,9 @@ export class GeneralTab extends Tab {
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
 
     tempDiv = this.contentEl.createDiv();
-    settingName = 'Display Lint on File Change Message';
-    settingDesc = 'Displays a message when `Lint on File Change` occurs';
-    new Setting(tempDiv)
+    settingName = getTextInLanguage('tabs.general.display-lint-on-file-change-message.name');
+    settingDesc = getTextInLanguage('tabs.general.display-lint-on-file-change-message.description');
+    setting = new Setting(tempDiv)
         .setName(settingName)
         .setDesc(settingDesc)
         .addToggle((toggle) => {
@@ -79,6 +79,8 @@ export class GeneralTab extends Tab {
                 await this.plugin.saveSettings();
               });
         });
+
+    parseTextToHTMLWithoutOuterParagraph(settingDesc, setting.descEl, this.plugin.settingsTab.component);
 
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
 

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -49,6 +49,40 @@ export class GeneralTab extends Tab {
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
 
     tempDiv = this.contentEl.createDiv();
+    settingName = 'Lint on File Change';
+    settingDesc = 'When the a file is closed or a new file is swapped to, the previous file is linted.';
+    new Setting(tempDiv)
+        .setName(settingName)
+        .setDesc(settingDesc)
+        .addToggle((toggle) => {
+          toggle
+              .setValue(this.plugin.settings.lintOnFileChange)
+              .onChange(async (value) => {
+                this.plugin.settings.lintOnFileChange = value;
+                await this.plugin.saveSettings();
+              });
+        });
+
+    this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
+
+    tempDiv = this.contentEl.createDiv();
+    settingName = 'Display Lint on File Change Message';
+    settingDesc = 'Displays a message when `Lint on File Change` occurs';
+    new Setting(tempDiv)
+        .setName(settingName)
+        .setDesc(settingDesc)
+        .addToggle((toggle) => {
+          toggle
+              .setValue(this.plugin.settings.displayLintOnFileChangeNotice)
+              .onChange(async (value) => {
+                this.plugin.settings.displayLintOnFileChangeNotice = value;
+                await this.plugin.saveSettings();
+              });
+        });
+
+    this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
+
+    tempDiv = this.contentEl.createDiv();
     settingName = getTextInLanguage('tabs.general.folders-to-ignore.name');
     settingDesc = getTextInLanguage('tabs.general.folders-to-ignore.description');
     new Setting(tempDiv)


### PR DESCRIPTION
Fixes #188 

Changes Made:
- Added 2 new settings 1 for when a the active file changes to another file or is closed and 1 for displaying a message once the previously active file is linted
  - The active file is the current file
- Added translations for the 2 new settings to the Linter via Google Translate
- Moved settings object and defaults for it to a new file to help make updating it easier and to potentially allow using it in UTs as well
- Added documentation around this new kind of file linting to the new docs