### PR TITLE
Fix: `Paragraph Blank Lines` Not Being Consistent Across List Types and Different List Indicators

### DIFF
--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -411,5 +411,157 @@ ruleTest({
         | 3 | 4 |
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1014
+      testName: 'List items starting with `*` as the indicator should not be affected',
+      before: dedent`
+        * abc
+        \tabc
+        \tbb
+      `,
+      after: dedent`
+        * abc
+        \tabc
+        \tbb
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1014
+      testName: 'List items starting with `+` as the indicator should not be affected',
+      before: dedent`
+        + abc
+        \tabc
+        \tbb
+      `,
+      after: dedent`
+        + abc
+        \tabc
+        \tbb
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1014
+      testName: 'Ordered list items with an end style of `)` should not be affected',
+      before: dedent`
+        1) abc
+        \tabc
+        \tbb
+      `,
+      after: dedent`
+        1) abc
+        \tabc
+        \tbb
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1014
+      testName: 'Checklists should not be affected',
+      before: dedent`
+        - [ ] abc
+        \tabc
+        \tbb
+        ${''}
+        - [x] abc
+        \tabc
+        \tbb
+        ${''}
+        - [y] abc
+        \tabc
+        \tbb
+        1) [ ] abc
+        \tabc
+        \tbb
+        ${''}
+        2. [x] abc
+        \tabc
+        \tbb
+        ${''}
+        3) [y] abc
+        \tabc
+        \tbb
+      `,
+      after: dedent`
+        - [ ] abc
+        \tabc
+        \tbb
+        ${''}
+        - [x] abc
+        \tabc
+        \tbb
+        ${''}
+        - [y] abc
+        \tabc
+        \tbb
+        1) [ ] abc
+        \tabc
+        \tbb
+        ${''}
+        2. [x] abc
+        \tabc
+        \tbb
+        ${''}
+        3) [y] abc
+        \tabc
+        \tbb
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1014
+      testName: 'Indented checklists should not be affected',
+      before: dedent`
+        - [ ] abc
+        \t- [ ] abc
+        \t\tabc
+        \t\tbb
+        ${''}
+          + [x] abc
+          \tabc
+          \tbb
+        ${''}
+        \t8) [y] abc
+        \t\tabc
+        \t\tbb
+      `,
+      after: dedent`
+        - [ ] abc
+        \t- [ ] abc
+        \t\tabc
+        \t\tbb
+        ${''}
+          + [x] abc
+          \tabc
+          \tbb
+        ${''}
+        \t8) [y] abc
+        \t\tabc
+        \t\tbb
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1014
+      testName: 'Indented list items should not be affected',
+      before: dedent`
+        - abc
+        \t- abc
+        \t\tabc
+        \t\tbb
+        ${''}
+          + abc
+          \tabc
+          \tbb
+        ${''}
+        \t* [y] abc
+        \t\tabc
+        \t\tbb
+      `,
+      after: dedent`
+        - abc
+        \t- abc
+        \t\tabc
+        \t\tbb
+        ${''}
+          + abc
+          \tabc
+          \tbb
+        ${''}
+        \t* [y] abc
+        \t\tabc
+        \t\tbb
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -2,7 +2,7 @@ import {visit} from 'unist-util-visit';
 import type {Position} from 'unist';
 import type {Root} from 'mdast';
 import {hashString53Bit, makeSureContentHasEmptyLinesAddedBeforeAndAfter, replaceTextBetweenStartAndEndWithNewValue, getStartOfLineIndex, replaceAt, getStartOfLineWhitespaceOrBlockquoteLevel} from './strings';
-import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator, checklistBoxStartsTextRegex, footnoteDefinitionIndicatorAtStartOfLine, emptyLineMathBlockquoteRegex, startsWithBlockquote} from './regex';
+import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator, checklistBoxStartsTextRegex, footnoteDefinitionIndicatorAtStartOfLine, emptyLineMathBlockquoteRegex, startsWithBlockquote, startsWithListMarkerRegex} from './regex';
 import {gfmFootnote} from 'micromark-extension-gfm-footnote';
 import {gfmTaskListItem} from 'micromark-extension-gfm-task-list-item';
 import {combineExtensions} from 'micromark-util-combine-extensions';
@@ -420,8 +420,7 @@ export function makeSureThereIsOnlyOneBlankLineBeforeAndAfterParagraphs(text: st
 
     // exclude list items, footnote definitions, and blockquotes
     const firstLine = paragraphLines[0].trimStart();
-    if (firstLine.startsWith('>') || firstLine.startsWith('- ') || firstLine.startsWith('-\t') ||
-      firstLine.match(/^[0-9]+\.( |\t)+/) || firstLine.match(footnoteDefinitionIndicatorAtStartOfLine)) {
+    if (firstLine.startsWith('>') || firstLine.match(startsWithListMarkerRegex) || firstLine.match(footnoteDefinitionIndicatorAtStartOfLine)) {
       continue;
     }
 


### PR DESCRIPTION
Fixes #1014 

There was an issue where the logic for `Paragraph Blank Lines` was not looking for indented unordered, ordered, or checklist list items. It was also not looking for ordered list items that had an end list style of `)`. There was also an issue where it did not consider `+` and `*` to be list indicators at the start of line when followed by a space or tab. This was simple to fix by swapping to `startsWithListMarkerRegex` as a regex match since it handles these scenarios already.

Changes Made:
- Swapped to use `startsWithListMarkerRegex` instead of some of the other list checks
- Added UTs for several different scenarios to make sure they were working now