### PR TITLE
Revert "Add ESLint Auto Fix for Fixable Issues in CI"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,5 @@ jobs:
         run: npm run build
       - name: Run unit tests
         run: npm test
-      - name: Run ESLint to fix errors
-        run: npm run lint
-      - name: Commit ESLint fixes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: "Bot: fix ESLint errors"
       - name: Run ESLint
         run: npx eslint . --ext .ts


### PR DESCRIPTION
Reverts platers/obsidian-linter#791

Relates to #782 

I need to revert the change since it is not working as intended with forks. It fails unexpectedly.