### PR TITLE
Make Sure `Quote Styles` Does Not Affect Markdown or Wiki Links

### DIFF
--- a/__tests__/quote-style.test.ts
+++ b/__tests__/quote-style.test.ts
@@ -111,7 +111,7 @@ ruleTest({
         doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
       },
     },
-    {  // accounts for https://github.com/platers/obsidian-linter/issues/929
+    { // accounts for https://github.com/platers/obsidian-linter/issues/929
       testName: 'Make sure quotes in markdown links get ignored',
       before: dedent`
         [link](https://test.it 'Test title')

--- a/__tests__/quote-style.test.ts
+++ b/__tests__/quote-style.test.ts
@@ -111,7 +111,7 @@ ruleTest({
         doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
       },
     },
-    {
+    {  // accounts for https://github.com/platers/obsidian-linter/issues/929
       testName: 'Make sure quotes in markdown links get ignored',
       before: dedent`
         [link](https://test.it 'Test title')

--- a/__tests__/quote-style.test.ts
+++ b/__tests__/quote-style.test.ts
@@ -111,5 +111,17 @@ ruleTest({
         doubleQuoteStyle: DoubleQuoteStyles.SmartQuote,
       },
     },
+    {
+      testName: 'Make sure quotes in markdown links get ignored',
+      before: dedent`
+        [link](https://test.it 'Test title')
+      `,
+      after: dedent`
+        [link](https://test.it 'Test title')
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+      },
+    },
   ],
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ const langToMomentLocale = {
 };
 
 
-const userClickTimeout = 0;   
+const userClickTimeout = 0;
 
 export default class LinterPlugin extends Plugin {
   settings: LinterSettings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,8 @@ const langToMomentLocale = {
   'ja': 'ja',
 };
 
-const userClickTimeout = 0;
+
+const userClickTimeout = 0;   
 
 export default class LinterPlugin extends Plugin {
   settings: LinterSettings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,6 @@ const langToMomentLocale = {
   'ja': 'ja',
 };
 
-
 const userClickTimeout = 0;
 
 export default class LinterPlugin extends Plugin {

--- a/src/rules/quote-style.ts
+++ b/src/rules/quote-style.ts
@@ -29,7 +29,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
       nameKey: 'rules.quote-style.name',
       descriptionKey: 'rules.quote-style.description',
       type: RuleType.CONTENT,
-      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html, IgnoreTypes.templaterCommand],
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.templaterCommand],
     });
   }
   get OptionsClass(): new () => QuoteStyleOptions {


### PR DESCRIPTION
Fixes #929 

Changes Made:
- Ignored markdown and wiki links for `Quote Styles`
- Added a test for the scenario in question