### PR TITLE
Fix Getting First Header Not Handling `#` at End of Markdown Link Display Text

### DIFF
--- a/__tests__/yaml-title.test.ts
+++ b/__tests__/yaml-title.test.ts
@@ -309,5 +309,17 @@ ruleTest({
         # >title
       `,
     },
+    {
+      testName: 'Escapes title if it has a hashtag in it that is not escaped and make sure that the link is properly parsed when it has a hashtag in it',
+      before: dedent`
+        # [test #1](github.com/platers/obsidian-linter)
+      `,
+      after: dedent`
+        ---
+        title: "test #1"
+        ---
+        # [test #1](github.com/platers/obsidian-linter)
+      `,
+    },
   ],
 });

--- a/__tests__/yaml-title.test.ts
+++ b/__tests__/yaml-title.test.ts
@@ -309,7 +309,7 @@ ruleTest({
         # >title
       `,
     },
-    {
+    { // accounts for https://github.com/platers/obsidian-linter/issues/941
       testName: 'Escapes title if it has a hashtag in it that is not escaped and make sure that the link is properly parsed when it has a hashtag in it',
       before: dedent`
         # [test #1](github.com/platers/obsidian-linter)
@@ -319,6 +319,42 @@ ruleTest({
         title: "test #1"
         ---
         # [test #1](github.com/platers/obsidian-linter)
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/941
+      testName: 'Escapes title if it has a hashtag in it that is not escaped',
+      before: dedent`
+        # test #2
+      `,
+      after: dedent`
+        ---
+        title: "test #2"
+        ---
+        # test #2
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/941
+      testName: 'Properly gets simple link text out and put in the title',
+      before: dedent`
+        # [test 3](github.com/platers/obsidian-linter)
+      `,
+      after: dedent`
+        ---
+        title: test 3
+        ---
+        # [test 3](github.com/platers/obsidian-linter)
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/941
+      testName: 'Make sure that pulling out an escaped hashtag in link text works properly',
+      before: dedent`
+        # [test \#4](github.com/platers/obsidian-linter)
+      `,
+      after: dedent`
+        ---
+        title: "test \#4"
+        ---
+        # [test \#4](github.com/platers/obsidian-linter)
       `,
     },
   ],

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -13,7 +13,7 @@ export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeB
 export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|]+))?\]{2}/g;
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
-export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+]+)/g;
+export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+\]]+)/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 export const ellipsisRegex = /(\. ?){2}\./g;


### PR DESCRIPTION
Fixes #941 

Links in the first H1 that had a `#` at the end of the markdown link display text would get improperly converted to a tag causing the text to put in the YAML to not be correct.
For example:
`[test #1](https://github.com)` would get its value added as `test #1](https://github.com` to the YAML.

Changes Made:
- Added UTs for the scenarios referenced
- Fixed tag regex including `]` in the values