### PR TITLE
Fix Newline Blockquote Recognition

### DIFF
--- a/__tests__/empty-line-around-blockquotes.test.ts
+++ b/__tests__/empty-line-around-blockquotes.test.ts
@@ -121,7 +121,6 @@ ruleTest({
         > [!FAQ] Title
         > Content here
         ${''}
-        >
         > [!NOTES] Title
         > Content
       `,
@@ -198,6 +197,70 @@ ruleTest({
         ${''}
         > 4
         ${''}
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/910
+      testName: 'Make sure that a blockquote 1 level lower than the next one ends in an empty line that it is on its level',
+      before: dedent`
+        > 1
+        >> 2
+        >
+        >>> 3
+        ${''}
+        > 4
+      `,
+      after: dedent`
+        > 1
+        >
+        >> 2
+        >>
+        >>> 3
+        ${''}
+        > 4
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/910
+      testName: 'Make sure that a blockquote that starts with an empty blockquote line gets the proper blockquote empty line set',
+      before: dedent`
+        > 1
+        >> 2
+        >>>
+        >>> 3
+        ${''}
+        > 4
+      `,
+      after: dedent`
+        > 1
+        >
+        >> 2
+        >>
+        >>> 3
+        ${''}
+        > 4
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/910
+      testName: 'Make sure that a blockquote that ends in a blank blockquote line gets the proper blockquote empty line set',
+      before: dedent`
+        > 1
+        >> 2
+        >>
+        >>> 3
+        >>>
+        >> 2
+        ${''}
+        > 4
+      `,
+      after: dedent`
+        > 1
+        >
+        >> 2
+        >>
+        >>> 3
+        >>
+        >> 2
+        ${''}
+        > 4
       `,
     },
   ],

--- a/__tests__/empty-line-around-blockquotes.test.ts
+++ b/__tests__/empty-line-around-blockquotes.test.ts
@@ -94,14 +94,14 @@ ruleTest({
       testName: 'Make sure that consecutive blockquotes do not get merged when the first one ends with an empty blockquote line',
       before: dedent`
         > [!FAQ] Title
-        > 
+        >
         ${''}
         > [!NOTES] Title
         > Content
       `,
       after: dedent`
         > [!FAQ] Title
-        > 
+        >
         ${''}
         > [!NOTES] Title
         > Content
@@ -165,6 +165,39 @@ ruleTest({
         >> - [x] Define Use Case
         >> - [ ] Craft User Story
         >> - [ ] Develop draft sketches
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/910
+      testName: 'Problem child...',
+      before: dedent`
+        ---
+        date created: 29-10-2023 04:16 PM
+        date modified: 12-11-2023 04:11 PM
+        ---
+
+        > 1
+        > 
+        > > 2
+        > > 
+        > > > 3
+
+        > 4
+
+      `,
+      after: dedent`
+        ---
+        date created: 29-10-2023 04:16 PM
+        date modified: 12-11-2023 04:11 PM
+        ---
+
+        > 1
+        >
+        > > 2
+        > >
+        > > > 3
+
+        > 4
+
       `,
     },
   ],

--- a/__tests__/empty-line-around-blockquotes.test.ts
+++ b/__tests__/empty-line-around-blockquotes.test.ts
@@ -168,36 +168,36 @@ ruleTest({
       `,
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/910
-      testName: 'Problem child...',
+      testName: 'Make sure that the end of a blockqoute is properly identified when there is a blank line right after a blockqoute',
       before: dedent`
         ---
         date created: 29-10-2023 04:16 PM
         date modified: 12-11-2023 04:11 PM
         ---
-
+        ${''}
         > 1
-        > 
+        >
         > > 2
-        > > 
+        > >
         > > > 3
-
+        ${''}
         > 4
-
+        ${''}
       `,
       after: dedent`
         ---
         date created: 29-10-2023 04:16 PM
         date modified: 12-11-2023 04:11 PM
         ---
-
+        ${''}
         > 1
         >
         > > 2
         > >
         > > > 3
-
+        ${''}
         > 4
-
+        ${''}
       `,
     },
   ],

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -25,6 +25,7 @@ import BlockquoteStyle from './rules/blockquote-style';
 import {IgnoreTypes, ignoreListOfTypes} from './utils/ignore-types';
 import MoveMathBlockIndicatorsToOwnLine from './rules/move-math-block-indicators-to-own-line';
 import {LinterSettings} from './settings-data';
+import TrailingSpaces from './rules/trailing-spaces';
 
 export type RunLinterRulesOptions = {
   oldText: string,
@@ -120,6 +121,8 @@ export class RulesRunner {
     [newText] = ForceYamlEscape.applyIfEnabled(newText, runOptions.settings, this.disabledRules, {
       defaultEscapeCharacter: runOptions.settings.commonStyles.escapeCharacter,
     });
+
+    [newText] = TrailingSpaces.applyIfEnabled(newText, runOptions.settings, this.disabledRules);
 
     let currentTime = runOptions.getCurrentTime();
     // run YAML timestamp at the end to help determine if something has changed

--- a/src/rules/trailing-spaces.ts
+++ b/src/rules/trailing-spaces.ts
@@ -14,6 +14,7 @@ export default class TrailingSpaces extends RuleBuilder<TrailingSpacesOptions> {
       nameKey: 'rules.trailing-spaces.name',
       descriptionKey: 'rules.trailing-spaces.description',
       type: RuleType.SPACING,
+      hasSpecialExecutionOrder: true, // run after all other possible rules to make sure trailing spaces are properly removed
       ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
     });
   }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -198,6 +198,12 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote
   let foundABlankLine = false;
   let previousChar = '';
   let firstChar = true;
+  // for some reason I am getting the ending new line character for the blockquote and other times it is
+  // the new line character after the ending new line character that is the end of the blockquote. So
+  // check the character before the starting end of content to see if we need to prematurely exit
+  // if it is a newline character.
+  // see https://github.com/platers/obsidian-linter/issues/910
+  const preEndingChar = text.charAt(index - 1);
   while (index < text.length) {
     const currentChar = text.charAt(index);
     if (currentChar.trim() !== '' && currentChar !== '>') {
@@ -229,7 +235,7 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote
 
     previousChar = currentChar;
     // the first character being a new line character means we have two new line characters back to back
-    if (firstChar && currentChar === '\n' && addingEmptyLinesAroundBlockquotes) {
+    if (firstChar && currentChar === '\n' && addingEmptyLinesAroundBlockquotes && preEndingChar === '\n') {
       endOfNewContent = index;
       break;
     }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -197,6 +197,7 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote
   let lineNestingLevel = 0;
   let foundABlankLine = false;
   let previousChar = '';
+  let firstChar = true;
   while (index < text.length) {
     const currentChar = text.charAt(index);
     if (currentChar.trim() !== '' && currentChar !== '>') {
@@ -227,6 +228,12 @@ function makeSureContentHasASingleEmptyLineAfterItUnlessItEndsAFileForBlockquote
     index++;
 
     previousChar = currentChar;
+    // the first character being a new line character means we have two new line characters back to back
+    if (firstChar && currentChar === '\n' && addingEmptyLinesAroundBlockquotes) {
+      endOfNewContent = index;
+      break;
+    }
+    firstChar = false;
   }
 
   if (index === text.length || endOfNewContent === text.length - 1) {


### PR DESCRIPTION
Relates to #910 

There seems to have been 3 issues:
- Blockqoute endings were not being uniformly passed in (sometimes the ending index referred to the newline character at the end of the blockquote and other times it was the newline character after it)
  - This was solved by a hacky fix that looked at the character before the ending index in order to see if which scenario we were dealing with
- Due to how the blockquote endings are being passed in inconsistently, there is a need to stop the while loop for finding the true end of the blockquote when a new line is found right after the initial end of the blockquote content when the previous character to the end is a newline character
- Trailing space removal was not affecting blockquote style results

Changes Made:
- Added a tests for the scenarios in question
- Added logic to make sure that the newline characters at the end of the blockquotes were handled properly
- Added logic to properly identify the last non-empty blockquote line and the first non-empty blockquote line
  - This was for scenarios where improper lines were being replaced due to not accounting for the starting and ending blank lines for the blockquote
- Added logic to properly handle making sure that blockquotes that touch each other decide to use the same empty line indicator for their shared empty line 
- Moved blockquote style formatting to the list of rules to run after the others