### PR TITLE
Fixed an Issue with `Remove Leftover Footnotes from Quote on Paste` Affecting Links and Images

### DIFF
--- a/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
+++ b/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
@@ -1,4 +1,5 @@
 // based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L15
+import { IgnoreTypes } from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -11,6 +12,7 @@ export default class RemoveLeftoverFootnotesFromQuoteOnPaste extends RuleBuilder
     super({
       nameKey: 'rules.remove-leftover-footnotes-from-quote-on-paste.name',
       descriptionKey: 'rules.remove-leftover-footnotes-from-quote-on-paste.description',
+      ruleIgnoreTypes: [IgnoreTypes.wikiLink, IgnoreTypes.link],
       type: RuleType.PASTE,
     });
   }
@@ -33,6 +35,17 @@ export default class RemoveLeftoverFootnotesFromQuoteOnPaste extends RuleBuilder
           He was sure that he would get off without doing any time, but the cops had other plans
           ${''}
           _Note that the format for footnote references to remove is a dot or comma followed by any number of digits_
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Footnote reference removal does not affect links',
+        before: dedent`
+          [[Half is .5]]
+          [Half is .5](HalfIs.5.md)
+        `,
+        after: dedent`
+          [[Half is .5]]
+          [Half is .5](HalfIs.5.md)
         `,
       }),
     ];

--- a/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
+++ b/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
@@ -12,7 +12,7 @@ export default class RemoveLeftoverFootnotesFromQuoteOnPaste extends RuleBuilder
     super({
       nameKey: 'rules.remove-leftover-footnotes-from-quote-on-paste.name',
       descriptionKey: 'rules.remove-leftover-footnotes-from-quote-on-paste.description',
-      ruleIgnoreTypes: [IgnoreTypes.wikiLink, IgnoreTypes.link],
+      ruleIgnoreTypes: [IgnoreTypes.wikiLink, IgnoreTypes.link, IgnoreTypes.image],
       type: RuleType.PASTE,
     });
   }
@@ -42,10 +42,14 @@ export default class RemoveLeftoverFootnotesFromQuoteOnPaste extends RuleBuilder
         before: dedent`
           [[Half is .5]]
           [Half is .5](HalfIs.5.md)
+          ![](HalfIs.5.jpg)
+          ![[Half is .5.jpg]]
         `,
         after: dedent`
           [[Half is .5]]
           [Half is .5](HalfIs.5.md)
+          ![](HalfIs.5.jpg)
+          ![[Half is .5.jpg]]
         `,
       }),
     ];

--- a/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
+++ b/src/rules/remove-leftover-footnotes-from-quote-on-paste.ts
@@ -1,5 +1,5 @@
 // based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L15
-import { IgnoreTypes } from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';

--- a/src/rules/remove-trailing-punctuation-in-heading.ts
+++ b/src/rules/remove-trailing-punctuation-in-heading.ts
@@ -31,7 +31,6 @@ export default class RemoveTrailingPunctuationInHeading extends RuleBuilder<Remo
 
           const trimmedHeaderText = $4.trimEnd();
           const lastHeadingChar = trimmedHeaderText.charAt(trimmedHeaderText.length - 1);
-          console.log(trimmedHeaderText, trimmedHeaderText.endsWith('  ') || trimmedHeaderText.endsWith('\t'));
           if (options.punctuationToRemove.includes(lastHeadingChar)) {
             return $1 + $2 + $3 + $4.substring(0, trimmedHeaderText.length - 1) + $4.substring(trimmedHeaderText.length) + $5;
           }

--- a/src/rules/rule-builder.ts
+++ b/src/rules/rule-builder.ts
@@ -87,14 +87,10 @@ export default abstract class RuleBuilder<TOptions extends Options> extends Rule
     this.type = args.type;
     this.hasSpecialExecutionOrder = args.hasSpecialExecutionOrder ?? false;
 
-    if (args.type === RuleType.PASTE) {
-      this.ignoreTypes = [];
+    if (args.ruleIgnoreTypes) {
+      this.ignoreTypes = [IgnoreTypes.customIgnore, ...args.ruleIgnoreTypes];
     } else {
-      if (args.ruleIgnoreTypes) {
-        this.ignoreTypes = [IgnoreTypes.customIgnore, ...args.ruleIgnoreTypes];
-      } else {
-        this.ignoreTypes = [IgnoreTypes.customIgnore];
-      }
+      this.ignoreTypes = [IgnoreTypes.customIgnore];
     }
   }
 


### PR DESCRIPTION
Fixes #846 

Changes Made:
- Removed a console log that was added for testing a different bug
- Updated the base rule logic to allow paste rules to ignore types
- Added an example of remove leftover footnotes from quote on paste not removing values from a link
- Added ignores in remove leftover footnotes from quote on paste for links