### PR TITLE
Updated Lint File from File Menu to Go Ahead and Lint Using the Editor if Possible

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -130,7 +130,7 @@ export default class LinterPlugin extends Plugin {
         const file = this.app.workspace.getActiveFile();
 
         if (!this.shouldIgnoreFile(file)) {
-          this.runLinterEditor(editor);
+          this.runLintEditorWithLogsIfApplicable(editor);
         }
       },
       icon: iconInfo.file.id,

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,12 +112,7 @@ export default class LinterPlugin extends Plugin {
       id: 'lint-file',
       name: getTextInLanguage('commands.lint-file.name'),
       editorCallback: (editor) => {
-        setCollectLogs(this.settings.recordLintOnSaveLogs);
-        clearLogs();
-
-        this.runLinterEditor(editor);
-
-        setCollectLogs(false);
+        this.runLintEditorWithLogsIfApplicable(editor);
       },
       icon: iconInfo.file.id,
       hotkeys: [
@@ -215,12 +210,7 @@ export default class LinterPlugin extends Plugin {
           const file = this.app.workspace.getActiveFile();
 
           if (!this.shouldIgnoreFile(file)) {
-            setCollectLogs(this.settings.recordLintOnSaveLogs);
-            clearLogs();
-
-            this.runLinterEditor(editor);
-
-            setCollectLogs(false);
+            this.runLintEditorWithLogsIfApplicable(editor);
           }
         }
       };
@@ -240,7 +230,13 @@ export default class LinterPlugin extends Plugin {
         item.setIcon(iconInfo.file.id)
             .setTitle(getTextInLanguage('commands.lint-file-pop-up-menu-text.name'))
             .onClick(async () => {
-              this.runLinterFile(file);
+              const activeFile = this.app.workspace.getActiveFile();
+              const editor = this.getEditor();
+              if (activeFile === file && editor) {
+                this.runLintEditorWithLogsIfApplicable(editor);
+              } else {
+                this.runLinterFile(file);
+              }
             });
       });
     } else if (file instanceof TFolder) {
@@ -359,6 +355,15 @@ export default class LinterPlugin extends Plugin {
     new LintConfirmationModal(this.app, startMessage, submitBtnText, submitBtnNoticeText, () => this.runLinterAllFilesInFolder(folder)).open();
   }
 
+
+  runLintEditorWithLogsIfApplicable(editor: Editor) {
+    setCollectLogs(this.settings.recordLintOnSaveLogs);
+    clearLogs();
+
+    this.runLinterEditor(editor);
+
+    setCollectLogs(false);
+  }
   runLinterEditor(editor: Editor) {
     logInfo(getTextInLanguage('logs.linter-run'));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,7 +112,7 @@ export default class LinterPlugin extends Plugin {
       id: 'lint-file',
       name: getTextInLanguage('commands.lint-file.name'),
       editorCallback: (editor) => {
-        this.runLintEditorWithLogsIfApplicable(editor);
+        this.runLinterEditor(editor);
       },
       icon: iconInfo.file.id,
       hotkeys: [
@@ -130,7 +130,7 @@ export default class LinterPlugin extends Plugin {
         const file = this.app.workspace.getActiveFile();
 
         if (!this.shouldIgnoreFile(file)) {
-          this.runLintEditorWithLogsIfApplicable(editor);
+          this.runLinterEditor(editor);
         }
       },
       icon: iconInfo.file.id,
@@ -210,7 +210,7 @@ export default class LinterPlugin extends Plugin {
           const file = this.app.workspace.getActiveFile();
 
           if (!this.shouldIgnoreFile(file)) {
-            this.runLintEditorWithLogsIfApplicable(editor);
+            this.runLinterEditor(editor);
           }
         }
       };
@@ -233,7 +233,7 @@ export default class LinterPlugin extends Plugin {
               const activeFile = this.app.workspace.getActiveFile();
               const editor = this.getEditor();
               if (activeFile === file && editor) {
-                this.runLintEditorWithLogsIfApplicable(editor);
+                this.runLinterEditor(editor);
               } else {
                 this.runLinterFile(file);
               }
@@ -355,16 +355,10 @@ export default class LinterPlugin extends Plugin {
     new LintConfirmationModal(this.app, startMessage, submitBtnText, submitBtnNoticeText, () => this.runLinterAllFilesInFolder(folder)).open();
   }
 
-
-  runLintEditorWithLogsIfApplicable(editor: Editor) {
+  runLinterEditor(editor: Editor) {
     setCollectLogs(this.settings.recordLintOnSaveLogs);
     clearLogs();
 
-    this.runLinterEditor(editor);
-
-    setCollectLogs(false);
-  }
-  runLinterEditor(editor: Editor) {
     logInfo(getTextInLanguage('logs.linter-run'));
 
     const file = this.app.workspace.getActiveFile();
@@ -412,6 +406,8 @@ export default class LinterPlugin extends Plugin {
     } catch (error) {
       this.handleLintError(file, error, getTextInLanguage('commands.lint-file.error-message') + ' \'{FILE_PATH}\'', false);
     }
+
+    setCollectLogs(false);
   }
 
   // based on https://github.com/liamcain/obsidian-calendar-ui/blob/03ceecbf6d88ef260dadf223ee5e483d98d24ffc/src/localization.ts#L85-L109


### PR DESCRIPTION
Relates to #745 

Changes Made:
- If the current file is linted via the file menu using the 3 dots, the linting experience should be like running the command for linting the current file
  - This requires that the current file be the file that is being linted from the menu and that the current file's editor is present
  - The file's editor is not present if you select the file from the file explorer and try to lint it that way
- Also updated the logic for the command for linting a file unless it is ignored to make sure that it also includes logs where applicable
- Refactored the logic for running linting with the editor to now always include logs since it can only be used for the currently active file and it is now always being run with logs if the settings are turned on