### PR TITLE
Fix: Linter break obsidian save file.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -228,15 +228,14 @@ export default class LinterPlugin extends Plugin {
       saveCommandDefinition.callback = () => {
         if (this.settings.lintOnSave && this.isEnabled) {
           const editor = this.getEditor();
-          if (!editor) {
-            return;
-          }
-
-          const file = this.app.workspace.getActiveFile();
-          if (!this.shouldIgnoreFile(file) && this.isMarkdownFile(file)) {
-            this.runLinterEditor(editor);
+          if (editor) {
+            const file = this.app.workspace.getActiveFile();
+            if (!this.shouldIgnoreFile(file) && this.isMarkdownFile(file)) {
+              this.runLinterEditor(editor);
+            }
           }
         }
+        save()
       };
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,7 +235,7 @@ export default class LinterPlugin extends Plugin {
             }
           }
         }
-        save()
+        save();
       };
     }
 


### PR DESCRIPTION
the previous save function is not called. Originally save function should trigger file to save immediately, but because of linter, file is not saved at all.