### PR TITLE
Make Sure `Blockqoute Style` Gets Rid of Multiple Spaces for Blockquote Indicators when Set to `Space`

### DIFF
--- a/__tests__/blockquote-style.test.ts
+++ b/__tests__/blockquote-style.test.ts
@@ -35,11 +35,13 @@ ruleTest({
         >   Text here
         >     >           More Text Here
         > \t > \t\t\t >Some More Text
+        >>>>\tJust a Tab
       `,
       after: dedent`
         > Text here
         > > More Text Here
         > > > Some More Text
+        > > > > Just a Tab
       `,
       options: {style: 'space'},
     },

--- a/__tests__/blockquote-style.test.ts
+++ b/__tests__/blockquote-style.test.ts
@@ -29,5 +29,19 @@ ruleTest({
       `,
       options: {style: 'no space'},
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/961
+      testName: 'Multiple spaces after a blockquote indicator is converted into one space',
+      before: dedent`
+        >   Text here
+        >     >           More Text Here
+        > \t > \t\t\t >Some More Text
+      `,
+      after: dedent`
+        > Text here
+        > > More Text Here
+        > > > Some More Text
+      `,
+      options: {style: 'space'},
+    },
   ],
 });

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -42,7 +42,7 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
   addSpaceToIndicator(startOfLine: string): string {
     // first we add spaces to blockquote indicators that are not followed by a space and then to catch any that were not handled already
     // we make sure to add a space between any 2 indicators that are side by side
-    return startOfLine.replace(/>([^ \t]|$)/g, '> $1').replace(/>>/g, '> >');
+    return startOfLine.replace(/>([^ \t]+|$)/g, '> $1').replace(/>>/g, '> >').replace(/>[ \t]+/g, '> ');
   }
   updateBlockquoteLines(blockquote: string, startOfLineModification: (startOfLine: string) => string): string {
     let currentIndex = 0;

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -42,7 +42,7 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
   addSpaceToIndicator(startOfLine: string): string {
     // first we add spaces to blockquote indicators that are not followed by a space and then to catch any that were not handled already
     // we make sure to add a space between any 2 indicators that are side by side
-    return startOfLine.replace(/>([^ \t]+|$)/g, '> $1').replace(/>>/g, '> >').replace(/>[ \t]+/g, '> ');
+    return startOfLine.replace(/>([^ \t]|$)/g, '> $1').replace(/>>/g, '> >').replace(/>(?:[ \t]{2,}|\t+)/g, '> ');
   }
   updateBlockquoteLines(blockquote: string, startOfLineModification: (startOfLine: string) => string): string {
     let currentIndex = 0;
@@ -67,7 +67,7 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
 
       newBlockquote = replaceTextBetweenStartAndEndWithNewValue(newBlockquote, startOfIndex, startOfIndex + startOfLine.length, updatedStartOfLine);
 
-      currentIndex = nextNewLine+ 1 + startOfLine.length - updatedStartOfLine.length;
+      currentIndex = nextNewLine+ 1 + updatedStartOfLine.length - startOfLine.length;
     } while (!breakOutOfLoop);
 
     return newBlockquote;


### PR DESCRIPTION
Fixes #961 

The logic for `Blockquote Style` was only adding missing spaces when the style was `Space`. This changes that to make it so that multiple spaces/tabs get cut down to just 1 space.

Changes Made:
- Added tests for multiple spaces, tabs, and a combination of spaces and tabs
- Added regex to take blockquote indicators followed by 2 or more spaces and or 1 or more tabs down to 1 space
- Fixed a bug with offsetting new line character positioning based on start of line differences in sizes that only mattered when nesting had lots of characters and text was small