### PR TITLE
Fix: Folds not Being Retained on Lint when Changes Made

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-linter",
-  "version": "1.20.1",
+  "version": "1.23.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
-      "version": "1.20.1",
+      "version": "1.23.2",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-private-methods": "^7.23.3",
@@ -55,7 +55,7 @@
         "eslint-plugin-unicorn": "^49.0.0",
         "jest": "^29.3.1",
         "moment": "^2.29.4",
-        "obsidian": "latest",
+        "obsidian": "^1.5.7-1",
         "ts-node": "^10.9.1",
         "tslib": "^2.4.1",
         "typescript": "^5.0.4",
@@ -8757,9 +8757,9 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
-      "integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
+      "version": "1.5.7-1",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
+      "integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
       "dev": true,
       "dependencies": {
         "@types/codemirror": "5.60.8",
@@ -16324,9 +16324,9 @@
       }
     },
     "obsidian": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
-      "integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
+      "version": "1.5.7-1",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
+      "integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
       "dev": true,
       "requires": {
         "@types/codemirror": "5.60.8",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-unicorn": "^49.0.0",
     "jest": "^29.3.1",
     "moment": "^2.29.4",
-    "obsidian": "latest",
+    "obsidian": "^1.5.7-1",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
     "typescript": "^5.0.4",


### PR DESCRIPTION
Fixes #1016 

There was an issue that arose after making changes to the logic to fix live preview linting to work with the frontmatter where the folds were not being retained in live preview or in source mode. This is because we just saved the whole file instead of using `editor.ReplaceRange` to surgically update values. Thus the folds were just dropped. Adding back a more precise version of the update logic allows for folds to be retained so long as the fold is not in the frontmatter when a change is made in live preview and there is no change made in the folded section.

Changes Made:
- Added logic to make sure that in source mode we use the original logic, but in live preview we check if the frontmatter was updated prior to making any changes. If the frontmatter is different we blanket update the frontmatter and just apply any changes that happened after that.
- Moved `endOfDocument` to a private function to help keep it from being instantiated over and over again.