### PR TITLE
Add Support for Checklist Items and List Items for `Blockquote Style`

### DIFF
--- a/__tests__/blockquote-style.test.ts
+++ b/__tests__/blockquote-style.test.ts
@@ -45,5 +45,57 @@ ruleTest({
       `,
       options: {style: 'space'},
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/961
+      testName: 'Multiple spaces after a blockquote indicator is not converted into one space when it is a list item or checklist line when `style=space`',
+      before: dedent`
+        >   Text here
+        >   - List item 1
+        >\t * List item 2
+        >   + List item 3
+        >   1. Ordered item 1
+        >   2) Ordered item 2
+        >   - [ ] Checklist item
+        >- List item 4
+      `,
+      after: dedent`
+        > Text here
+        >   - List item 1
+        > \t * List item 2
+        >   + List item 3
+        >   1. Ordered item 1
+        >   2) Ordered item 2
+        >   - [ ] Checklist item
+        > - List item 4
+      `,
+      options: {style: 'space'},
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/961
+      testName: 'Multiple spaces after a blockquote indicator should be removed except when dealing with list mark lines when `style=no space`',
+      before: dedent`
+        >   Text here
+        >   - List item 1
+        >\t * List item 2
+        >   + List item 3
+        >   1. Ordered item 1
+        >   2) Ordered item 2
+        >   - [ ] Checklist item
+        >- List item 4
+        > >  >   \t > - List item 5
+        > >  >   \t > > - List item 6
+      `,
+      after: dedent`
+        >Text here
+        >   - List item 1
+        >\t * List item 2
+        >   + List item 3
+        >   1. Ordered item 1
+        >   2) Ordered item 2
+        >   - [ ] Checklist item
+        >- List item 4
+        >>>> - List item 5
+        >>>>> - List item 6
+      `,
+      options: {style: 'no space'},
+    },
   ],
 });

--- a/src/rules/remove-empty-list-markers.ts
+++ b/src/rules/remove-empty-list-markers.ts
@@ -20,7 +20,7 @@ export default class RemoveEmptyListMarkers extends RuleBuilder<RemoveEmptyListM
     return RemoveEmptyListMarkersOptions;
   }
   apply(text: string, options: RemoveEmptyListMarkersOptions): string {
-    const emptyListMarkerRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}(-|\\*|\\+|\\d+[.)]|- (\\[( |x)\\]))\\s*?$`, 'gm');
+    const emptyListMarkerRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}(-|\\*|\\+|\\d+[.)]|- (\\[(.)\\]))\\s*?$`, 'gm');
     // remove all empty list markers followed by a new line
     text = text.replace(new RegExp(emptyListMarkerRegex.source + '\\n', 'gm'), '');
     // remove all empty list markers proceeded by a new line

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -43,6 +43,8 @@ export const checklistBoxStartsTextRegex = new RegExp(`^${checklistBoxIndicator}
 export const indentedOrBlockquoteNestedChecklistIndicatorRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}- ${checklistBoxIndicator} `);
 export const nonBlockquoteChecklistRegex = new RegExp(`^\\s*- ${checklistBoxIndicator} `);
 
+export const startsWithListMarkerRegex = new RegExp(`^\\s*(-|\\*|\\+|\\d+[.)]|- (${checklistBoxIndicator}))`, 'm');
+
 export const footnoteDefinitionIndicatorAtStartOfLine = /^(\[\^\w+\]) ?([,.;!:?])/gm;
 export const calloutRegex = /^(>\s*)+\[![^\s]*\]/m;
 


### PR DESCRIPTION
Fixes #961 

It was noted that we probably should not remove spaces prior to a list item when dealing with blockquote style. As such a check for them has been added which changes how the blockquote style is modified. If it is a list item or checklist line, we just ignore multiple spaces in a row after the last `>` in the blockquote indicators.

Changes Made:
- Handled list item and checklist item lines in blockquotes as special
- Allowed custom checklist values in `Remove Empty List Markers`
- Added a new regex that can be used to identify list item and checklist indicators