### PR TITLE
Fix `Re-Index Footnotes` Not Working for Markdown Link Values

### DIFF
--- a/__tests__/move-footnotes-to-the-bottom.test.ts
+++ b/__tests__/move-footnotes-to-the-bottom.test.ts
@@ -274,5 +274,36 @@ ruleTest({
         [^3]: D
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1006
+      testName: 'Moving footnotes to the bottom of the file should properly order values even when links are present',
+      before: dedent`
+        Paragraph 1. [^4]
+        ${''}
+        Paragraph 2. [^1]
+        ${''}
+        Paragraph 3. [^2]
+        ${''}
+        Paragraph 4. [^3]
+        ${''}
+        [^1]: [1111](111)
+        [^2]: [2222](222)
+        [^3]: [3333](333)
+        [^4]: [4444](4444)
+      `,
+      after: dedent`
+        Paragraph 1. [^4]
+        ${''}
+        Paragraph 2. [^1]
+        ${''}
+        Paragraph 3. [^2]
+        ${''}
+        Paragraph 4. [^3]
+        ${''}
+        [^4]: [4444](4444)
+        [^1]: [1111](111)
+        [^2]: [2222](222)
+        [^3]: [3333](333)
+      `,
+    },
   ],
 });

--- a/__tests__/re-index-footnotes.test.ts
+++ b/__tests__/re-index-footnotes.test.ts
@@ -93,6 +93,36 @@ ruleTest({
         More text.
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1006
+      testName: 'Re-indexing footnotes with links as the referenced values should keep the references to text correlation',
+      before: dedent`
+        Paragraph 1. [^4]
+        ${''}
+        Paragraph 2. [^1]
+        ${''}
+        Paragraph 3. [^2]
+        ${''}
+        Paragraph 4. [^3]
+        ${''}
+        [^4]: [4444](4444)
+        [^1]: [1111](111)
+        [^2]: [2222](222)
+        [^3]: [3333](333)
+      `,
+      after: dedent`
+        Paragraph 1. [^1]
+        ${''}
+        Paragraph 2. [^2]
+        ${''}
+        Paragraph 3. [^3]
+        ${''}
+        Paragraph 4. [^4]
+        ${''}
+        [^1]: [4444](4444)
+        [^2]: [1111](111)
+        [^3]: [2222](222)
+        [^4]: [3333](333)
+      `,
+    },
   ],
 });
-

--- a/src/rules/re-index-footnotes.ts
+++ b/src/rules/re-index-footnotes.ts
@@ -13,7 +13,7 @@ export default class ReIndexFootnotes extends RuleBuilder<ReIndexFootnotesOption
       nameKey: 'rules.re-index-footnotes.name',
       descriptionKey: 'rules.re-index-footnotes.description',
       type: RuleType.FOOTNOTE,
-      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.tag],
     });
   }
   get OptionsClass(): new () => ReIndexFootnotesOptions {


### PR DESCRIPTION
Fixes #1006 

There was an issue where `Re-Index Footnotes` would not properly recognize footnote references if they had markdown or wiki links in them.

For example:
``` markdown
 Paragraph 1. [^4]

Paragraph 2. [^1]

Paragraph 3. [^2]

Paragraph 4. [^3]

[^4]: [4444](4444)
[^1]: [1111](111)
[^2]: [2222](222)
[^3]: [3333](333)
```
was left as is.

To fix this, we needed to stop ignoring markdown and wiki links.

Changes Made:
- Added tests around the move and re-index footnotes
- Removed ignoring wiki and markdown links for footnotes