### PR TITLE
Make Timing Logs Only Show for Rules that Run and Make Example Clearer

### DIFF
--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -67,7 +67,6 @@ export class RulesRunner {
         continue;
       }
 
-      timingBegin(rule.alias);
       [newText] = RuleBuilderBase.applyIfEnabledBase(rule, newText, runOptions.settings, {
         fileCreatedTime: runOptions.fileInfo.createdAtFormatted,
         fileModifiedTime: runOptions.fileInfo.modifiedAtFormatted,
@@ -79,7 +78,6 @@ export class RulesRunner {
         defaultEscapeCharacter: runOptions.settings.commonStyles.escapeCharacter,
         removeUnnecessaryEscapeCharsForMultiLineArrays: runOptions.settings.commonStyles.removeUnnecessaryEscapeCharsForMultiLineArrays,
       });
-      timingEnd(rule.alias);
     }
 
     const customRegexLogText = getTextInLanguage('logs.custom-regex');

--- a/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
+++ b/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
@@ -27,12 +27,12 @@ export default class RemoveLeftoverFootnotesFromQuoteOnPaste extends RuleBuilder
         before: dedent`
           He was sure that he would get off without doing any time, but the cops had other plans.50
           ${''}
-          _Note that the format for footnote references to move is a dot or comma followed by any number of digits_
+          _Note that the format for footnote references to remove is a dot or comma followed by any number of digits_
         `,
         after: dedent`
           He was sure that he would get off without doing any time, but the cops had other plans
           ${''}
-          _Note that the format for footnote references to move is a dot or comma followed by any number of digits_
+          _Note that the format for footnote references to remove is a dot or comma followed by any number of digits_
         `,
       }),
     ];


### PR DESCRIPTION
Changes Made:
- Moved timing for specific rules into the base of the running of a rule to make it clearer which rules are running and how long they took
- Also updated the wording in an example to say remove rather than move (relates to #814 )