### PR TITLE
Ignored Inline Code for `Remove Space Around Characters`

### DIFF
--- a/__tests__/remove-space-around-characters.test.ts
+++ b/__tests__/remove-space-around-characters.test.ts
@@ -5,8 +5,7 @@ import {ruleTest} from './common';
 ruleTest({
   RuleBuilderClass: RemoveSpaceAroundCharacters,
   testCases: [
-    {
-      // accounts for https://github.com/platers/obsidian-linter/issues/344
+    { // accounts for https://github.com/platers/obsidian-linter/issues/344
       testName: 'Make sure that lists with a dollar sign in them actually get escaped correctly',
       before: dedent`
         # Title
@@ -64,6 +63,18 @@ ruleTest({
       `,
       after: dedent`
         Spaces around custom symbols:are;removed
+      `,
+      options: {
+        otherSymbols: ':;',
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/826
+      testName: 'Make sure that inline code is left alone',
+      before: dedent`
+        \`Spaces around custom symbols : are ; left alone\`
+      `,
+      after: dedent`
+        \`Spaces around custom symbols : are ; left alone\`
       `,
       options: {
         otherSymbols: ':;',

--- a/src/rules/remove-space-around-characters.ts
+++ b/src/rules/remove-space-around-characters.ts
@@ -19,7 +19,7 @@ export default class RemoveSpaceAroundCharacters extends RuleBuilder<RemoveSpace
       nameKey: 'rules.remove-space-around-characters.name',
       descriptionKey: 'rules.remove-space-around-characters.description',
       type: RuleType.SPACING,
-      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => RemoveSpaceAroundCharactersOptions {


### PR DESCRIPTION
Relates to #826 

Changes Made:
- Added a test for ignoring inline code for removing space around characters
- Added the inline code type to the ignore logic for `Remove Space Around Characters`