### PR TITLE
Fixed an Issue with `Empty Lines Around Code` Breaking Some Callouts Apart

### DIFF
--- a/__tests__/empty-line-around-code-fences.test.ts
+++ b/__tests__/empty-line-around-code-fences.test.ts
@@ -126,5 +126,23 @@ ruleTest({
         > Other content
       `,
     },
+    { // relates to https://github.com/platers/obsidian-linter/issues/833
+      testName: 'Make sure that a nested callout with a code block does not get broken apart',
+      before: dedent`
+        > [!abstract]- Mentions
+        > > [!abstract]- Mentions2
+        > > \`\`\`dataview
+        > > XXX
+        > > \`\`\`
+      `,
+      after: dedent`
+        > [!abstract]- Mentions
+        > > [!abstract]- Mentions2
+        > >
+        > > \`\`\`dataview
+        > > XXX
+        > > \`\`\`
+      `,
+    },
   ],
 });

--- a/__tests__/empty-line-around-code-fences.test.ts
+++ b/__tests__/empty-line-around-code-fences.test.ts
@@ -86,5 +86,45 @@ ruleTest({
         2222
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/833
+      testName: 'Make sure that a callout with a code block is not broken apart',
+      before: dedent`
+        > [!abstract]- Mentions
+        > \`\`\`dataview
+        > XXX
+        > \`\`\`
+      `,
+      after: dedent`
+        > [!abstract]- Mentions
+        >
+        > \`\`\`dataview
+        > XXX
+        > \`\`\`
+      `,
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/833
+      testName: 'Make sure that a callout with a code block followed by another callout does not get merged',
+      before: dedent`
+        > [!abstract]- Mentions
+        > \`\`\`dataview
+        > XXX
+        > \`\`\`
+        ${''}
+        > [!abstract]- Mentions2
+        >
+        > Other content
+      `,
+      after: dedent`
+        > [!abstract]- Mentions
+        >
+        > \`\`\`dataview
+        > XXX
+        > \`\`\`
+        ${''}
+        > [!abstract]- Mentions2
+        >
+        > Other content
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -598,7 +598,7 @@ export function ensureEmptyLinesAroundBlockquotes(text: string): string {
       endIndex++;
     }
 
-    text = makeSureContentHasEmptyLinesAddedBeforeAndAfter(text, position.start.offset, endIndex);
+    text = makeSureContentHasEmptyLinesAddedBeforeAndAfter(text, position.start.offset, endIndex, true);
   }
 
   return text;

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -95,7 +95,7 @@ function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFile(text: str
   return text.substring(0, startOfNewContent) + '\n' + text.substring(startOfContent);
 }
 
-function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(text: string, startOfLine: string, startOfContent: number, isCallout: boolean = false): string {
+function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(text: string, startOfLine: string, startOfContent: number, isCallout: boolean = false, addingEmptyLinesAroundBlockquotes: boolean = false): string {
   if (startOfContent === 0) {
     return text;
   }
@@ -151,7 +151,9 @@ function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockqu
     priorLine = text.substring(indexOfLastNewLine, startOfNewContent);
   }
 
-  return text.substring(0, startOfNewContent) + getEmptyLineForBlockqute(priorLine, isCallout, nestingLevel) + text.substring(startOfContent);
+  const emptyLine = addingEmptyLinesAroundBlockquotes ? getEmptyLineForBlockqute(priorLine, isCallout, nestingLevel) : getEmptyLine(priorLine);
+
+  return text.substring(0, startOfNewContent) + emptyLine + text.substring(startOfContent);
 }
 
 function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFile(text: string, endOfContent: number): string {
@@ -183,7 +185,7 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFile(text: string
   return text.substring(0, endOfContent) + '\n' + text.substring(endOfNewContent);
 }
 
-function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text: string, startOfLine: string, endOfContent: number, isCallout: boolean = false): string {
+function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text: string, startOfLine: string, endOfContent: number, isCallout: boolean = false, addingEmptyLinesAroundBlockquotes: boolean = false): string {
   if (endOfContent === (text.length - 1)) {
     return text;
   }
@@ -245,7 +247,9 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote
     nextLine = text.substring(endOfNewContent + 1, indexOfSecondNewLineAfterContent);
   }
 
-  return text.substring(0, endOfContent) + getEmptyLineForBlockqute(nextLine, isCallout, nestingLevel) + text.substring(endOfNewContent);
+  const emptyLine = addingEmptyLinesAroundBlockquotes ? getEmptyLineForBlockqute(nextLine, isCallout, nestingLevel) : getEmptyLine(nextLine);
+
+  return text.substring(0, endOfContent) + emptyLine + text.substring(endOfNewContent);
 }
 
 /**
@@ -253,15 +257,16 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote
  * @param {string} text - The entire file's contents
  * @param {number} start - The starting index of the content to escape
  * @param {number} end - The ending index of the content to escape
+ * @param {boolean} addingEmptyLinesAroundBlockquotes - Whether or not the logic is meant to add empty lines around blockquotes. This is something meant to better help with spacing around blockquotes.
  * @return {string} The new file contents after the empty lines have been added
  */
-export function makeSureContentHasEmptyLinesAddedBeforeAndAfter(text: string, start: number, end: number): string {
+export function makeSureContentHasEmptyLinesAddedBeforeAndAfter(text: string, start: number, end: number, addingEmptyLinesAroundBlockquotes: boolean = false): string {
   const [startOfLine, startOfLineIndex] = getStartOfLineWhitespaceOrBlockquoteLevel(text, start);
   if (startOfLine.trim() !== '') {
     const isCallout = calloutRegex.test(text.substring(start, end));
-    const newText = makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text, startOfLine, end, isCallout);
+    const newText = makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote(text, startOfLine, end, isCallout, addingEmptyLinesAroundBlockquotes);
 
-    return makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(newText, startOfLine, startOfLineIndex, isCallout);
+    return makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockquote(newText, startOfLine, startOfLineIndex, isCallout, addingEmptyLinesAroundBlockquotes);
   }
 
   const newText = makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFile(text, end);


### PR DESCRIPTION
Fixes #833 

Changes Made:
- Added tests for the issue in question
- Updated the logic to only use the special callout logic to prevent merging callout content when dealing with a empty lines around blockquotes to prevent accidentally breaking some callouts apart