### PR TITLE
Fix Up Heading Blank Line Logic for Avoiding Adding a Blank Line Between Headers when Bottom is False

### DIFF
--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -24,7 +24,7 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
   }
   apply(text: string, options: HeadingBlankLinesOptions): string {
     if (!options.bottom) {
-      text = text.replace(/(#+\s.*)?\n+(#+\s.*)/g, this.handleBlankLinesBeforeAHeaderWhenNoBlankLines);
+      text = text.replace(/^([^#\n]*)\n+(#+\s.*)/gm, '$1\n\n$2');
     } else {
       text = text.replace(/^(#+\s.*)/gm, '\n\n$1\n\n'); // add blank line before and after headings
       text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings
@@ -39,14 +39,6 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
     }
 
     return text;
-  }
-  handleBlankLinesBeforeAHeaderWhenNoBlankLines(match: string, $1: string, $2: string): string {
-    // if there is a heading behind the current heading then we leave things alone
-    if ($1 && $1 != '') {
-      return match;
-    }
-
-    return '\n\n' + $2;
   }
   get exampleBuilders(): ExampleBuilder<HeadingBlankLinesOptions>[] {
     return [
@@ -88,7 +80,6 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
           line
           ${''}
           ## H2
-          ${''}
           # H1
           line
         `,


### PR DESCRIPTION
Relates to #773 

Changes Made:
- Updated a UT
- Updated the regex used to make sure the previous line does not start with a heading