### PR TITLE
Update `Heading Blank Lines` to Not Add Blank Line Between 2 Headings when `Bottom=false`

### DIFF
--- a/__tests__/heading-blank-lines.test.ts
+++ b/__tests__/heading-blank-lines.test.ts
@@ -127,5 +127,39 @@ ruleTest({
         emptyLineAfterYaml: false,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/773
+      testName: 'Make sure that blank lines are not added when there is no content between 2 headings when `bottom = false`',
+      before: dedent`
+        # Heading 1
+        ## Heading 2
+      `,
+      after: dedent`
+        # Heading 1
+        ## Heading 2
+      `,
+      options: {
+        bottom: false,
+        emptyLineAfterYaml: false,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/773
+      testName: 'Make sure that blank lines are not changed when there is no content between 2 headings when `bottom = false`',
+      before: dedent`
+        # Heading 1
+        ${''}
+        ${''}
+        ## Heading 2
+      `,
+      after: dedent`
+        # Heading 1
+        ${''}
+        ${''}
+        ## Heading 2
+      `,
+      options: {
+        bottom: false,
+        emptyLineAfterYaml: false,
+      },
+    },
   ],
 });

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -24,7 +24,7 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
   }
   apply(text: string, options: HeadingBlankLinesOptions): string {
     if (!options.bottom) {
-      text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
+      text = text.replace(/(#+\s.*)?\n+(#+\s.*)/g, this.handleBlankLinesBeforeAHeaderWhenNoBlankLines);
     } else {
       text = text.replace(/^(#+\s.*)/gm, '\n\n$1\n\n'); // add blank line before and after headings
       text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
@@ -39,6 +39,14 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
     }
 
     return text;
+  }
+  handleBlankLinesBeforeAHeaderWhenNoBlankLines(match: string, $1: string, $2: string): string {
+    // if there is a heading behind the current heading then we leave things alone
+    if ($1 && $1 != '') {
+      return match;
+    }
+
+    return '\n\n' + $2;
   }
   get exampleBuilders(): ExampleBuilder<HeadingBlankLinesOptions>[] {
     return [


### PR DESCRIPTION
Fixes #773 

Changes Made:
- Updated the logic to leave two headings that are back to back with any number of blank lines between them as they were
- Added tests for the scenario in question

**Do note that this means that if 2 headings have 5 blank lines between them and the option to add a blank line between headings is set to false, then those 5 blank lines will be left as is.**

Here is what will happen in the scenario mentioned above:
``` markdown
# Heading 1




# Heading 2
```

After lint:
``` markdown
# Heading 1




# Heading 2
```