### PR TITLE
Update `Sort YAML Keys` to Handle Keys Ending in Colon

### DIFF
--- a/__tests__/yaml-key-sort.test.ts
+++ b/__tests__/yaml-key-sort.test.ts
@@ -66,5 +66,40 @@ ruleTest({
         yamlSortOrderForOtherKeys: 'Ascending Alphabetical',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/796
+      testName: 'Sort works when priority keys end in a colon',
+      before: dedent`
+        ---
+        language: Typescript
+        type: programming
+        tags: computer
+        keywords: []
+        status: WIP
+        date: 01/15/2022
+        modified: Wednesday, January 1st 2020, 12:00:00 am
+        ---
+      `,
+      after: dedent`
+        ---
+        date: 01/15/2022
+        type: programming
+        language: Typescript
+        tags: computer
+        keywords: []
+        status: WIP
+        modified: Thursday, January 2nd 2020, 12:00:00 am
+        ---
+      `,
+      options: {
+        yamlKeyPrioritySortOrder: [
+          'date:',
+          'type:',
+          'language:',
+        ],
+        dateModifiedKey: 'modified',
+        currentTimeFormatted: 'Thursday, January 2nd 2020, 12:00:00 am',
+        yamlTimestampDateModifiedEnabled: true,
+      },
+    },
   ],
 });

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -357,7 +357,7 @@ export default {
     // format-yaml-array.ts
     'format-yaml-array': {
       'name': 'Format YAML Array',
-      'description': 'Allows for the formatting of regular YAML arrays as either multi-line or single-line and `tags` and `aliases` are allowed to have some Obsidian specific YAML formats. Note that single string to single-line goes from a single string entry to a single-line array if more than 1 entry is present. The same is true for single string to multi-line except it becomes a multi-line array.',
+      'description': 'Allows for the formatting of regular YAML arrays as either multi-line or single-line and `tags` and `aliases` are allowed to have some Obsidian specific YAML formats. **Note: that single string to single-line goes from a single string entry to a single-line array if more than 1 entry is present. The same is true for single string to multi-line except it becomes a multi-line array.**',
       'alias-key': {
         'name': 'Format YAML aliases section',
         'description': 'Turns on formatting for the YAML aliases section. You should not enable this option alongside the rule `YAML Title Alias` as they may not work well together or they may have different format styles selected causing unexpected results.',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -304,7 +304,7 @@ export default {
     // empty-line-around-blockquotes.ts
     'empty-line-around-blockquotes': {
       'name': 'Empty Line Around Blockquotes',
-      'description': 'Ensures that there is an empty line around blockquotes unless they start or end a document. **Note that an empty line is either one less level of nesting for blockquotes or a newline character.**',
+      'description': 'Ensures that there is an empty line around blockquotes unless they start or end a document. **Note: an empty line is either one less level of nesting for blockquotes or a newline character.**',
     },
     // empty-line-around-code-fences.ts
     'empty-line-around-code-fences': {
@@ -455,7 +455,7 @@ export default {
     // ordered-list-style.ts
     'ordered-list-style': {
       'name': 'Ordered List Style',
-      'description': 'Makes sure that ordered lists follow the style specified. Note that 2 spaces or 1 tab is considered to be an indentation level.',
+      'description': 'Makes sure that ordered lists follow the style specified. **Note: that 2 spaces or 1 tab is considered to be an indentation level.**',
       'number-style': {
         'name': 'Number Style',
         'description': 'The number style used in ordered list indicators',
@@ -514,7 +514,7 @@ export default {
     // re-index-footnotes.ts
     're-index-footnotes': {
       'name': 'Re-Index Footnotes',
-      'description': 'Re-indexes footnote keys and footnote, based on the order of occurrence (NOTE: This rule does *not* work if there is more than one footnote for a key.)',
+      'description': 'Re-indexes footnote keys and footnote, based on the order of occurrence. **Note: This rule does _not_ work if there is more than one footnote for a key.**',
     },
     // remove-consecutive-list-markers.ts
     'remove-consecutive-list-markers': {
@@ -569,7 +569,7 @@ export default {
     // remove-space-around-characters.ts
     'remove-space-around-characters': {
       'name': 'Remove Space around Characters',
-      'description': 'Ensures that certain characters are not surrounded by whitespace (either single spaces or a tab). Note that this may causes issues with markdown format in some cases.',
+      'description': 'Ensures that certain characters are not surrounded by whitespace (either single spaces or a tab). **Note: this may causes issues with markdown format in some cases.**',
       'include-fullwidth-forms': {
         'name': 'Include Fullwidth Forms',
         'description': 'Include <a href="https://en.wikipedia.org/wiki/Halfwidth_and_Fullwidth_Forms_(Unicode_block)">Fullwidth Forms Unicode block</a>',
@@ -590,7 +590,7 @@ export default {
     // remove-space-before-or-after-characters.ts
     'remove-space-before-or-after-characters': {
       'name': 'Remove Space Before or After Characters',
-      'description': 'Removes space before the specified characters and after the specified characters. Note that this may causes issues with markdown format in some cases.',
+      'description': 'Removes space before the specified characters and after the specified characters. **Note: this may causes issues with markdown format in some cases.**',
       'characters-to-remove-space-before': {
         'name': 'Remove Space Before Characters',
         'description': 'Removes space before the specified characters. **Note: using `{` or `}` in the list of characters will unexpectedly affect files as it is used in the ignore syntax behind the scenes.**',
@@ -663,7 +663,7 @@ export default {
     // yaml-key-sort.ts
     'yaml-key-sort': {
       'name': 'YAML Key Sort',
-      'description': 'Sorts the YAML keys based on the order and priority specified. Note: may remove blank lines as well.',
+      'description': 'Sorts the YAML keys based on the order and priority specified. **Note: may remove blank lines as well.**',
       'yaml-key-priority-sort-order': {
         'name': 'YAML Key Priority Sort Order',
         'description': 'The order in which to sort keys with one on each line where it sorts in the order found in the list',

--- a/src/rules/rule-builder.ts
+++ b/src/rules/rule-builder.ts
@@ -1,8 +1,9 @@
-import {Example, Options, Rule, RuleType, registerRule, LinterSettings, wrapLintError} from '../rules';
+import {Example, Options, Rule, RuleType, registerRule, wrapLintError} from '../rules';
 import {BooleanOption, DropdownOption, DropdownRecord, MomentFormatOption, Option, TextAreaOption, TextOption} from '../option';
 import {logDebug} from '../utils/logger';
 import {getTextInLanguage, LanguageStringKey} from '../lang/helpers';
 import {IgnoreType, IgnoreTypes} from '../utils/ignore-types';
+import {LinterSettings} from 'src/settings-data';
 
 export abstract class RuleBuilderBase {
   static #ruleMap = new Map<string, Rule>();

--- a/src/rules/yaml-key-sort.ts
+++ b/src/rules/yaml-key-sort.ts
@@ -44,6 +44,15 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
     const priorityAtStartOfYaml: boolean = options.priorityKeysAtStartOfYaml;
 
     const yamlKeys: string[] = options.yamlKeyPrioritySortOrder;
+    let index = 0;
+    for (const key of yamlKeys) {
+      if (key.endsWith(':')) {
+        yamlKeys[index] = key.substring(0, key.length - 1);
+      }
+
+      index++;
+    }
+
     const sortKeysResult = this.getYAMLKeysSorted(yamlText, yamlKeys);
     const priorityKeysSorted = sortKeysResult.sortedYamlKeyValues;
     yamlText = sortKeysResult.remainingYaml;


### PR DESCRIPTION
Fixes #796 

Changes Made:
- Added UTs for the scenario in question
- Removed a colon from the end of keys to make sure they can be properly found as keys
- Updated note wording to make it consistent across rules
- Fixed a warning/error in the imports