### PR TITLE
Make YAML Array Value Sorting Case Insensitive

### DIFF
--- a/__tests__/sort-yaml-array-values.test.ts
+++ b/__tests__/sort-yaml-array-values.test.ts
@@ -1,0 +1,34 @@
+import SortYamlArrayValues from '../src/rules/sort-yaml-array-values';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+import {NormalArrayFormats} from '../src/utils/yaml';
+
+ruleTest({
+  RuleBuilderClass: SortYamlArrayValues,
+  testCases: [
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1024
+      testName: 'Sort YAML Arrays sorts values in a case-insensitive manner',
+      before: dedent`
+        ---
+        tags:
+          - tag/a
+          - tag/B
+          - tag/c
+          - tag/D
+        ---
+      `,
+      after: dedent`
+        ---
+        tags:
+          - tag/a
+          - tag/B
+          - tag/c
+          - tag/D
+        ---
+      `,
+      options: {
+        tagArrayStyle: NormalArrayFormats.MultiLine,
+      },
+    },
+  ],
+});

--- a/src/rules/sort-yaml-array-values.ts
+++ b/src/rules/sort-yaml-array-values.ts
@@ -123,7 +123,18 @@ export default class RuleTemplate extends RuleBuilder<SortYamlArrayValuesOptions
       return arr;
     }
 
-    arr.sort();
+    // logic from https://stackoverflow.com/a/26061065/8353749
+    arr.sort(function(a, b) {
+      /* Storing case insensitive comparison */
+      const comparison = a.toLowerCase().localeCompare(b.toLowerCase());
+      /* If strings are equal in case insensitive comparison */
+      if (comparison === 0) {
+        /* Return case sensitive comparison instead */
+        return a.localeCompare(b);
+      }
+      /* Otherwise return result */
+      return comparison;
+    });
     if (sortType === 'Ascending Alphabetical') {
       return arr;
     }


### PR DESCRIPTION
Fixes #1024 

There was a report that capital and lowercase values were not be compared consistently with regards to a lowercase A and uppercase a being considered the same. So a change was made to the sort where it ignores case unless two values are equal.

Changes Made:
- Added a UT for the scenario in question
- Updated the sort logic to ignore case unless two values are the same