### PR TITLE
Fix Blank Lines Around Callouts Causing Callouts to Merge

### DIFF
--- a/__tests__/empty-line-around-blockquotes.test.ts
+++ b/__tests__/empty-line-around-blockquotes.test.ts
@@ -126,5 +126,46 @@ ruleTest({
         > Content
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/684
+      testName: 'Make sure that a nested set of callouts are not merged when only a blank lines is between them with no content',
+      before: dedent`
+        > [!multi-column]
+        >
+        >> [!note]+ Use Case
+        >> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        >> ##### User Case Background
+        >> Vitae nunc sed velit dignissim sodales. In cursus turpis massa tincidunt dui ut ornare lectus.
+        >
+        >> [!warning]+ Resources
+        >> #### Requirement
+        >> - Lorem ipsum dolor sit amet
+        >> - Vitae nunc sed velit dignissim sodales.
+        >> - In cursus turpis massa tincidunt dui ut ornare lectus.
+        >
+        >> [!todo]+
+        >> - [x] Define Use Case
+        >> - [ ] Craft User Story
+        >> - [ ] Develop draft sketches
+      `,
+      after: dedent`
+        > [!multi-column]
+        >
+        >> [!note]+ Use Case
+        >> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        >> ##### User Case Background
+        >> Vitae nunc sed velit dignissim sodales. In cursus turpis massa tincidunt dui ut ornare lectus.
+        >
+        >> [!warning]+ Resources
+        >> #### Requirement
+        >> - Lorem ipsum dolor sit amet
+        >> - Vitae nunc sed velit dignissim sodales.
+        >> - In cursus turpis massa tincidunt dui ut ornare lectus.
+        >
+        >> [!todo]+
+        >> - [x] Define Use Case
+        >> - [ ] Craft User Story
+        >> - [ ] Develop draft sketches
+      `,
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -42,6 +42,7 @@ export const indentedOrBlockquoteNestedChecklistIndicatorRegex = new RegExp(`^${
 export const nonBlockquoteChecklistRegex = new RegExp(`^\\s*- ${checklistBoxIndicator} `);
 
 export const footnoteDefinitionIndicatorAtStartOfLine = /^(\[\^\w+\]) ?([,.;!:?])/gm;
+export const calloutRegex = /^(>\s*)+\[![^\s]*\]/m;
 
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string


### PR DESCRIPTION
Fixes #812 

Changes Made:
- Added a test for the scenario in question
- Updated the logic for getting an empty line for blockquotes to check to see if we are currently dealing with a callout
  - If dealing with a callout or the next blockquote is a callout, we need to make sure that the blank being added is not the same as the current blockquote level since that will merge the current blockquote with the callout, so instead we remove a level from the original blank line and then it should give us a valid blank to use 