### PR TITLE
Fix Issue with Lint via File Menu Always Updating File Modified Date

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -169,7 +169,7 @@ export default {
       },
     },
     'debug': {
-    // debug-tab.ts
+      // debug-tab.ts
       'log-level': {
         'name': 'Log Level',
         'description': 'The types of logs that will be allowed to be logged by the service. The default is ERROR.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,7 +292,9 @@ export default class LinterPlugin extends Plugin {
     const oldText = stripCr(await this.app.vault.read(file));
     const newText = this.rulesRunner.lintText(createRunLinterRulesOptions(oldText, file, this.momentLocale, this.settings));
 
-    await this.app.vault.modify(file, newText);
+    if (oldText != newText) {
+      await this.app.vault.modify(file, newText);
+    }
 
     // Make sure this is disabled until we actually add something to let it work on folder and vault linting
     // this.rulesRunner.runCustomCommands(this.settings.lintCommands, this.app.commands);


### PR DESCRIPTION
Fixes #745 

Changes Made:
- Fix spacing around a comment
- Make sure to only call the method for modifying a file when the text has changed since for some reason that forces an update of the date modified when there is no change to the file contents itself