### PR TITLE
Fix Linting Non-Markdown Files for `Lint on File Change`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -256,7 +256,7 @@ export default class LinterPlugin extends Plugin {
 
     const currentActiveFile = this.app.workspace.getActiveFile();
     const lastActiveFileExists = this.lastActiveFile == null ? false : await this.app.vault.adapter.exists(this.lastActiveFile.path);
-    if (!this.settings.lintOnFileChange || !lastActiveFileExists || this.lastActiveFile === currentActiveFile || this.shouldIgnoreFile(this.lastActiveFile)) {
+    if (!this.settings.lintOnFileChange || !lastActiveFileExists || this.lastActiveFile === currentActiveFile || this.lastActiveFile.extension !== 'md' || this.shouldIgnoreFile(this.lastActiveFile)) {
       this.lastActiveFile = currentActiveFile;
       return;
     }


### PR DESCRIPTION
Fixes #837 

Changes Made:
- Checked to make sure that the extension of the file is one of a markdown file