### PR TITLE
`Heading Blank Lines`: Make Sure Tags on The Line Before a Heading Gets a Blank Line Added when `Bottom=false`

### DIFF
--- a/__tests__/heading-blank-lines.test.ts
+++ b/__tests__/heading-blank-lines.test.ts
@@ -180,5 +180,29 @@ ruleTest({
         emptyLineAfterYaml: false,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/993
+      testName: 'Make sure that headings proceeded by a line with a hashtag get a blank line added when `Bottom=false`.',
+      before: dedent`
+        # Heading 1
+        Lorem ipsum.
+        ${''}
+        ## Heading 2
+        Woah, cool text here. #reallycool
+        ## Heading 3
+      `,
+      after: dedent`
+        # Heading 1
+        Lorem ipsum.
+        ${''}
+        ## Heading 2
+        Woah, cool text here. #reallycool
+        ${''}
+        ## Heading 3
+      `,
+      options: {
+        bottom: false,
+        emptyLineAfterYaml: false,
+      },
+    },
   ],
 });

--- a/src/rules/heading-blank-lines.ts
+++ b/src/rules/heading-blank-lines.ts
@@ -24,7 +24,7 @@ export default class HeadingBlankLines extends RuleBuilder<HeadingBlankLinesOpti
   }
   apply(text: string, options: HeadingBlankLinesOptions): string {
     if (!options.bottom) {
-      text = text.replace(/^([^#\n]+)\n+(#+\s.*)/gm, '$1\n\n$2');
+      text = text.replace(/^([^#\n][^\n]+)\n+(#+\s.*)/gm, '$1\n\n$2');
     } else {
       text = text.replace(/^(#+\s.*)/gm, '\n\n$1\n\n'); // add blank line before and after headings
       text = text.replace(/\n+(#+\s.*)/g, '\n\n$1'); // trim blank lines before headings


### PR DESCRIPTION
Fixes #993

There was an issue where `Bottom=false` and the line before a heading had a `#` in it.
For example:
``` markdown
# Heading 1
Lorem ipsum.

## Heading 2
Woah, cool text here. #reallycool
## Heading 3
```
would not get changed.

After the change it now looks like:
``` markdown
# Heading 1
Lorem ipsum.

## Heading 2
Woah, cool text here. #reallycool

## Heading 3
```

Changes Made:
- Added a test for the scenario in question
- Updated the regex for when `Bottom=false` to make sure that it only does not allow a line to start with `#` for adding a blank line before a heading