### PR TITLE
Potential Fix for Live Preview Properties Update

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -246,6 +246,8 @@ export default class LinterPlugin extends Plugin {
 
     if (typeof this.originalSaveCallback === 'function') {
       saveCommandDefinition.callback = () => {
+        this.originalSaveCallback();
+
         if (this.settings.lintOnSave && this.isEnabled) {
           const editor = this.getEditor();
           if (editor) {
@@ -255,8 +257,6 @@ export default class LinterPlugin extends Plugin {
             }
           }
         }
-
-        this.originalSaveCallback();
       };
     }
 


### PR DESCRIPTION
Fixes #973 

There seems to be an issue caused by calling the original save callback right after linting a file. This causes Live Preview and Reading View's properties view to not update immediately. I am not sure what causes this, but likely the save event causes a refreshing of the cache or something that prevents the immediate UI update. So it seems best to do the original save callback and then do the Linter logic. This could cause 2 save events, but the debounce should prevent that from my understanding.

Changes Made:
- Made the original save callback run before linting the file