### PR TITLE
Add Ability to Run Custom Commands on Folder and Vault Lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,25 @@
 {
   "name": "obsidian-linter",
+<<<<<<< HEAD
   "version": "1.20.1",
+=======
+  "version": "1.19.0",
+>>>>>>> 0fbb87b (added the async lock and made sure to add the logic for running custom commands for multiple file lint runs)
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
+<<<<<<< HEAD
       "version": "1.20.1",
+=======
+      "version": "1.19.0",
+>>>>>>> 0fbb87b (added the async lock and made sure to add the logic for running custom commands for multiple file lint runs)
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
         "@types/js-yaml": "^4.0.5",
+        "async-lock": "^1.4.0",
         "diff-match-patch": "^1.0.5",
         "js-yaml": "^4.1.0",
         "loglevel": "^1.8.1",
@@ -3733,6 +3742,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
     },
     "node_modules/babel-jest": {
       "version": "29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,12 @@
 {
   "name": "obsidian-linter",
-<<<<<<< HEAD
-<<<<<<< HEAD
   "version": "1.20.1",
-=======
-  "version": "1.19.0",
->>>>>>> 0fbb87b (added the async lock and made sure to add the logic for running custom commands for multiple file lint runs)
-=======
-  "version": "1.20.1",
->>>>>>> 15992f2 (added types for async lock)
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "1.20.1",
-=======
-      "version": "1.19.0",
->>>>>>> 0fbb87b (added the async lock and made sure to add the logic for running custom commands for multiple file lint runs)
-=======
-      "version": "1.20.1",
->>>>>>> 15992f2 (added types for async lock)
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,28 @@
 {
   "name": "obsidian-linter",
 <<<<<<< HEAD
+<<<<<<< HEAD
   "version": "1.20.1",
 =======
   "version": "1.19.0",
 >>>>>>> 0fbb87b (added the async lock and made sure to add the logic for running custom commands for multiple file lint runs)
+=======
+  "version": "1.20.1",
+>>>>>>> 15992f2 (added types for async lock)
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
 <<<<<<< HEAD
+<<<<<<< HEAD
       "version": "1.20.1",
 =======
       "version": "1.19.0",
 >>>>>>> 0fbb87b (added the async lock and made sure to add the logic for running custom commands for multiple file lint runs)
+=======
+      "version": "1.20.1",
+>>>>>>> 15992f2 (added types for async lock)
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
@@ -43,6 +51,7 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-typescript": "^7.18.6",
         "@jest/types": "^29.5.0",
+        "@types/async-lock": "^1.4.2",
         "@types/diff": "^5.0.2",
         "@types/diff-match-patch": "^1.0.32",
         "@types/jest": "^29.2.3",
@@ -3132,6 +3141,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@types/async-lock": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
       "dev": true
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
     "@jest/types": "^29.5.0",
+    "@types/async-lock": "^1.4.2",
     "@types/diff": "^5.0.2",
     "@types/diff-match-patch": "^1.0.32",
     "@types/jest": "^29.2.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/plugin-proposal-private-methods": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.18.6",
+    "@jest/types": "^29.5.0",
     "@types/diff": "^5.0.2",
     "@types/diff-match-patch": "^1.0.32",
     "@types/jest": "^29.2.3",
@@ -45,12 +46,12 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
     "typescript": "^5.0.4",
-    "unified-lint-rule": "^2.1.1",
-    "@jest/types": "^29.5.0"
+    "unified-lint-rule": "^2.1.1"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
     "@types/js-yaml": "^4.0.5",
+    "async-lock": "^1.4.0",
     "diff-match-patch": "^1.0.5",
     "js-yaml": "^4.1.0",
     "loglevel": "^1.8.1",

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -102,6 +102,7 @@ export default {
   // lint-confirmation-modal.ts
   'warning-text': 'Warning',
   'file-backup-text': 'Make sure you have backed up your files.',
+  'custom-command-warning': 'Linting multiple files with custom commands enabled is a slow process that requires the ability to open panes in the side panel. It is noticeably slower than running without custom commands enabled. Please proceed with caution.',
 
   'copy-aria-label': 'Copy',
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon, htmlToMarkdown, EditorSelection, EditorChange} from 'obsidian';
+import {App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon, htmlToMarkdown, EditorSelection, EditorChange, WorkspaceLeaf} from 'obsidian';
 import {Options, RuleType, ruleTypeToRules, rules} from './rules';
 import DiffMatchPatch from 'diff-match-patch';
 import dedent from 'ts-dedent';
@@ -15,6 +15,7 @@ import {urlRegex} from './utils/regex';
 import {getTextInLanguage, LanguageStringKey, setLanguage} from './lang/helpers';
 import {RuleAliasSuggest} from './cm6/rule-alias-suggester';
 import {DEFAULT_SETTINGS, LinterSettings} from './settings-data';
+import AsyncLock from 'async-lock';
 
 // https://github.com/liamcain/obsidian-calendar-ui/blob/03ceecbf6d88ef260dadf223ee5e483d98d24ffc/src/localization.ts#L20-L43
 const langToMomentLocale = {
@@ -53,6 +54,7 @@ export default class LinterPlugin extends Plugin {
   private rulesRunner = new RulesRunner();
   private lastActiveFile: TFile;
   private overridePaste: boolean = false;
+  private customCommandsLock = new AsyncLock();
 
   async onload() {
     setLanguage(window.localStorage.getItem('language'));
@@ -322,8 +324,18 @@ export default class LinterPlugin extends Plugin {
       }
     }
 
-    // Make sure this is disabled until we actually add something to let it work on folder and vault linting
-    // this.rulesRunner.runCustomCommands(this.settings.lintCommands, this.app.commands);
+    let sidebarTab: WorkspaceLeaf = null;
+    if (this.settings.lintCommands && this.settings.lintCommands.length !== 0) {
+      if (!sidebarTab) {
+        sidebarTab = this.app.workspace.getRightLeaf(false);
+      }
+
+      await this.customCommandsLock.acquire('command', async () => {
+        await sidebarTab.openFile(file);
+        this.rulesRunner.runCustomCommands(this.settings.lintCommands, this.app.commands);
+      });
+      sidebarTab.detach();
+    }
   }
 
   async runLinterAllFiles(app: App) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,7 @@ export default class LinterPlugin extends Plugin {
         const submitBtnNoticeText = getTextInLanguage('commands.lint-all-files.submit-button-notice-text');
         new LintConfirmationModal(this.app, startMessage, submitBtnText, submitBtnNoticeText, () => {
           return this.runLinterAllFiles(this.app);
-        }).open();
+        }, this.settings.lintCommands && this.settings.lintCommands.length > 0).open();
       },
     });
 
