### PR TITLE
Fix Multicursor Paste Again and Enhance Paste Modification Logic by Only Enabling when A Paste Rule is Enabled

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -60,7 +60,7 @@ export class BooleanOption extends Option {
           toggle.onChange((value) => {
             this.setOption(value, settings);
             plugin.settings = settings;
-            plugin.saveData(plugin.settings);
+            plugin.saveSettings();
           });
         });
 
@@ -78,7 +78,7 @@ export class TextOption extends Option {
           textbox.onChange((value) => {
             this.setOption(value, settings);
             plugin.settings = settings;
-            plugin.saveData(plugin.settings);
+            plugin.saveSettings();
           });
         });
 
@@ -96,7 +96,7 @@ export class TextAreaOption extends Option {
           textbox.onChange((value) => {
             this.setOption(value, settings);
             plugin.settings = settings;
-            plugin.saveData(plugin.settings);
+            plugin.saveSettings();
           });
         });
 
@@ -115,7 +115,7 @@ export class MomentFormatOption extends Option {
           format.onChange((value) => {
             this.setOption(value, settings);
             plugin.settings = settings;
-            plugin.saveData(plugin.settings);
+            plugin.saveSettings();
           });
         });
 
@@ -164,7 +164,7 @@ export class DropdownOption extends Option {
           dropdown.onChange((value) => {
             this.setOption(value, settings);
             plugin.settings = settings;
-            plugin.saveData(plugin.settings);
+            plugin.saveSettings();
           });
         });
 


### PR DESCRIPTION
Relates to #480 

Changes Made:
- When I made some changes to fix an issue with pasting checklist and list values, it broke multi-cursor paste again, so that  needed a fix for adding the selected line content
- Updated the paste without modification rule to just go ahead and only show when paste overriding is active
- Paste overriding will now only be active when a paste rule is enabled
- Options now call out to the plugin method for saving settings instead of just hitting save data directly