### PR TITLE
Add helpUrl to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,6 @@
   "description": "Formats and styles your notes. It can be used to format YAML tags, aliases, arrays, and metadata; footnotes; headings; spacing; math blocks; regular markdown contents like list, italics, and bold styles; and more with the use of custom rule options as well.",
   "author": "Victor Tao",
   "authorUrl": "https://github.com/platers",
+  "helpUrl": "https://platers.github.io/obsidian-linter/",
   "isDesktopOnly": false
 }


### PR DESCRIPTION
I am adding helpUrl to the manifest to support the help system integration into Obsidian. Please consider supporting this initiative. Please note that this key value in manifest.json must be in the manifest downloaded as part of the plugin in the release.

https://forum.obsidian.md/t/links-to-help-and-manuals-for-plugins-and-themes/70733/8