@@ -394,7 +394,7 @@ export default class LinterPlugin extends Plugin {
     const startMessage = getTextInLanguage('commands.lint-all-files-in-folder.start-message').replace('{FOLDER_NAME}', folder.name);
     const submitBtnText = getTextInLanguage('commands.lint-all-files-in-folder.submit-button-text').replace('{FOLDER_NAME}', folder.name);
     const submitBtnNoticeText = getTextInLanguage('commands.lint-all-files-in-folder.submit-button-notice-text').replace('{FOLDER_NAME}', folder.name);
-    new LintConfirmationModal(this.app, startMessage, submitBtnText, submitBtnNoticeText, () => this.runLinterAllFilesInFolder(folder)).open();
+    new LintConfirmationModal(this.app, startMessage, submitBtnText, submitBtnNoticeText, () => this.runLinterAllFilesInFolder(folder), this.settings.lintCommands && this.settings.lintCommands.length > 0).open();
   }
 
   runLinterEditor(editor: Editor) {

--- a/src/ui/modals/lint-confirmation-modal.ts
+++ b/src/ui/modals/lint-confirmation-modal.ts
@@ -4,11 +4,15 @@ import {getTextInLanguage} from 'src/lang/helpers';
 // https://github.com/nothingislost/obsidian-workspaces-plus/blob/bbba928ec64b30b8dec7fe8fc9e5d2d96543f1f3/src/modal.ts#L68
 export class LintConfirmationModal extends Modal {
   constructor(app: App, startModalMessageText: string, submitBtnText: string,
-      submitBtnNoticeText: string, btnSubmitAction: () => Promise<void>) {
+      submitBtnNoticeText: string, btnSubmitAction: () => Promise<void>, showCustomCommandWarning: boolean = false) {
     super(app);
     this.modalEl.addClass('confirm-modal');
 
     this.contentEl.createEl('h3', {text: getTextInLanguage('warning-text')}).style.textAlign = 'center';
+
+    if (showCustomCommandWarning) {
+      this.contentEl.createEl('p', {text: getTextInLanguage('custom-command-warning')}).style.fontWeight = 'bold';
+    }
 
     this.contentEl.createEl('p',
         {text: startModalMessageText + ' ' + getTextInLanguage('file-backup-text')}).id = 'confirm-dialog';


### PR DESCRIPTION
Fixes #419 

For now this is a placeholder for the logic that is to be merged. I know that several concerns were raised around this for other plugins that would conflict with this, but we will iron those out as we move along.

Things that still need adding:
- [x] Warning added to lint folder and vault modals when they have custom commands enabled (there is a noticeable performance drop due to having to run in a new window to run the custom commands on an active file)

Changes Made:
- Run custom commands on opened windows that are in the side pane (they are closed once you are done)
- Added async lock to help out with the running of custom commands once on a file