### PR TITLE
Fix Linter Running Against Non-Markdown Files in Some Instances

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -140,8 +140,7 @@ export default class LinterPlugin extends Plugin {
           return that.isMarkdownFile(ctx.file);
         }
 
-        const file = that.app.workspace.getActiveFile();
-        if (!that.shouldIgnoreFile(file)) {
+        if (!that.shouldIgnoreFile(ctx.file)) {
           that.runLinterEditor(editor);
         }
       },
@@ -166,12 +165,12 @@ export default class LinterPlugin extends Plugin {
       id: 'lint-all-files-in-folder',
       name: getTextInLanguage('commands.lint-all-files-in-folder.name'),
       icon: iconInfo.folder.id,
-      editorCheckCallback: (checking: Boolean, _) => {
+      editorCheckCallback: (checking: Boolean, _, ctx) => {
         if (checking) {
-          return !this.app.workspace.getActiveFile().parent.isRoot();
+          return !ctx.file.parent.isRoot();
         }
 
-        this.createFolderLintModal(this.app.workspace.getActiveFile().parent);
+        this.createFolderLintModal(ctx.file.parent);
       },
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,15 +112,16 @@ export default class LinterPlugin extends Plugin {
   }
 
   addCommands() {
+    const that = this;
     this.addCommand({
       id: 'lint-file',
       name: getTextInLanguage('commands.lint-file.name'),
       editorCheckCallback(checking, editor, ctx) {
         if (checking) {
-          return this.isMarkdownFile(ctx.file);
+          return that.isMarkdownFile(ctx.file);
         }
 
-        this.runLinterEditor(editor);
+        that.runLinterEditor(editor);
       },
       icon: iconInfo.file.id,
       hotkeys: [
@@ -136,12 +137,12 @@ export default class LinterPlugin extends Plugin {
       name: getTextInLanguage('commands.lint-file-unless-ignored.name'),
       editorCheckCallback(checking, editor, ctx) {
         if (checking) {
-          return this.isMarkdownFile(ctx.file);
+          return that.isMarkdownFile(ctx.file);
         }
 
-        const file = this.app.workspace.getActiveFile();
-        if (!this.shouldIgnoreFile(file)) {
-          this.runLinterEditor(editor);
+        const file = that.app.workspace.getActiveFile();
+        if (!that.shouldIgnoreFile(file)) {
+          that.runLinterEditor(editor);
         }
       },
       icon: iconInfo.file.id,
@@ -280,7 +281,7 @@ export default class LinterPlugin extends Plugin {
     }
   }
 
-  shouldIgnoreFile(file: TFile) {
+  shouldIgnoreFile(file: TFile): boolean {
     for (const folder of this.settings.foldersToIgnore) {
       if (folder.length > 0 && file.path.startsWith(folder)) {
         return true;
@@ -289,7 +290,7 @@ export default class LinterPlugin extends Plugin {
     return false;
   }
 
-  isMarkdownFile(file: TFile) {
+  isMarkdownFile(file: TFile): boolean {
     return file && file.extension === 'md';
   }
 


### PR DESCRIPTION
Relates to #864 

Changes Made:
- Updated the logic to make sure it is only running the Linter against Mardkown files. Right now that definition is being limited to just files that end with the extension `md`.
- Uses the file from the context to determine what file to run against