### PR TITLE
Fix `Capitalize Headings` Affecting Inline Code in Headers

### DIFF
--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -182,5 +182,17 @@ ruleTest({
         ignoreCasedWords: true,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/921
+      testName: `Make sure that a header with inline code is properly ignored for capitalization`,
+      before: dedent`
+        ## \`= durationformat(date(this.day) - date(2023-10-06),"dd")\` th days passed since the Black Shabbat
+      `,
+      after: dedent`
+        ## \`= durationformat(date(this.day) - date(2023-10-06),"dd")\` TH DAYS PASSED SINCE THE BLACK SHABBAT
+      `,
+      options: {
+        style: 'ALL CAPS',
+      },
+    },
   ],
 });

--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -26,7 +26,6 @@ import uk from './locale/uk';
 import zhCN from './locale/zh-cn';
 import zhTW from './locale/zh-tw';
 
-
 type LanguageStrings = typeof en;
 
 export const localeMap: { [k: string]: Partial<LanguageStrings> } = {

--- a/src/rules/capitalize-headings.ts
+++ b/src/rules/capitalize-headings.ts
@@ -404,7 +404,7 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
       descriptionKey: 'rules.capitalize-headings.description',
       type: RuleType.HEADING,
       hasSpecialExecutionOrder: true, // this is meant to run at the end after all headers have been updated, added, or removed from the file
-      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => CapitalizeHeadingsOptions {


### PR DESCRIPTION
Fixes #921 

Changes Made:
- Added a UT for the scenario in question
- Removed a blank line
- Included inline code in the list of values to ignore for capitalize headings