### PR TITLE
Fix: Make Sure Tags Do Not Have "`" in Them

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -298,7 +298,7 @@ ruleTest({
       },
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/1068
-      testName: 'Make sure that "`" is not valid in a header',
+      testName: 'Make sure that "`" is not valid in a tag',
       before: dedent`
         ---
         title: Note

--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -297,5 +297,31 @@ ruleTest({
         tagArrayStyle: TagSpecificArrayFormats.SingleStringSpaceDelimited,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1068
+      testName: 'Make sure that "`" is not valid in a header',
+      before: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: [text, val2]
+        ---
+        ${''}
+        #\`
+      `,
+      after: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: [text, val2]
+        ---
+        ${''}
+        #\`
+      `,
+      options: {
+        tagArrayStyle: NormalArrayFormats.SingleLine,
+      },
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -13,7 +13,7 @@ export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeB
 export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|]+))?\]{2}/g;
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
-export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+{\]]+)/g;
+export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+{`\]]+)/g;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 export const ellipsisRegex = /(\. ?){2}\./g;


### PR DESCRIPTION
Fixes #1068 

There was a report that in a specific instance there was an issue where pasting content was causing issues when it was linted. I looked into it and found that the problem was that we were allowing "`" to be a tag character. Adding it to the values to ignore for a tag fixes the problem.

Changes Made:
- Added a test for this scenario
- Added "`" to the list of characters to not allow in a tag