### PR TITLE
`Blockquote Style`: Handle `>` in Blockquotes So They Are Not Affected

### DIFF
--- a/__tests__/blockquote-style.test.ts
+++ b/__tests__/blockquote-style.test.ts
@@ -1,0 +1,33 @@
+import BlockquoteStyle from '../src/rules/blockquote-style';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: BlockquoteStyle,
+  testCases: [
+    { // accounts for https://github.com/platers/obsidian-linter/issues/935
+      testName: 'Make sure we properly handle adding spaces to blockquote indicators instead of adding them to values that are not at the start of the line',
+      before: dedent`
+        > Using a C++ "member of pointer" operator: \`pointer->field\`
+        >\`>\`
+      `,
+      after: dedent`
+        > Using a C++ "member of pointer" operator: \`pointer->field\`
+        > \`>\`
+      `,
+      options: {style: 'space'},
+    },
+    // { // accounts for https://github.com/platers/obsidian-linter/issues/935
+    //   testName: 'Make sure we properly handle removing spaces from blockquote indicators instead of removing them from values that are not at the start of the line',
+    //   before: dedent`
+    //     > Using a C++ "member of pointer" operator: \`pointer-> field\`
+    //     > \`> \`
+    //   `,
+    //   after: dedent`
+    //     >Using a C++ "member of pointer" operator: \`pointer-> field\`
+    //     >\`> \`
+    //   `,
+    //   options: {style: 'no space'},
+    // },
+  ],
+});

