### PR TITLE
Feat: Add Default Language for Code Fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [auto-correct-common-misspellings](https://platers.github.io/obsidian-linter/settings/content-rules/#auto-correct-common-misspellings)
 - [blockquote-style](https://platers.github.io/obsidian-linter/settings/content-rules/#blockquote-style)
 - [convert-bullet-list-markers](https://platers.github.io/obsidian-linter/settings/content-rules/#convert-bullet-list-markers)
+- [default-language-for-code-fences](https://platers.github.io/obsidian-linter/settings/content-rules/#default-language-for-code-fences)
 - [emphasis-style](https://platers.github.io/obsidian-linter/settings/content-rules/#emphasis-style)
 - [no-bare-urls](https://platers.github.io/obsidian-linter/settings/content-rules/#no-bare-urls)
 - [ordered-list-style](https://platers.github.io/obsidian-linter/settings/content-rules/#ordered-list-style)

--- a/docs/docs/settings/content-rules.md
+++ b/docs/docs/settings/content-rules.md
@@ -221,13 +221,13 @@ After:
 
 Alias: `default-language-for-code-fences`
 
-Add a default language for code fences if not exist.
+Add a default language to code fences that do not have a language specified.
 
 ### Options
 
 | Name | Description | List Items | Default Value |
 | ---- | ----------- | ---------- | ------------- |
-| `Default Language` | The default programing language for code fences. | N/A |  |
+| `Programming Language` | Leave empty to do nothing. Languages tags can be found [here](https://prismjs.com/#supported-languages). | N/A |  |
 
 
 
@@ -268,6 +268,26 @@ After:
 
 `````` markdown
 ```javascript
+var temp = 'text';
+// this is a code block
+```
+``````
+</details>
+<details><summary>Empty string as the default language will not add a language to code blocks</summary>
+
+Before:
+
+`````` markdown
+```
+var temp = 'text';
+// this is a code block
+```
+``````
+
+After:
+
+`````` markdown
+```
 var temp = 'text';
 // this is a code block
 ```

--- a/docs/docs/settings/content-rules.md
+++ b/docs/docs/settings/content-rules.md
@@ -217,6 +217,63 @@ After:
 ``````
 </details>
 
+## Default Language For Code Fences
+
+Alias: `default-language-for-code-fences`
+
+Add a default language for code fences if not exist.
+
+### Options
+
+| Name | Description | List Items | Default Value |
+| ---- | ----------- | ---------- | ------------- |
+| `Default Language` | The default programing language for code fences. | N/A |  |
+
+
+
+### Examples
+
+<details><summary>Add a default language `javascript` to code blocks that do not have a language specified</summary>
+
+Before:
+
+`````` markdown
+```
+var temp = 'text';
+// this is a code block
+```
+``````
+
+After:
+
+`````` markdown
+```javascript
+var temp = 'text';
+// this is a code block
+```
+``````
+</details>
+<details><summary>If a code block already has a language specified, do not change it</summary>
+
+Before:
+
+`````` markdown
+```javascript
+var temp = 'text';
+// this is a code block
+```
+``````
+
+After:
+
+`````` markdown
+```javascript
+var temp = 'text';
+// this is a code block
+```
+``````
+</details>
+
 ## Emphasis Style
 
 Alias: `emphasis-style`

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -238,15 +238,6 @@ export default {
       'name': 'Add Blockquote Indentation on Paste',
       'description': 'Adds blockquotes to all but the first line, when the cursor is in a blockquote/callout line during pasting',
     },
-    // default-language-for-code-fences.ts
-    'default-language-for-code-fences': {
-      'name': 'Default Language For Code Fences',
-      'description': 'Add a default language for code fences if not exist.',
-      'default-language': {
-        'name': 'Default Language',
-        'description': 'The default programing language for code fences.',
-      },
-    },
     // blockquote-style.ts
     'blockquote-style': {
       'name': 'Blockquote Style',
@@ -303,6 +294,15 @@ export default {
       'tabsize': {
         'name': 'Tabsize',
         'description': 'Number of spaces that will be converted to a tab',
+      },
+    },
+    // default-language-for-code-fences.ts
+    'default-language-for-code-fences': {
+      'name': 'Default Language For Code Fences',
+      'description': 'Add a default language to code fences that do not have a language specified.',
+      'default-language': {
+        'name': 'Programming Language',
+        'description': 'Leave empty to do nothing. Languages tags can be found [here](https://prismjs.com/#supported-languages).',
       },
     },
     // emphasis-style.ts

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -238,6 +238,15 @@ export default {
       'name': 'Add Blockquote Indentation on Paste',
       'description': 'Adds blockquotes to all but the first line, when the cursor is in a blockquote/callout line during pasting',
     },
+    // default-language-for-code-fences.ts
+    'default-language-for-code-fences': {
+      'name': 'Default Language For Code Fences',
+      'description': 'Add a default language for code fences if not exist.',
+      'default-language': {
+        'name': 'Default Language',
+        'description': 'The default programing language for code fences.',
+      },
+    },
     // blockquote-style.ts
     'blockquote-style': {
       'name': 'Blockquote Style',

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -289,6 +289,15 @@ export default {
         'description': '制表符对应的空格宽度',
       },
     },
+    // default-language-for-code-fences.ts
+    'default-language-for-code-fences': {
+      'name': '代码块默认语言',
+      'description': '为没有指定语言的代码块添加默认语言。',
+      'default-language': {
+        'name': '编程语言',
+        'description': '留空不进行任何操作。可以在[这里](https://prismjs.com/#supported-languages)找到语言标签。',
+      },
+    },
     // emphasis-style.ts
     'emphasis-style': {
       'name': '突出样式',

--- a/src/rules/default-language-for-code-fences.ts
+++ b/src/rules/default-language-for-code-fences.ts
@@ -62,6 +62,24 @@ export default class DefaultLanguageForCodeFences extends RuleBuilder<DefaultLan
           defaultLanguage: 'shell',
         },
       }),
+      new ExampleBuilder({
+        description: 'Empty string as the default language will not add a language to code blocks',
+        before: dedent`
+          \`\`\`
+          var temp = 'text';
+          // this is a code block
+          \`\`\`
+        `,
+        after: dedent`
+          \`\`\`
+          var temp = 'text';
+          // this is a code block
+          \`\`\`
+        `,
+        options: {
+          defaultLanguage: '',
+        },
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<DefaultLanguageForCodeFencesOptions>[] {

--- a/src/rules/default-language-for-code-fences.ts
+++ b/src/rules/default-language-for-code-fences.ts
@@ -1,0 +1,77 @@
+import {IgnoreTypes} from '../utils/ignore-types';
+import {Options, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextOptionBuilder} from './rule-builder';
+import {ensureFencedCodeBlocksHasLanguage} from '../utils/mdast';
+import dedent from 'ts-dedent';
+
+class DefaultLanguageForCodeFencesOptions implements Options {
+  defaultLanguage?: string = '';
+}
+
+@RuleBuilder.register
+export default class DefaultLanguageForCodeFences extends RuleBuilder<DefaultLanguageForCodeFencesOptions> {
+  constructor() {
+    super({
+      nameKey: 'rules.default-language-for-code-fences.name',
+      descriptionKey: 'rules.default-language-for-code-fences.description',
+      type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
+    });
+  }
+  get OptionsClass(): new () => DefaultLanguageForCodeFencesOptions {
+    return DefaultLanguageForCodeFencesOptions;
+  }
+  apply(text: string, options: DefaultLanguageForCodeFencesOptions): string {
+    return ensureFencedCodeBlocksHasLanguage(text, options.defaultLanguage);
+  }
+  get exampleBuilders(): ExampleBuilder<DefaultLanguageForCodeFencesOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Add a default language `javascript` to code blocks that do not have a language specified',
+        before: dedent`
+          \`\`\`
+          var temp = 'text';
+          // this is a code block
+          \`\`\`
+        `,
+        after: dedent`
+          \`\`\`javascript
+          var temp = 'text';
+          // this is a code block
+          \`\`\`
+        `,
+        options: {
+          defaultLanguage: 'javascript',
+        },
+      }),
+      new ExampleBuilder({
+        description: 'If a code block already has a language specified, do not change it',
+        before: dedent`
+          \`\`\`javascript
+          var temp = 'text';
+          // this is a code block
+          \`\`\`
+        `,
+        after: dedent`
+          \`\`\`javascript
+          var temp = 'text';
+          // this is a code block
+          \`\`\`
+        `,
+        options: {
+          defaultLanguage: 'shell',
+        },
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<DefaultLanguageForCodeFencesOptions>[] {
+    return [
+      new TextOptionBuilder({
+        OptionsClass: DefaultLanguageForCodeFencesOptions,
+        nameKey: 'rules.default-language-for-code-fences.default-language.name',
+        descriptionKey: 'rules.default-language-for-code-fences.default-language.description',
+        optionsKey: 'defaultLanguage',
+      }),
+    ];
+  }
+}

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -991,3 +991,22 @@ export function getAllCustomIgnoreSectionsInText(text: string): {startIndex: num
 
   return positions.reverse();
 }
+
+export function ensureFencedCodeBlocksHasLanguage(text: string, defaultLanguage: string): string {
+  const positions: Position[] = getPositions(MDAstTypes.Code, text);
+
+  for (const position of positions) {
+    const codeBlock = text.substring(position.start.offset, position.end.offset);
+    if (!codeBlock.startsWith('```')) {
+      continue;
+    }
+
+    const language = codeBlock.substring(3, codeBlock.indexOf('\n')).trim();
+    if (language !== '') {
+      continue;
+    }
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset + 3, position.start.offset + 3, defaultLanguage);
+  }
+
+  return text;
+}


### PR DESCRIPTION
Fixes #943 

This pull request adds a new feature to the Markdown linter. The feature ensures that when a Markdown file's code block does not specify a language, a default language is added to the code block.

Changes:

- Added a new class DefaultLanguageForCodeFences in default-language-for-code-fences.ts.

Testing:

`npm run test` is passed.