### PR TITLE
`Convert Spaces to Tabs` Now Works on Blockquotes after the First Space

### DIFF
--- a/__tests__/convert-spaces-to-tabs.test.ts
+++ b/__tests__/convert-spaces-to-tabs.test.ts
@@ -20,5 +20,37 @@ ruleTest({
         \t\t- Donec ut auctor dui.
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/410
+      testName: 'Properly converts callout spaces to tabs',
+      before: dedent`
+        > [!note]
+        > - A
+        >     - B
+        > - C
+      `,
+      after: dedent`
+        > [!note]
+        > - A
+        > \t- B
+        > - C
+      `,
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/410
+      testName: 'Properly converts callout spaces to tabs with nested callouts',
+      before: dedent`
+        > Blockquote 1
+        >> [!note]
+        > > - A
+        > >     - B
+        >> - C
+      `,
+      after: dedent`
+        > Blockquote 1
+        >> [!note]
+        > > - A
+        > > \t- B
+        >> - C
+      `,
+    },
   ],
 });

--- a/src/rules/convert-spaces-to-tabs.ts
+++ b/src/rules/convert-spaces-to-tabs.ts
@@ -23,12 +23,24 @@ export default class ConvertSpacesToTabs extends RuleBuilder<ConvertSpacesToTabs
   apply(text: string, options: ConvertSpacesToTabsOptions): string {
     const tabsize = String(options.tabsize);
     const tabsize_regex = new RegExp(
-        '^(\t*) {' + String(tabsize) + '}',
+        '^(\t*) {' + tabsize + '}',
         'gm',
     );
 
-    while (text.match(tabsize_regex) != null) {
-      text = text.replace(tabsize_regex, '$1\t');
+    text = this.replaceAllRegexMatches(text, tabsize_regex);
+
+    const blockquote_regex = new RegExp(
+        '^((>( |\t*))*(>( |\t))\t*) {' + tabsize + '}',
+        'gm',
+    );
+
+    text = this.replaceAllRegexMatches(text, blockquote_regex);
+
+    return text;
+  }
+  replaceAllRegexMatches(text: string, regex: RegExp): string {
+    while (text.match(regex) != null) {
+      text = text.replace(regex, '$1\t');
     }
 
     return text;
@@ -49,6 +61,25 @@ export default class ConvertSpacesToTabs extends RuleBuilder<ConvertSpacesToTabs
           \t- text indented with 3 spaces
           - text with no indention
           \t\t- text indented with 6 spaces
+        `,
+        options: {
+          tabsize: 3,
+        },
+      }),
+      new ExampleBuilder({
+        // accounts for https://github.com/platers/obsidian-linter/issues/410
+        description: 'Converting spaces to tabs with `tabsize = 3` works in blockquotes',
+        before: dedent`
+          > - text with no indention
+          >    - text indented with 3 spaces
+          > - text with no indention
+          >       - text indented with 6 spaces
+        `,
+        after: dedent`
+          > - text with no indention
+          > \t- text indented with 3 spaces
+          > - text with no indention
+          > \t\t- text indented with 6 spaces
         `,
         options: {
           tabsize: 3,


### PR DESCRIPTION
Fixes #410 

Changes Made:
- Added UTs for a couple of scenarios
- Added an example for the scenario in question so people can see it on the wiki
- Updated the logic to make sure it could convert the specified amount of spaces to a tab after the first space after the last blockquote indicator at a start of a line