--- a/__tests__/blockquote-style.test.ts
+++ b/__tests__/blockquote-style.test.ts
@@ -17,17 +17,17 @@ ruleTest({
       `,
       options: {style: 'space'},
     },
-    // { // accounts for https://github.com/platers/obsidian-linter/issues/935
-    //   testName: 'Make sure we properly handle removing spaces from blockquote indicators instead of removing them from values that are not at the start of the line',
-    //   before: dedent`
-    //     > Using a C++ "member of pointer" operator: \`pointer-> field\`
-    //     > \`> \`
-    //   `,
-    //   after: dedent`
-    //     >Using a C++ "member of pointer" operator: \`pointer-> field\`
-    //     >\`> \`
-    //   `,
-    //   options: {style: 'no space'},
-    // },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/935
+      testName: 'Make sure we properly handle removing spaces from blockquote indicators instead of removing them from values that are not at the start of the line',
+      before: dedent`
+        > Using a C++ "member of pointer" operator: \`pointer-> field\`
+        > \`> \`
+      `,
+      after: dedent`
+        >Using a C++ "member of pointer" operator: \`pointer-> field\`
+        >\`> \`
+      `,
+      options: {style: 'no space'},
+    },
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-linter",
-  "version": "1.12.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
-      "version": "1.12.0",
+      "version": "1.20.1",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
@@ -24,7 +24,8 @@
         "micromark-util-combine-extensions": "^1.0.0",
         "moment-parseformat": "^4.0.0",
         "quick-lru": "^6.1.1",
-        "ts-dedent": "^2.2.0"
+        "ts-dedent": "^2.2.0",
+        "unist-util-visit": "^4.1.2"
       },
       "devDependencies": {
         "@babel/core": "^7.20.2",
@@ -32,6 +33,7 @@
         "@babel/plugin-proposal-private-methods": "^7.18.6",
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
+        "@jest/types": "^29.5.0",
         "@types/diff": "^5.0.2",
         "@types/diff-match-patch": "^1.0.32",
         "@types/jest": "^29.2.3",

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -42,7 +42,7 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
   addSpaceToIndicator(startOfLine: string): string {
     // first we add spaces to blockquote indicators that are not followed by a space and then to catch any that were not handled already
     // we make sure to add a space between any 2 indicators that are side by side
-    return startOfLine.replace(/>([^ \t])/g, '> $1').replace(/>>/g, '> >');
+    return startOfLine.replace(/>([^ \t]|$)/g, '> $1').replace(/>>/g, '> >');
   }
   updateBlockquoteLines(blockquote: string, startOfLineModification: (startOfLine: string) => string): string {
     let currentIndex = 0;
@@ -62,11 +62,12 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
       [startOfLine, startOfIndex] = getStartOfLineWhitespaceOrBlockquoteLevel(newBlockquote, nextNewLine-1);
       updatedStartOfLine = startOfLineModification(startOfLine);
 
+      // since start of index refers to where the new line character is
+      startOfIndex++;
+
       newBlockquote = replaceTextBetweenStartAndEndWithNewValue(newBlockquote, startOfIndex, startOfIndex + startOfLine.length, updatedStartOfLine);
 
-      // nextNewLine = newBlockquote.indexOf('\n', currentIndex);
-      // TODO: determine what the actual new location of the new line is
-      currentIndex = nextNewLine+ 2 + startOfLine.length - updatedStartOfLine.length;
+      currentIndex = nextNewLine+ 1 + startOfLine.length - updatedStartOfLine.length;
     } while (!breakOutOfLoop);
 
     return newBlockquote;

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -31,7 +31,7 @@ export function stripCr(text: string): string {
   return text.replace(/\r/g, '');
 }
 
-function getStartOfLineWhitespaceOrBlockquoteLevel(text: string, startPosition: number): [string, number] {
+export function getStartOfLineWhitespaceOrBlockquoteLevel(text: string, startPosition: number): [string, number] {
   if (startPosition === 0) {
     return ['', 0];
   }
@@ -60,7 +60,7 @@ function getEmptyLine(priorLine: string = ''): string {
   return '\n' + priorLineStart.trim();
 }
 
-function getEmptyLineForBlockqute(priorLine: string = '', isCallout: boolean = false, blockquoteLevel: number = 1): string {
+function getEmptyLineForBlockquote(priorLine: string = '', isCallout: boolean = false, blockquoteLevel: number = 1): string {
   const potentialEmptyLine = getEmptyLine(priorLine);
   const previousBlockquoteLevel = countInstances(potentialEmptyLine, '>');
   const dealingWithACallout = isCallout || calloutRegex.test(priorLine);
@@ -151,7 +151,7 @@ function makeSureContentHasASingleEmptyLineBeforeItUnlessItStartsAFileForBlockqu
     priorLine = text.substring(indexOfLastNewLine, startOfNewContent);
   }
 
-  const emptyLine = addingEmptyLinesAroundBlockquotes ? getEmptyLineForBlockqute(priorLine, isCallout, nestingLevel) : getEmptyLine(priorLine);
+  const emptyLine = addingEmptyLinesAroundBlockquotes ? getEmptyLineForBlockquote(priorLine, isCallout, nestingLevel) : getEmptyLine(priorLine);
 
   return text.substring(0, startOfNewContent) + emptyLine + text.substring(startOfContent);
 }
@@ -247,7 +247,7 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote
     nextLine = text.substring(endOfNewContent + 1, indexOfSecondNewLineAfterContent);
   }
 
-  const emptyLine = addingEmptyLinesAroundBlockquotes ? getEmptyLineForBlockqute(nextLine, isCallout, nestingLevel) : getEmptyLine(nextLine);
+  const emptyLine = addingEmptyLinesAroundBlockquotes ? getEmptyLineForBlockquote(nextLine, isCallout, nestingLevel) : getEmptyLine(nextLine);
 
   return text.substring(0, endOfContent) + emptyLine + text.substring(endOfNewContent);
 }


### PR DESCRIPTION
Fixes #935 

Changes Made:
- Added UTs for the 2 scenarios provided
- Updated the blockquote style logic to make sure that the `>` values are styled properly are only affected if they are a part of the blockquote indicators and not a part of the content in the the blockquote
- Fixed a typo in a function name
- Exported a function for getting the start of a blockquote that was previously not exported