### PR TITLE
Fix Ignored Syntax Getting Included in Tags

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -247,6 +247,55 @@ ruleTest({
         howToHandleExistingTags: 'Remove whole tag',
       },
     },
-
+    { // accounts for https://github.com/platers/obsidian-linter/issues/952
+      testName: 'Make sure that tags immediately followed by a wiki link only copies the tag value and not the wiki link value and removes properly',
+      before: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        ---
+        ${''}
+        #tag![[image.png]]
+      `,
+      after: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: tag
+        ---
+        ![[image.png]]
+      `,
+      options: {
+        tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
+        howToHandleExistingTags: 'Remove whole tag',
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/952
+      testName: 'Make sure that tags immediately followed by a wiki link only copies the tag value and not the wiki link value',
+      before: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        ---
+        ${''}
+        #tag![[image.png]]
+      `,
+      after: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: tag
+        ---
+        ${''}
+        #tag![[image.png]]
+      `,
+      options: {
+        tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
+      },
+    },
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "eslint-plugin-unicorn": "^49.0.0",
         "jest": "^29.3.1",
         "moment": "^2.29.4",
-        "obsidian": "^1.1.1",
+        "obsidian": "latest",
         "ts-node": "^10.9.1",
         "tslib": "^2.4.1",
         "typescript": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-unicorn": "^49.0.0",
     "jest": "^29.3.1",
     "moment": "^2.29.4",
-    "obsidian": "^1.1.1",
+    "obsidian": "latest",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
     "typescript": "^5.0.4",

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -13,7 +13,7 @@ export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeB
 export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|]+))?\]{2}/g;
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
-export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+\]]+)/g;
+export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+{\]]+)/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 export const ellipsisRegex = /(\. ?){2}\./g;


### PR DESCRIPTION
Fixes #952 

There is an issue where a tag followed by a wiki link causes extra info to get added to the tag text because of how wiki links are ignored. Adding `{` to the ignored list 

Changes Made:
- Updated tag regex to not allow tags to have `{` in them to make sure that ignored values are not pulled in
- Added 2 tests around this to make sure remove and copy work as expected when this scenario is encountered
- Updated Obsidian package info to be listed as the latest package to keep it up to date with what has been published