### PR TITLE
Fix `Lint on File Change` Throwing an Error on Current File Delete

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -255,7 +255,8 @@ export default class LinterPlugin extends Plugin {
     }
 
     const currentActiveFile = this.app.workspace.getActiveFile();
-    if (!this.settings.lintOnFileChange || this.lastActiveFile == null || this.lastActiveFile === currentActiveFile || this.shouldIgnoreFile(this.lastActiveFile)) {
+    const lastActiveFileExists = this.lastActiveFile == null ? false : await this.app.vault.adapter.exists(this.lastActiveFile.path);
+    if (!this.settings.lintOnFileChange || !lastActiveFileExists || this.lastActiveFile === currentActiveFile || this.shouldIgnoreFile(this.lastActiveFile)) {
       this.lastActiveFile = currentActiveFile;
       return;
     }


### PR DESCRIPTION
Fixes #834 

Changes Made:
- Checked that the last file exists before continuing on to try linting it