### PR TITLE
Fix Duplicated Description for `Lint on File Change` and Fix Removal of Indicators for Lists and Checklists when Paste Content and Selected Text Start with List or Checlkist Indicators

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -490,7 +490,11 @@ export default class LinterPlugin extends Plugin {
     const cursorSelections = editor.listSelections();
     if (cursorSelections.length === 1) {
       const cursorSelection = cursorSelections[0];
-      clipboardText = this.rulesRunner.runPasteLint(this.getLineContent(editor, cursorSelection), createRunLinterRulesOptions(clipboardText, null, this.momentLocale, this.settings));
+      clipboardText = this.rulesRunner.runPasteLint(this.getLineContent(editor, cursorSelection),
+          editor.getSelection() ?? '',
+          createRunLinterRulesOptions(clipboardText, null, this.momentLocale, this.settings),
+      );
+
       editor.replaceSelection(clipboardText);
     } else {
       this.handleMultiCursorPaste(editor, cursorSelections, clipboardText);

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -186,7 +186,7 @@ export class RulesRunner {
     });
   }
 
-  runPasteLint(currentLine: string, runOptions: RunLinterRulesOptions): string {
+  runPasteLint(currentLine: string, selectedText: string, runOptions: RunLinterRulesOptions): string {
     let newText = runOptions.oldText;
 
     [newText] = RemoveHyphensOnPaste.applyIfEnabled(newText, runOptions.settings, []);
@@ -199,9 +199,9 @@ export class RulesRunner {
 
     [newText] = RemoveLeadingOrTrailingWhitespaceOnPaste.applyIfEnabled(newText, runOptions.settings, []);
 
-    [newText] = PreventDoubleChecklistIndicatorOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine});
+    [newText] = PreventDoubleChecklistIndicatorOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine, selectedText: selectedText});
 
-    [newText] = PreventDoubleListItemIndicatorOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine});
+    [newText] = PreventDoubleListItemIndicatorOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine, selectedText: selectedText});
 
     [newText] = BlockquotifyOnPaste.applyIfEnabled(newText, runOptions.settings, [], {lineContent: currentLine});
 

--- a/src/rules/prevent-double-list-item-indicator-on-paste.ts
+++ b/src/rules/prevent-double-list-item-indicator-on-paste.ts
@@ -7,6 +7,8 @@ import {lineStartingWithWhitespaceOrBlockquoteTemplate} from '../utils/regex';
 class PreventDoubleListItemIndicatorOnPasteOptions implements Options {
   @RuleBuilder.noSettingControl()
     lineContent: string;
+  @RuleBuilder.noSettingControl()
+    selectedText: string;
 }
 
 @RuleBuilder.register
@@ -26,8 +28,9 @@ export default class PreventDoubleListItemIndicatorOnPaste extends RuleBuilder<P
     const listRegex = /^\s*[*+-] /;
 
     const isListLine = indentedOrBlockquoteNestedListIndicatorRegex.test(options.lineContent);
+    const selectedStartsWithListItem = indentedOrBlockquoteNestedListIndicatorRegex.test(options.selectedText);
     const isListClipboard = listRegex.test(text);
-    if (!isListLine || !isListClipboard) {
+    if (selectedStartsWithListItem || !isListLine || !isListClipboard) {
       return text;
     }
 
@@ -45,6 +48,7 @@ export default class PreventDoubleListItemIndicatorOnPaste extends RuleBuilder<P
         `,
         options: {
           lineContent: 'Regular text here',
+          selectedText: '',
         },
       }),
       new ExampleBuilder({
@@ -59,6 +63,7 @@ export default class PreventDoubleListItemIndicatorOnPaste extends RuleBuilder<P
         `,
         options: {
           lineContent: '> > ',
+          selectedText: '',
         },
       }),
       new ExampleBuilder({
@@ -73,6 +78,7 @@ export default class PreventDoubleListItemIndicatorOnPaste extends RuleBuilder<P
         `,
         options: {
           lineContent: '> * ',
+          selectedText: '',
         },
       }),
       new ExampleBuilder({
@@ -87,6 +93,22 @@ export default class PreventDoubleListItemIndicatorOnPaste extends RuleBuilder<P
         `,
         options: {
           lineContent: '+ ',
+          selectedText: '',
+        },
+      }),
+      new ExampleBuilder({ // accounts for https://github.com/platers/obsidian-linter/issues/801
+        description: 'When pasting a list item and the selected text starts with a list item indicator, the text to paste should still start with a list item indicator',
+        before: dedent`
+          - List item 1
+          - List item 2
+        `,
+        after: dedent`
+          - List item 1
+          - List item 2
+        `,
+        options: {
+          lineContent: '+ ',
+          selectedText: '+ ',
         },
       }),
     ];

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -70,7 +70,6 @@ export class GeneralTab extends Tab {
     settingDesc = getTextInLanguage('tabs.general.display-lint-on-file-change-message.description');
     setting = new Setting(tempDiv)
         .setName(settingName)
-        .setDesc(settingDesc)
         .addToggle((toggle) => {
           toggle
               .setValue(this.plugin.settings.displayLintOnFileChangeNotice)


### PR DESCRIPTION
Fixes #801 

Changes Made:
- Passed selected text into the rules for prevent duplicate indicators for checklists and list items and kept the one from the paste content if both the paste content and the selected content started with checklist or list item indicators
- Added an example/test for the above scenario
- Also fixed a duplication of a setting description introduced when I added the settings for linting a file when the active file changed