### PR TITLE
Add Rule for Sorting YAML Array Values

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -306,15 +306,15 @@ export default {
     'dedupe-yaml-array-values': {
       'name': 'Dedupe YAML Array Values',
       'description': 'Removes duplicate array values in a case sensitive manner.',
-      'alias-key': {
+      'dedupe-alias-key': {
         'name': 'Dedupe YAML aliases section',
         'description': 'Turns on removing duplicate aliases.',
       },
-      'tag-key': {
+      'dedupe-tag-key': {
         'name': 'Dedupe YAML tags section',
         'description': 'Turns on removing duplicate tags.',
       },
-      'default-array-keys': {
+      'dedupe-array-keys': {
         'name': 'Dedupe YAML array sections',
         'description': 'Turns on removing duplicate values for regular YAML arrays',
       },
@@ -660,6 +660,31 @@ export default {
       'yaml-keys-to-remove': {
         'name': 'YAML Keys to Remove',
         'description': 'The YAML keys to remove from the YAML frontmatter with or without colons',
+      },
+    },
+    // sort-yaml-array-values.ts
+    'sort-yaml-array-values': {
+      'name': 'Sort YAML Array Values',
+      'description': 'Sorts YAML array values based on the specified sort order.',
+      'sort-alias-key': {
+        'name': 'Sort YAML aliases section',
+        'description': 'Turns on sorting aliases.',
+      },
+      'sort-tag-key': {
+        'name': 'Sort YAML tags section',
+        'description': 'Turns on sorting tags.',
+      },
+      'sort-array-keys': {
+        'name': 'Sort YAML array sections',
+        'description': 'Turns on sorting values for regular YAML arrays',
+      },
+      'ignore-keys': {
+        'name': 'YAML Keys to Ignore',
+        'description': 'A list of YAML keys without the ending colon on their own lines that are not meant to have their values sorted.',
+      },
+      'sort-order': {
+        'name': 'Sort Order',
+        'description': 'The way to sort the YAML array values.',
       },
     },
     // space-after-list-markers.ts

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -177,6 +177,7 @@ export class RulesRunner {
       logDebug(getTextInLanguage('logs.running-custom-regex'));
 
       let newText = text;
+      let initialText = text;
       for (const eachRegex of customRegexes) {
         const findIsEmpty = eachRegex.find === undefined || eachRegex.find == '' || eachRegex.find === null;
         const replaceIsEmpty = eachRegex.replace === undefined || eachRegex.replace === null;
@@ -184,9 +185,22 @@ export class RulesRunner {
           continue;
         }
 
+        let debugMsg = eachRegex.label;
+        if (debugMsg.trim() != '') {
+          debugMsg += ':\n';
+        }
+        debugMsg +=`/${eachRegex.find}/${eachRegex.flags}/${eachRegex.replace}/`;
+
+        logDebug(debugMsg);
         const regex = new RegExp(`${eachRegex.find}`, eachRegex.flags);
         // make sure that characters are not string escaped unescape in the replace value to make sure things like \n and \t are correctly inserted
         newText = newText.replace(regex, convertStringVersionOfEscapeCharactersToEscapeCharacters(eachRegex.replace));
+
+        if (initialText != newText) {
+          logDebug(newText);
+        }
+
+        initialText = newText;
       }
 
       return newText;


### PR DESCRIPTION
Fixes #508 

Add the base level logic for sorting array values.

Changes Made
- Updated the usage of keys for the dedupe YAML array values rule to make its name clearer in the JSON-esq format
- Added a rule for sorting array values in alphabetical ascending or descending order
- Added wording for the rules in English
- Added some more debug logs and in this case ones for custom regex replacement