### PR TITLE
Feat: Add Ability to Specify Alias Helper Key for `YAML Title Alias`

### DIFF
--- a/docs/additional-info/rules/yaml-title-alias.md
+++ b/docs/additional-info/rules/yaml-title-alias.md
@@ -1,0 +1,2 @@
+!!! Note
+    An empty `Alias Helper Key` will be treated as if you are using `linter-yaml-title-alias` as the value.

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -788,8 +788,12 @@ export default {
         'description': 'Such aliases are usually redundant',
       },
       'use-yaml-key-to-keep-track-of-old-filename-or-heading': {
-        'name': 'Use the YAML key `linter-yaml-title-alias` to help with filename and heading changes',
+        'name': 'Use the YAML key specified by `Alias Helper Key` to help with filename and heading changes',
         'description': 'If set, when the first H1 heading changes or filename if first H1 is not present changes, then the old alias stored in this key will be replaced with the new value instead of just inserting a new entry in the aliases array',
+      },
+      'alias-helper-key': {
+        'name': 'Alias Helper Key',
+        'description': 'The key to use to help keep track of what the last file name or heading was that was stored in the frontmatter by this rule.',
       },
     },
     // yaml-title.ts

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -631,8 +631,12 @@ export default {
         'description': 'Estos alias suelen ser redundantes.',
       },
       'use-yaml-key-to-keep-track-of-old-filename-or-heading': {
-        'name': 'Use la clave de YAML `linter-yaml-title-alias` para ayudar con los cambios de nombre de archivo y encabezado',
+        'name': 'Use la clave de YAML especificado por `Clave auxiliar de alias` para ayudar con los cambios de nombre de archivo y encabezado',
         'description': 'Si se establece, cuando cambia el primer encabezado H1 o cambia el nombre de archivo si el primer H1 no está presente, el alias anterior almacenado en esta clave se reemplazará con el nuevo valor en lugar de simplemente insertar una nueva entrada en la matriz de alias.',
+      },
+      'alias-helper-key': {
+        'name': 'Clave auxiliar de alias',
+        'description': 'La clave que se debe utilizar para ayudar a realizar un seguimiento de cuál fue el último nombre de archivo o encabezado que esta regla almacenó en el frontmatter.',
       },
     },
     'yaml-title': {

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
-import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase, TextOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
-import {convertAliasValueToStringOrStringArray, escapeStringIfNecessaryAndPossible, formatYamlArrayValue, getYamlSectionValue, initYAML, LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEYS, OBSIDIAN_ALIAS_KEY_PLURAL, QuoteCharacter, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray, isValueEscapedAlready} from '../utils/yaml';
+import {convertAliasValueToStringOrStringArray, escapeStringIfNecessaryAndPossible, formatYamlArrayValue, getYamlSectionValue, initYAML, DEFAULT_LINTER_ALIASES_HELPER_KEY, loadYAML, NormalArrayFormats, OBSIDIAN_ALIASES_KEYS, OBSIDIAN_ALIAS_KEY_PLURAL, QuoteCharacter, removeYamlSection, setYamlSection, SpecialArrayFormats, splitValueIfSingleOrMultilineArray, isValueEscapedAlready} from '../utils/yaml';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {getFirstHeaderOneText, yamlRegex} from '../utils/regex';
 import {isNumeric} from '../utils/strings';
@@ -10,6 +10,7 @@ class YamlTitleAliasOptions implements Options {
   preserveExistingAliasesSectionStyle?: boolean = true;
   keepAliasThatMatchesTheFilename?: boolean = false;
   useYamlKeyToKeepTrackOfOldFilenameOrHeading?: boolean = true;
+  aliasHelperKey?: string = DEFAULT_LINTER_ALIASES_HELPER_KEY;
 
   @RuleBuilder.noSettingControl()
     aliasArrayStyle?: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.MultiLine;
@@ -48,7 +49,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     let newYaml = yaml.replace('---\n', '').replace('\n---', '');
     const parsedYaml = loadYAML(yaml);
 
-    previousTitle = parsedYaml[LINTER_ALIASES_HELPER_KEY] ?? null;
+    previousTitle = parsedYaml[options.aliasHelperKey] ?? null;
     if (previousTitle != null) {
       // force previousTitle to be a string by concatenating with an empty string to make non-strings like numbers get handled correctly
       previousTitle = previousTitle + '';
@@ -101,9 +102,9 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     }
 
     if (!options.useYamlKeyToKeepTrackOfOldFilenameOrHeading || shouldRemoveTitleAlias) {
-      newYaml = removeYamlSection(newYaml, LINTER_ALIASES_HELPER_KEY);
+      newYaml = removeYamlSection(newYaml, options.aliasHelperKey);
     } else {
-      newYaml = setYamlSection(newYaml, LINTER_ALIASES_HELPER_KEY, ` ${title}`);
+      newYaml = setYamlSection(newYaml, options.aliasHelperKey, ` ${title}`);
     }
 
     text = text.replace(`---\n${yaml}---`, `---\n${newYaml}---`);
@@ -277,8 +278,27 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
         options: {
           aliasArrayStyle: NormalArrayFormats.MultiLine,
         },
-      },
-      ),
+      }),
+      new ExampleBuilder({ // accounts for https://github.com/platers/obsidian-linter/issues/1044
+        description: 'Using `title` as `Alias Helper Key` sets the value of `title` to the alias.',
+        before: dedent`
+          ${''}
+        `,
+        after: dedent`
+          ---
+          aliases:
+            - Filename
+          title: Filename
+          ---
+          ${''}
+        `,
+        options: {
+          fileName: 'Filename',
+          keepAliasThatMatchesTheFilename: true,
+          aliasArrayStyle: NormalArrayFormats.MultiLine,
+          aliasHelperKey: 'title',
+        },
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<YamlTitleAliasOptions>[] {
@@ -300,6 +320,12 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
         nameKey: 'rules.yaml-title-alias.use-yaml-key-to-keep-track-of-old-filename-or-heading.name',
         descriptionKey: 'rules.yaml-title-alias.use-yaml-key-to-keep-track-of-old-filename-or-heading.description',
         optionsKey: 'useYamlKeyToKeepTrackOfOldFilenameOrHeading',
+      }),
+      new TextOptionBuilder({
+        OptionsClass: YamlTitleAliasOptions,
+        nameKey: 'rules.yaml-title-alias.alias-helper-key.name',
+        descriptionKey: 'rules.yaml-title-alias.alias-helper-key.description',
+        optionsKey: 'aliasHelperKey',
       }),
     ];
   }

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -48,8 +48,12 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
 
     let newYaml = yaml.replace('---\n', '').replace('\n---', '');
     const parsedYaml = loadYAML(yaml);
