### PR TITLE
Fix: Custom Commands Can Attempt to Run When No Custom Commands Are Valid

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ export default class LinterPlugin extends Plugin {
   private rulesRunner = new RulesRunner();
   private lastActiveFile: TFile;
   private overridePaste: boolean = false;
+  private hasCustomCommands: boolean = false;
   private customCommandsLock = new AsyncLock();
   private originalSaveCallback?: () => void = null;
   // The amount of files you can use editor lint on at once is pretty small, so we will use an array
@@ -126,11 +127,13 @@ export default class LinterPlugin extends Plugin {
     }
 
     this.updatePasteOverrideStatus();
+    this.updateHasCustomCommandStatus();
   }
 
   async saveSettings() {
     await this.saveData(this.settings);
     this.updatePasteOverrideStatus();
+    this.updateHasCustomCommandStatus();
   }
 
   addCommands() {
@@ -678,7 +681,7 @@ export default class LinterPlugin extends Plugin {
   }
 
   private async runCustomCommandsInSidebar(file: TFile) {
-    if (!this.settings.lintCommands || this.settings.lintCommands.length == 0) {
+    if (!this.settings.lintCommands || this.settings.lintCommands.length == 0 || !this.hasCustomCommands) {
       return;
     }
 
@@ -703,7 +706,7 @@ export default class LinterPlugin extends Plugin {
   }
 
   private async runCustomCommands(file: TFile) {
-    if (!this.settings.lintCommands || this.settings.lintCommands.length == 0) {
+    if (!this.settings.lintCommands || this.settings.lintCommands.length == 0 || !this.hasCustomCommands) {
       return;
     }
 
@@ -821,6 +824,17 @@ export default class LinterPlugin extends Plugin {
     }
 
     this.overridePaste = false;
+  }
+
+  private updateHasCustomCommandStatus() {
+    for (const customCommand of this.settings.lintCommands) {
+      if (customCommand.id && customCommand.id.trim() != '') {
+        this.hasCustomCommands = true;
+        return;
+      }
+    }
+
+    this.hasCustomCommands = false;
   }
 
   private endOfDocument(doc: string) {


### PR DESCRIPTION
Fixes #1060 

There is an issue where if you have 1 or more custom commands and all of them are invalid, then custom commands will try to run. This is not valid as there is no need to run the custom commands at all. This has caused at least 2 issues to be reported (the other happened on mobile #991 ). Adding some logic to determine if any valid custom commands exist should help users avoid experiencing some confusion around this happening.