### PR TITLE
Update Multiline Empty Array Value

### DIFF
--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -799,8 +799,7 @@ ruleTest({
       `,
       after: dedent`
         ---
-        key:
-          - 
+        key: []
         ---
       `,
       options: {
@@ -840,7 +839,7 @@ ruleTest({
       },
     },
     {
-      testName: 'Trying to format tags to a multi-line when it is has an empty single-line will result in an empty multi-line',
+      testName: 'Trying to format tags to a multi-line when it is has an empty single-line will leave it as is',
       before: dedent`
         ---
         tags: []
@@ -848,8 +847,7 @@ ruleTest({
       `,
       after: dedent`
         ---
-        tags:
-          - 
+        tags: []
         ---
       `,
       options: {
@@ -939,14 +937,12 @@ ruleTest({
       testName: 'An empty multi-line array does not get modified when linted and it is supposed to be a multi-line array',
       before: dedent`
         ---
-        speakers:
-          - 
+        speakers: []
         ---
       `,
       after: dedent`
         ---
-        speakers:
-          - 
+        speakers: []
         ---
       `,
       options: {

--- a/__tests__/heading-blank-lines.test.ts
+++ b/__tests__/heading-blank-lines.test.ts
@@ -161,5 +161,24 @@ ruleTest({
         emptyLineAfterYaml: false,
       },
     },
+    { // relates to https://github.com/platers/obsidian-linter/issues/773
+      testName: 'Make sure that blank lines are not added when there is already a blank line between headings `bottom = false`',
+      before: dedent`
+        ## foobar
+        ### Hello World
+        ${''}
+        ### Hello two
+      `,
+      after: dedent`
+        ## foobar
+        ### Hello World
+        ${''}
+        ### Hello two
+      `,
+      options: {
+        bottom: false,
+        emptyLineAfterYaml: false,
+      },
+    },
   ],
 });

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -24,7 +24,7 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
   }
   apply(text: string, options: HeadingBlankLinesOptions): string {
     if (!options.bottom) {
-      text = text.replace(/^([^#\n]*)\n+(#+\s.*)/gm, '$1\n\n$2');
+      text = text.replace(/^([^#\n]+)\n+(#+\s.*)/gm, '$1\n\n$2');
     } else {
       text = text.replace(/^(#+\s.*)/gm, '\n\n$1\n\n'); // add blank line before and after headings
       text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -159,7 +159,7 @@ export function formatYamlArrayValue(value: string | string[], format: NormalArr
         return ' ' + value[0];
       }
     case NormalArrayFormats.MultiLine:
-      return '\n  - ' + value.join('\n  - ');
+      return convertStringArrayToMultilineArray(value);
     case TagSpecificArrayFormats.SingleStringSpaceDelimited:
       if (value.length === 1) {
         return ' ' + value[0];
@@ -187,9 +187,8 @@ function getDefaultYAMLArrayValue(format: NormalArrayFormats | SpecialArrayForma
   switch (format) {
     case NormalArrayFormats.SingleLine:
     case TagSpecificArrayFormats.SingleLineSpaceDelimited:
-      return ' []';
     case NormalArrayFormats.MultiLine:
-      return '\n  - ';
+      return ' []';
     case SpecialArrayFormats.SingleStringToSingleLine:
     case SpecialArrayFormats.SingleStringToMultiLine:
     case TagSpecificArrayFormats.SingleStringSpaceDelimited:
@@ -205,6 +204,14 @@ function convertStringArrayToSingleLineArray(arrayItems: string[]): string {
   }
 
   return '[' + arrayItems.join(', ') + ']';
+}
+
+function convertStringArrayToMultilineArray(arrayItems: string[]): string {
+  if (arrayItems == null || arrayItems.length === 0) {
+    return '[]';
+  }
+
+  return '\n  - ' + arrayItems.join('\n  - ');
 }
 
 /**


### PR DESCRIPTION
Fixes #876 

Changes Made:
- Updated UTs
- Swapped the default value from `\n   -` to `[]` for an empty multi-line array
- Adds remaining fix for heading blank lines (this just caught up in the changes)
