### PR TITLE
Fix: Undefined Custom Regex Label Causes Error

### DIFF
--- a/__tests__/rules-runner.test.ts
+++ b/__tests__/rules-runner.test.ts
@@ -208,6 +208,22 @@ const customReplaceTestCases: CustomReplaceTestCase[] = [
       <!-- linter-enable -->
     `,
   },
+  { // accounts for https://github.com/platers/obsidian-linter/issues/1025
+    testName: 'A custom replace with an undefined label should still run.',
+    listOfRegexReplacements: [
+      {
+        label: undefined, find: 'lobo', replace: 'hello', flags: 'g',
+      },
+    ],
+    before: dedent`
+      How does this look?
+      Did it stay the same?
+    `,
+    after: dedent`
+      How does this look?
+      Did it stay the same?
+    `,
+  },
 ];
 
 describe('Rules Runner', () => {

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -186,7 +186,7 @@ export class RulesRunner {
         }
 
         let debugMsg = eachRegex.label;
-        if (debugMsg.trim() != '') {
+        if (debugMsg && debugMsg.trim() != '') {
           debugMsg += ':\n';
         }
         debugMsg +=`/${eachRegex.find}/${eachRegex.flags}/${eachRegex.replace}/`;


### PR DESCRIPTION
Fixes #1025 

There was an issue where a custom regex replace not having any kind of label (not even an empty string) would cause the Linter to fail linting on custom regex replacements because it was trying to trim the label before checking that it was not undefined.

Changes Made:
- Check that custom regex replace label is not undefined or null before trying to trim it
- Added a UT for this scenario