### PR TITLE
Fix Timestamp Format Having Trailing Whitespace Making Format Invalid

### DIFF
--- a/__tests__/yaml-timestamp.test.ts
+++ b/__tests__/yaml-timestamp.test.ts
@@ -41,6 +41,32 @@ ruleTest({
         format: '',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/861
+      testName: 'When format ends in whitespace, date created is not changed when time updates',
+      before: dedent`
+        ---
+        created: Wednesday, January 1st 2020, 12:00 am
+        modified: Thursday, January 2nd 2020, 12:00 am
+        ---
+      `,
+      after: dedent`
+        ---
+        created: Wednesday, January 1st 2020, 12:00 am
+        modified: Thursday, January 2nd 2020, 12:00 am
+        ---
+      `,
+      options: {
+        dateCreated: true,
+        dateCreatedKey: 'created',
+        dateModified: true,
+        dateModifiedKey: 'modified',
+        format: 'dddd, MMMM Do YYYY, h:mm a ',
+        currentTime: moment('Thursday, January 2nd 2020, 12:01 am', 'dddd, MMMM Do YYYY, h:mm a'),
+        alreadyModified: false,
+        forceRetentionOfCreatedValue: false,
+        fileModifiedTime: '2020-01-02T00:00:00-00',
+      },
+    },
     {
       testName: 'When the date format changes and `forceRetentionOfCreatedValue = true`, date created value is based on the one in the YAML frontmatter.',
       before: dedent`

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -136,7 +136,7 @@ export class RulesRunner {
 
     currentTime = runOptions.getCurrentTime();
     [newText] = YamlKeySort.applyIfEnabled(newText, runOptions.settings, this.disabledRules, {
-      currentTimeFormatted: currentTime.format(yamlTimestampOptions.format),
+      currentTimeFormatted: currentTime.format(yamlTimestampOptions.format.trimEnd()),
       yamlTimestampDateModifiedEnabled: isYamlTimestampEnabled && yamlTimestampOptions.dateModified,
       dateModifiedKey: yamlTimestampOptions.dateModifiedKey,
     });

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -53,6 +53,7 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
     let textModified = options.alreadyModified;
     const newText = initYAML(text);
     textModified = textModified || newText !== text;
+    options.format = options.format.trimEnd();
 
     return formatYAML(newText, (text) => {
       if (options.dateCreated) {


### PR DESCRIPTION
Fixes #861 

Changes Made:
- Added a UT for the scenario in question
- Made sure to trim the end of the format when passing it into YAML Key Sort and in the logic for YAML Timestamp