### PR TITLE
Fix Custom Table Parser Not Respecting Escaped Pipes

### DIFF
--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -198,7 +198,7 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
       ---
       date: 06/16/2022
       type: topic
-      tags: 
+      tags:
       keywords: []
       status: WIP
       ---
@@ -217,6 +217,20 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
     `,
     expectedTablesInText: 0,
     expectedPositions: [],
+  },
+  { // accounts for https://github.com/platers/obsidian-linter/issues/999
+    name: 'handle tables with a escaped pipes in them',
+    text: dedent`
+      | 1 | 2 |
+      | --- | --- |
+      | 3 | 4 |
+
+      | [[2024-01-25\\|Thursday]] | [[2024-01-26\\|Friday]] |
+      | --- | --- |
+      | 3 | 4 |
+    `,
+    expectedTablesInText: 2,
+    expectedPositions: [{startIndex: 112, endIndex: 35}, {startIndex: 0, endIndex: 33}],
   },
 ];
 

--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -230,7 +230,7 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
       | 3 | 4 |
     `,
     expectedTablesInText: 2,
-    expectedPositions: [{startIndex: 112, endIndex: 35}, {startIndex: 0, endIndex: 33}],
+    expectedPositions: [{startIndex: 35, endIndex: 112}, {startIndex: 0, endIndex: 33}],
   },
 ];
 

--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -390,5 +390,26 @@ ruleTest({
         [^5]: D
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/999
+      testName: 'Make sure that tables with escaped pipes in them are ignored',
+      before: dedent`
+        | 1 | 2 |
+        | --- | --- |
+        | 3 | 4 |
+
+        | [[2024-01-25\\|Thursday]] | [[2024-01-26\\|Friday]] |
+        | --- | --- |
+        | 3 | 4 |
+      `,
+      after: dedent`
+        | 1 | 2 |
+        | --- | --- |
+        | 3 | 4 |
+
+        | [[2024-01-25\\|Thursday]] | [[2024-01-26\\|Friday]] |
+        | --- | --- |
+        | 3 | 4 |
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -909,7 +909,7 @@ export function getAllTablesInText(text: string): {startIndex: number, endIndex:
 
     // if the delimiter row and the first row do not have the same amount of cells,
     // we are not dealing with a table
-    if (firstLine.split('|').length !== delimiterLine.split('|').length) {
+    if (countTableDelimiters(firstLine) !== countTableDelimiters(delimiterLine)) {
       continue;
     }
 
@@ -956,6 +956,29 @@ function isInvalidTableSeparatorRow(fullRow: string, separatorMatch: string): bo
   // it could contain text or an invalid table cell for the separator
   const nonSeparatorContent = fullRow.replace(separatorMatch, '');
   return /[^\s>]/.test(nonSeparatorContent);
+}
+
+function countTableDelimiters(line: string): number {
+  let previousCharIsEscapeChar = false;
+  let numEscapeCharsInARow = 0;
+  let numDelimiters = 0;
+  let currentChar = '';
+  for (let i = 0; i < line.length; i++) {
+    currentChar = line[i];
+    if (currentChar === '\\') {
+      numEscapeCharsInARow++;
+      previousCharIsEscapeChar = numEscapeCharsInARow % 2 == 1;
+    } else {
+      numEscapeCharsInARow = 0;
+      if (currentChar === '|' && !previousCharIsEscapeChar) {
+        numDelimiters++;
+      }
+
+      previousCharIsEscapeChar = false;
+    }
+  }
+
+  return numDelimiters;
 }
 
 export function getAllCustomIgnoreSectionsInText(text: string): {startIndex: number, endIndex: number}[] {


### PR DESCRIPTION
Fixes #999 

There was an issue where if the table header row included an escaped pipe in it (`\|`) then it would still count that as a regular pipe when counting the number of rows present in the header row versus the delimiter row. This caused those tables to erroneously be treated as regular paragraphs instead of tables by the Linter.

Changes Made:
- Added logic for counting unescaped pipes only to do a row count
- Added tests in paragraph blank lines and the table parser to make sure that each one properly handles the escaped pipes