### PR TITLE
Fix: Live Preview Inserting Frontmatter when It Does Not Exist Already

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -474,7 +474,7 @@ export default class LinterPlugin extends Plugin {
     changes.forEach((change) => {
       let [type, value] = change;
       isBeforeStartIndex = curText.length < startingIndex;
-      if (isBeforeStartIndex && curText.length + value.length >= startingIndex) {
+      if (isBeforeStartIndex && curText.length + value.length >= startingIndex && type == DiffMatchPatch.DIFF_INSERT) {
         const valueIndexStart = startingIndex - curText.length;
         curText = value.substring(0, valueIndexStart);
         value = value.substring(valueIndexStart);

--- a/src/main.ts
+++ b/src/main.ts
@@ -458,16 +458,28 @@ export default class LinterPlugin extends Plugin {
         oldTextFrontmatterInfo.from != newTextFrontmatterInfo.from ||
         oldTextFrontmatterInfo.to != newTextFrontmatterInfo.to ||
         oldTextFrontmatterInfo.frontmatter != newTextFrontmatterInfo.frontmatter) {
-        editor.replaceRange(newTextFrontmatterInfo.frontmatter, editor.offsetToPos(oldTextFrontmatterInfo.from), editor.offsetToPos(oldTextFrontmatterInfo.to));
-        startingIndex = newTextFrontmatterInfo.to;
+        let newFrontmatter: string;
+        if (oldTextFrontmatterInfo.exists == false) {
+          newFrontmatter = `---\n${newTextFrontmatterInfo.frontmatter}---`;
+        } else {
+          newFrontmatter = newTextFrontmatterInfo.frontmatter;
+        }
+
+        editor.replaceRange(newFrontmatter, editor.offsetToPos(oldTextFrontmatterInfo.from), editor.offsetToPos(oldTextFrontmatterInfo.to));
+        startingIndex = oldTextFrontmatterInfo.from + newFrontmatter.length;
       }
     }
 
     let isBeforeStartIndex = false;
     changes.forEach((change) => {
+      let [type, value] = change;
       isBeforeStartIndex = curText.length < startingIndex;
-
-      const [type, value] = change;
+      if (isBeforeStartIndex && curText.length + value.length >= startingIndex) {
+        const valueIndexStart = startingIndex - curText.length;
+        curText = value.substring(0, valueIndexStart);
+        value = value.substring(valueIndexStart);
+        isBeforeStartIndex = false;
+      }
 
       // handle updates
       if (!isBeforeStartIndex) {


### PR DESCRIPTION
Relates to #1016 

There were two issues mentioned about the other fix:
- When new frontmatter is to be added to a file that does not have any, it just keeps adding and duplicating it
- When a file is empty and then you add frontmatter plus content, only the frontmatter part appears

The former was caused by assuming the frontmatter text returned by obsidian included `---`, but it does not. This was fixed by adding those values in when adding frontmatter.

The latter was caused by the insert starting as part of the frontmatter and progressing on past that. Thus it got ignored as a change. To fix this, the added change must be checked against being more than just what the current frontmatter is. If it is, then it must be broken into the frontmatter versus everything else.

Changes Made:
- Updated logic to make sure `---` is added before and after the frontmatter when it is being added to a file that did not have it before
- Added logic to handle a partial insert (an insert that overlaps with the frontmatter, but adds more than that
- Made sure that when a change is made to current file it is slated as part of files to lint after the metadata cache updates