### PR TITLE
Update `Quote Style` Smart Quote Logic to Make it More Robust

### DIFF
--- a/__tests__/quote-style.test.ts
+++ b/__tests__/quote-style.test.ts
@@ -98,5 +98,18 @@ ruleTest({
         doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
       },
     },
+    { // relates to https://github.com/platers/obsidian-linter/issues/885
+      testName: 'Make sure that replacing quotes with smart quotes works properly in partial replace situations',
+      before: dedent`
+        He said to his friend, “How are you able to say ‘this is fun.' when we could get grounded?" But he got no response.
+      `,
+      after: dedent`
+        He said to his friend, “How are you able to say ‘this is fun.’ when we could get grounded?” But he got no response.
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+        doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+      },
+    },
   ],
 });

--- a/__tests__/quote-style.test.ts
+++ b/__tests__/quote-style.test.ts
@@ -20,5 +20,83 @@ ruleTest({
         doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/885
+      testName: 'Make sure that more nuanced scenarios are handled properly when using smart quotes for foreign languages',
+      before: dedent`
+        Het 'is' zo.
+      `,
+      after: dedent`
+        Het ‘is’ zo.
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+        doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/885
+      testName: 'Make sure if a double quote starts a file, it becomes an opening smart quote when using smart double quotes',
+      before: dedent`
+        "
+      `,
+      after: dedent`
+        “
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+        doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/885
+      testName: 'Make sure if a double quote starts a file, it becomes an opening smart quote when using smart single quotes',
+      before: dedent`
+        '
+      `,
+      after: dedent`
+        ‘
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+        doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/885
+      testName: 'Make sure if a double quote starts a file, it becomes an opening smart quote when using smart single quotes',
+      before: dedent`
+        '
+      `,
+      after: dedent`
+        ‘
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+        doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/885
+      testName: 'Make sure quotes in a sentence get handled correctly with smart quotes',
+      before: dedent`
+        He said to his friend, "How are you able to say 'this is fun' when we could get grounded?" But he got no response.
+      `,
+      after: dedent`
+        He said to his friend, “How are you able to say ‘this is fun’ when we could get grounded?” But he got no response.
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+        doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+      },
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/885
+      testName: 'Make sure that a letter before and after a single quote get interpreted as a contraction',
+      before: dedent`
+        zo'n
+      `,
+      after: dedent`
+        zo’n
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+        doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
+      },
+    },
   ],
 });

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -83,9 +83,6 @@ export default {
     // rules.ts
     'wrapper-yaml-error': 'Fehler in der YAML: {ERROR_MESSAGE}',
     'wrapper-unknown-error': 'Unbekannter Fehler: {ERROR_MESSAGE}',
-
-    // quote-style.ts
-    'uneven-amount-of-quotes': 'Die Vorkommen des Anführungszeichens `{QUOTE}` in der Datei sind nicht gerade, daher können wir gerade Anführungszeichen nicht in intelligente Anführungszeichen umwandeln',
   },
 
   'notice-text': {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -83,9 +83,6 @@ export default {
     // rules.ts
     'wrapper-yaml-error': 'error in the YAML: {ERROR_MESSAGE}',
     'wrapper-unknown-error': 'unknown error: {ERROR_MESSAGE}',
-
-    // quote-style.ts
-    'uneven-amount-of-quotes': 'The instances of the `{QUOTE}` quote in the file is not even, so we cannot convert straight quotes to smart quotes',
   },
 
   'notice-text': {

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -67,7 +67,6 @@ export default {
     'too-many-footnotes-error-message': `La clave de nota al pie '{FOOTNOTE_KEY}' tiene más de 1 nota al pie que hace referencia a ella. Actualice las notas al pie para que solo haya una nota al pie por clave de nota al pie.`,
     'wrapper-yaml-error': 'hubo un error en el YAML: {ERROR_MESSAGE}',
     'wrapper-unknown-error': 'huno un error desconocido: {ERROR_MESSAGE}',
-    'uneven-amount-of-quotes': 'Las instancias de la cita `{QUOTE}` en el archivo no son pares, por lo que no podemos convertir las comillas rectas en comillas tipográficas.',
   },
   'notice-text': {
     'empty-clipboard': 'No hay contenido del portapapeles.',

--- a/src/lang/locale/tr.ts
+++ b/src/lang/locale/tr.ts
@@ -83,9 +83,6 @@ export default {
     // rules.ts
     'wrapper-yaml-error': 'YAML\'da hata: {ERROR_MESSAGE}',
     'wrapper-unknown-error': 'bilinmeyen hata: {ERROR_MESSAGE}',
-
-    // quote-style.ts
-    'uneven-amount-of-quotes': 'Dosyadaki `{QUOTE}` alıntısının sayısı çift değil, bu yüzden düz alıntıları akıllı alıntılara dönüştüremeyiz',
   },
 
   'notice-text': {

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -83,9 +83,6 @@ export default {
     // rules.ts
     'wrapper-yaml-error': 'yaml出现错误: {ERROR_MESSAGE}',
     'wrapper-unknown-error': '未知错误: {ERROR_MESSAGE}',
-
-    // quote-style.ts
-    'uneven-amount-of-quotes': '`{QUOTE}` 引号在文件中的数量不是偶数，所以我们无法将直引号转换为弯引号',
   },
 
   'notice-text': {

--- a/src/rules/quote-style.ts
+++ b/src/rules/quote-style.ts
@@ -82,7 +82,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
       nextCharIsALetter = unicodeLetterRegex.test(nextChar);
       isContraction = previousCharIsALetter && nextCharIsALetter;
       if (isContraction && isForSingleQuotes) {
-        quoteReplacement = openingSmartQuote;
+        quoteReplacement = closingSmartQuote;
       } else if (previousCharIsALetter && (isForSingleQuotes || !nextCharIsALetter)) {
         quoteReplacement = closingSmartQuote;
         previousQuote = quoteReplacement;

--- a/src/rules/quote-style.ts
+++ b/src/rules/quote-style.ts
@@ -2,9 +2,8 @@ import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {smartDoubleQuoteRegex, smartSingleQuoteRegex} from '../utils/regex';
-import {countInstances} from '../utils/strings';
-import {getTextInLanguage} from '../lang/helpers';
+import {smartDoubleQuoteRegex, smartSingleQuoteRegex, unicodeLetterRegex} from '../utils/regex';
+import {replaceTextBetweenStartAndEndWithNewValue} from '../utils/strings';
 
 export enum SingleQuoteStyles {
   Straight = '\'\'',
@@ -15,187 +14,6 @@ export enum DoubleQuoteStyles {
   Straight = '""',
   SmartQuote = '“”',
 }
-
-// from https://en.wikipedia.org/wiki/Wikipedia:List_of_English_contractions with any contractions
-// missing a single quote removed
-const englishContractions = [
-  'a\'ight',
-  'ain\'t',
-  'amn\'t',
-  '\'n\'',
-  'aren\'t',
-  '\'bout',
-  'boy\'s',
-  'can\'t',
-  'cap\'n',
-  '\'cause',
-  '\'cept',
-  'could\'ve',
-  'couldn\'t',
-  'couldn\'t\'ve',
-  'daren\'t',
-  'daresn\'t',
-  'dasn\'t',
-  'didn\'t',
-  'doesn\'t',
-  'don\'t',
-  'd\'ye',
-  'd\'ya',
-  'e\'en',
-  'e\'er',
-  '\'em',
-  'everybody\'s',
-  'everyone\'s',
-  'everything\'s',
-  'fo\'c\'sle',
-  '\'gainst',
-  'g\'day',
-  'girl\'s',
-  'giv\'n',
-  'gi\'z',
-  'gon\'t',
-  'guy\'s',
-  'hadn\'t',
-  'had\'ve',
-  'hasn\'t',
-  'haven\'t',
-  'he\'d',
-  'he\'ll',
-  'he\'s',
-  'here\'s',
-  'how\'d',
-  'how\'ll',
-  'how\'re',
-  'how\'s',
-  'I\'d',
-  'I\'d\'ve',
-  'I\'d\'nt',
-  'I\'d\'nt\'ve',
-  'If\'n',
-  'I\'ll',
-  'I\'m',
-  'I\'m\'o',
-  'I\'ve',
-  'isn\'t',
-  'it\'d',
-  'it\'ll',
-  'it\'s',
-  'let\'s',
-  'loven\'t',
-  'ma\'am',
-  'mayn\'t',
-  'may\'ve',
-  'mightn\'t',
-  'might\'ve',
-  'mine\'s',
-  'mustn\'t',
-  'mustn\'t\'ve',
-  'must\'ve',
-  '\'neath',
-  'needn\'t',
-  'ne\'er',
-  'o\'clock',
-  'o\'er',
-  'ol\'',
-  'ought\'ve',
-  'oughtn\'t',
-  'oughtn\'t\'ve',
-  '\'round',
-  'shalln\'t',
-  'shan\'',
-  'shan\'t',
-  'she\'d',
-  'she\'ll',
-  'she\'s',
-  'should\'ve',
-  'shouldn\'t',
-  'shouldn\'t\'ve',
-  'somebody\'s',
-  'someone\'s',
-  'something\'s',
-  'so\'re',
-  'so\'s',
-  'so\'ve',
-  'that\'ll',
-  'that\'re',
-  'that\'s',
-  'that\'d',
-  'there\'d',
-  'there\'ll',
-  'there\'re',
-  'there\'s',
-  'these\'re',
-  'these\'ve',
-  'they\'d',
-  'they\'d\'ve',
-  'they\'ll',
-  'they\'re',
-  'they\'ve',
-  'this\'s',
-  'those\'re',
-  'those\'ve',
-  '\'thout',
-  '\'til',
-  '\'tis',
-  'to\'ve',
-  '\'twas',
-  '\'tween',
-  '\'twere',
-  'w\'all',
-  'w\'at',
-  'wasn\'t',
-  'we\'d',
-  'we\'d\'ve',
-  'we\'ll',
-  'we\'re',
-  'we\'ve',
-  'weren\'t',
-  'what\'d',
-  'what\'ll',
-  'what\'re',
-  'what\'s',
-  'what\'ve',
-  'when\'s',
-  'where\'d',
-  'where\'ll',
-  'where\'re',
-  'where\'s',
-  'where\'ve',
-  'which\'d',
-  'which\'ll',
-  'which\'re',
-  'which\'s',
-  'which\'ve',
-  'who\'d',
-  'who\'d\'ve',
-  'who\'ll',
-  'who\'re',
-  'who\'s',
-  'who\'ve',
-  'why\'d',
-  'why\'re',
-  'why\'s',
-  'willn\'t',
-  'won\'t',
-  'would\'ve',
-  'wouldn\'t',
-  'wouldn\'t\'ve',
-  'y\'ain\'t',
-  'y\'all',
-  'y\'all\'d\'ve',
-  'y\'all\'d\'n\'t\'ve',
-  'y\'all\'re',
-  'y\'all\'ren\'t',
-  'y\'at',
-  'yes\'m',
-  'y\'know',
-  'you\'d',
-  'you\'ll',
-  'you\'re',
-  'you\'ve',
-  'when\'d',
-  'willn\'t',
-];
 
 class QuoteStyleOptions implements Options {
   singleQuoteStyleEnabled?: boolean = true;
@@ -223,7 +41,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
       if (options.doubleQuoteStyle === DoubleQuoteStyles.Straight) {
         newText = this.convertSmartDoubleQuotesToStraightQuotes(newText);
       } else {
-        newText = this.convertStraightDoubleQuotesToDoubleSmartQuotes(newText);
+        newText = this.convertStraightQuoteToSmartQuote(newText, '"', DoubleQuoteStyles.SmartQuote[0], DoubleQuoteStyles.SmartQuote[1], false);
       }
     }
 
@@ -231,7 +49,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
       if (options.singleQuoteStyle === SingleQuoteStyles.Straight) {
         newText = this.convertSmartSingleQuotesToStraightQuotes(newText);
       } else {
-        newText = this.convertStraightSingleQuotesToSingleSmartQuotes(newText);
+        newText = this.convertStraightQuoteToSmartQuote(newText, '\'', SingleQuoteStyles.SmartQuote[0], SingleQuoteStyles.SmartQuote[1], true);
       }
     }
 
@@ -243,77 +61,53 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
   convertSmartDoubleQuotesToStraightQuotes(text: string): string {
     return text.replace(smartDoubleQuoteRegex, '"');
   }
-  // based on https://inkplant.com/tools/smart-quotes-converter
-  convertStraightDoubleQuotesToDoubleSmartQuotes(text: string): string {
-    this.throwErrorIfNotEqualNumberOfQuotes(text, '"');
-    const openingDoubleQuote = DoubleQuoteStyles.SmartQuote[0];
-    const endingDoubleQuote = DoubleQuoteStyles.SmartQuote[1];
+  convertStraightQuoteToSmartQuote(text: string, straightQuote: string, openingSmartQuote: string, closingSmartQuote: string, isForSingleQuotes: boolean): string {
+    const indices = this.locations(straightQuote, text);
+    if (indices.length === 0) {
+      return text;
+    }
 
-    let numReplacementsMade = 0;
-    text = text.replaceAll('"', () => {
-      let doubleQuote = openingDoubleQuote;
-      if (numReplacementsMade % 2 === 1) {
-        doubleQuote = endingDoubleQuote;
+    const endOfText = text.length - 1;
+    let quoteReplacement: string;
+    let previousChar = '';
+    let nextChar = '';
+    let previousCharIsALetter = false;
+    let nextCharIsALetter = false;
+    let isContraction = false;
+    let previousQuote = '';
+    for (const index of indices) {
+      previousChar = index == 0 ? '' : text.charAt(index - 1);
+      nextChar = index === endOfText ? '' : text.charAt(index + 1);
+      previousCharIsALetter = unicodeLetterRegex.test(previousChar);
+      nextCharIsALetter = unicodeLetterRegex.test(nextChar);
+      isContraction = previousCharIsALetter && nextCharIsALetter;
+      if (isContraction && isForSingleQuotes) {
+        quoteReplacement = openingSmartQuote;
+      } else if (previousCharIsALetter && (isForSingleQuotes || !nextCharIsALetter)) {
+        quoteReplacement = closingSmartQuote;
+        previousQuote = quoteReplacement;
+      } else if (nextCharIsALetter && (isForSingleQuotes || !previousCharIsALetter)) {
+        quoteReplacement = openingSmartQuote;
+        previousQuote = quoteReplacement;
+      } else { // this case is meant for languages that do not have a concept of letters like Japanese or Chinese or in the case that we have a scenario where no letters surround the quote (generally this will be punctuation followed by a quote)
+        if (previousQuote === '' || previousQuote === closingSmartQuote) {
+          quoteReplacement = openingSmartQuote;
+        } else {
+          quoteReplacement = closingSmartQuote;
+        }
+
+        previousQuote = quoteReplacement;
       }
 
-      numReplacementsMade++;
-
-      return doubleQuote;
-    });
-
-    return text;
-  }
-  // based on https://inkplant.com/tools/smart-quotes-converter
-  convertStraightSingleQuotesToSingleSmartQuotes(text: string): string {
-    const openingSingleQuote = SingleQuoteStyles.SmartQuote[0];
-    const endingSingleQuote = SingleQuoteStyles.SmartQuote[1];
-
-    text = this.convertContractionStraightQuotesToSmartQuotes(text, openingSingleQuote, endingSingleQuote);
-
-    text = this.convertPossessiveStraightQuotesToSmartQuotes(text, endingSingleQuote);
-
-    this.throwErrorIfNotEqualNumberOfQuotes(text, '\'');
-
-    let numReplacementsMade = 0;
-    text = text.replaceAll('\'', () => {
-      let singleQuote = openingSingleQuote;
-      if (numReplacementsMade % 2 === 1) {
-        singleQuote = endingSingleQuote;
-      }
-
-      numReplacementsMade++;
-
-      return singleQuote;
-    });
-
-    return text;
-  }
-  convertContractionStraightQuotesToSmartQuotes(text: string, openingSmartQuote: string, closingSmartQuote: string): string {
-    const replaceMatchQuotes = function(match: string) {
-      if (match[0] === '\'') {
-        match = openingSmartQuote + match.substring(1);
-      }
-
-      return match.replaceAll('\'', closingSmartQuote);
-    };
-
-    for (const contraction of englishContractions) {
-      text = text.replace(new RegExp(contraction, 'gi'), replaceMatchQuotes);
+      text = replaceTextBetweenStartAndEndWithNewValue(text, index, index + 1, quoteReplacement);
     }
 
     return text;
   }
-  convertPossessiveStraightQuotesToSmartQuotes(text: string, smartQuote: string): string {
-    return text.replace(/([a-zA-Z0-9]'s|s')/g, (match: string) => {
-      return match.replace('\'', smartQuote);
-    });
-  }
-  throwErrorIfNotEqualNumberOfQuotes(text: string, quote: string) {
-    const numInstances = countInstances(text, quote);
-
-    if (numInstances % 2 !== 0) {
-      throw new Error(getTextInLanguage('logs.uneven-amount-of-quotes').replace('{QUOTE}', quote));
-    }
+  locations(substring: string, text: string): number[] {
+    const a=[]; let i=-1;
+    while ((i=text.indexOf(substring, i+1)) >= 0) a.push(i);
+    return a;
   }
   get exampleBuilders(): ExampleBuilder<QuoteStyleOptions>[] {
     return [

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -46,6 +46,8 @@ export const nonBlockquoteChecklistRegex = new RegExp(`^\\s*- ${checklistBoxIndi
 export const footnoteDefinitionIndicatorAtStartOfLine = /^(\[\^\w+\]) ?([,.;!:?])/gm;
 export const calloutRegex = /^(>\s*)+\[![^\s]*\]/m;
 
+export const unicodeLetterRegex = RegExp(/\p{L}/, 'u');
+
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string
 // could have user constructed dollar signs in it

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -366,3 +366,13 @@ export function isNumeric(str: string) {
   return !isNaN(str as unknown as number) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
          !isNaN(parseFloat(str)); // ...and ensure strings of whitespace fail
 }
+
+export function getSubstringIndex(substring: string, text: string): number[] {
+  const indexes = [];
+  let i = -1;
+  while ((i = text.indexOf(substring, i + 1)) >= 0) {
+    indexes.push(i);
+  }
+
+  return indexes;
+}


### PR DESCRIPTION
Fixes #885 

Changes Made:
- Added several new UTs
- Removed list of contractions
- Swapped to logic where we consider a contraction a single quote between two unicode letters
- Swapped logic to make it so that it will swap to an opening smart quote when followed by non-whitespace and proceeded by whitespace
- Swapped logic to make it so that it will swap to a closing smart quote when proceeded by non-whitespace and followed by whitespace
- If that fails, it will rely on the last quote it inserted that is not a contraction to determine whether to do an opening or closing quote.