+    let aliasHelperKey = options.aliasHelperKey ?? DEFAULT_LINTER_ALIASES_HELPER_KEY;
+    if (aliasHelperKey.endsWith(':')) {
+      aliasHelperKey = aliasHelperKey.substring(0, aliasHelperKey.length - 1);
+    }
 
-    previousTitle = parsedYaml[options.aliasHelperKey] ?? null;
+    previousTitle = parsedYaml[aliasHelperKey] ?? null;
     if (previousTitle != null) {
       // force previousTitle to be a string by concatenating with an empty string to make non-strings like numbers get handled correctly
       previousTitle = previousTitle + '';
@@ -102,9 +106,9 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
     }
 
     if (!options.useYamlKeyToKeepTrackOfOldFilenameOrHeading || shouldRemoveTitleAlias) {
-      newYaml = removeYamlSection(newYaml, options.aliasHelperKey);
+      newYaml = removeYamlSection(newYaml, aliasHelperKey);
     } else {
-      newYaml = setYamlSection(newYaml, options.aliasHelperKey, ` ${title}`);
+      newYaml = setYamlSection(newYaml, aliasHelperKey, ` ${title}`);
     }
 
     text = text.replace(`---\n${yaml}---`, `---\n${newYaml}---`);

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -10,7 +10,7 @@ export const OBSIDIAN_TAG_KEYS = [OBSIDIAN_TAG_KEY_SINGULAR, OBSIDIAN_TAG_KEY_PL
 export const OBSIDIAN_ALIAS_KEY_SINGULAR = 'alias';
 export const OBSIDIAN_ALIAS_KEY_PLURAL = 'aliases';
 export const OBSIDIAN_ALIASES_KEYS = [OBSIDIAN_ALIAS_KEY_SINGULAR, OBSIDIAN_ALIAS_KEY_PLURAL];
-export const LINTER_ALIASES_HELPER_KEY = 'linter-yaml-title-alias';
+export const DEFAULT_LINTER_ALIASES_HELPER_KEY = 'linter-yaml-title-alias';
 export const DISABLED_RULES_KEY = 'disabled rules';
 
 /**


### PR DESCRIPTION
Fixes #1044 
Fixes #561 

There were a couple of requests to make the place that the `YAML Title Alias` stores its helper data to determine what to do about the alias in a user defined location. So I went ahead and added it after all of this time.

Changes Made:
- Updated wording in Spanish and English translations for what shows up in the UI to include info about the new option
- Added a note to the additional info to mention the default for the new option when nothing is specified
- Added an example for the scenario in question where the value for the alias helper key is `title`
- Added logic to swap out the variable usage from the original hardcoded value to a user specified value with the ending colon trimmed if present or the original hard coded value if it is empty