### PR TITLE
Fix: `Blockquote Style` Removes Spaces in Code Blocks

### DIFF
--- a/__tests__/blockquote-style.test.ts
+++ b/__tests__/blockquote-style.test.ts
@@ -34,7 +34,7 @@ ruleTest({
       before: dedent`
         >   Text here
         >     >           More Text Here
-        > \t > \t\t\t >Some More Text
+        > \t > \t >Some More Text
         >>>>\tJust a Tab
       `,
       after: dedent`
@@ -80,8 +80,8 @@ ruleTest({
         >   2) Ordered item 2
         >   - [ ] Checklist item
         >- List item 4
-        > >  >   \t > - List item 5
-        > >  >   \t > > - List item 6
+        > >  > \t > - List item 5
+        > >  > \t > > - List item 6
       `,
       after: dedent`
         >Text here
@@ -96,6 +96,30 @@ ruleTest({
         >>>>> - List item 6
       `,
       options: {style: 'no space'},
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1055
+      testName: 'Code blocks in a blockquote should not have their spacing affected since that can remove indentation for code',
+      before: dedent`
+        > Example blockquote
+        >Wrongly indented line
+        > 
+        >\`\`\`javascript
+        > function greet() {
+        >     console.log("Hello mom!")
+        > }
+        > \`\`\`
+      `,
+      after: dedent`
+        > Example blockquote
+        > Wrongly indented line
+        > 
+        > \`\`\`javascript
+        > function greet() {
+        >     console.log("Hello mom!")
+        > }
+        > \`\`\`
+      `,
+      options: {style: 'space'},
     },
   ],
 });

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -20,7 +20,7 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
       descriptionKey: 'rules.blockquote-style.description',
       type: RuleType.CONTENT,
       hasSpecialExecutionOrder: true, // to make sure we run after the other rules to make sure all blockquotes are affected and follow the same style
-      ruleIgnoreTypes: [IgnoreTypes.html],
+      ruleIgnoreTypes: [IgnoreTypes.html, IgnoreTypes.code],
     });
   }
   get OptionsClass(): new () => BlockquoteStyleOptions {


### PR DESCRIPTION
Fixes #1055 

There was an issue where `Blockquote Style` was removing spaces in a code block if it was in a blockquote. This can mess up code formatting. So to fix this, we will ignore code blocks from the `Blockquote Style` rule.

Changes Made:
- Cleaned up tests to no longer have indentation based code blocks in it
- Added a UT for the scenario in question
- Added code blocks to the ignore list for blockquote style