### PR TITLE
Feat: Customize CJK English Spacing

### DIFF
--- a/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
+++ b/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
@@ -122,5 +122,18 @@ ruleTest({
         ![[流浪地球-1.webp|image title|600]]
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1036
+      testName: 'A dash can be removed from the characters to add space around for before and after CJK characters.',
+      before: dedent`
+        你好-世界
+      `,
+      after: dedent`
+        你好-世界
+      `,
+      options: {
+        englishNonLetterCharactersAfterCJKCharacters: `+'"([¥$`,
+        englishNonLetterCharactersBeforeCJKCharacters: `+;:'"°%$)]`,
+      },
+    },
   ],
 });

--- a/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
+++ b/__tests__/space-between-chinese-japanese-or-korean-and-english-or-numbers.test.ts
@@ -135,5 +135,20 @@ ruleTest({
         englishNonLetterCharactersBeforeCJKCharacters: `+;:'"°%$)]`,
       },
     },
+    {
+      testName: 'Make sure that whitespace is removed from the value of punctuation or symbols and that an empty value does not cause issues',
+      before: dedent`
+        你好\t\t世界
+        this测试-还
+      `,
+      after: dedent`
+        你好\t\t世界
+        this 测试-还
+      `,
+      options: {
+        englishNonLetterCharactersAfterCJKCharacters: ``,
+        englishNonLetterCharactersBeforeCJKCharacters: ` \t`,
+      },
+    },
   ],
 });

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -696,6 +696,14 @@ export default {
     'space-between-chinese-japanese-or-korean-and-english-or-numbers': {
       'name': 'Space between Chinese Japanese or Korean and English or numbers',
       'description': 'Ensures that Chinese, Japanese, or Korean and English or numbers are separated by a single space. Follows these [guidelines](https://github.com/sparanoid/chinese-copywriting-guidelines)',
+      'english-symbols-punctuation-before': {
+        'name': 'English Punctuations and Symbols Before CJK',
+        'description': 'The list of non-letter punctuation and symbols to consider to be from English when found before Chinese, Japanese, or Korean characters. **Note: "*" is always considered to be English and is necessary for handling some markdown syntaxes properly.**',
+      },
+      'english-symbols-punctuation-after': {
+        'name': 'English Punctuations and Symbols After CJK',
+        'description': 'The list of non-letter punctuation and symbols to consider to be from English when found after Chinese, Japanese, or Korean characters. **Note: "*" is always considered to be English and is necessary for handling some markdown syntaxes properly.**',
+      },
     },
     // strong-style.ts
     'strong-style': {

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,6 +124,18 @@ export default class LinterPlugin extends Plugin {
       if (!this.settings.ruleConfigs[rule.alias]) {
         this.settings.ruleConfigs[rule.alias] = rule.getDefaultOptions();
       }
+
+      // remove this after a reasonable amount of time
+      if (rule.alias == 'space-between-chinese-japanese-or-korean-and-english-or-numbers') {
+        const defaults = rule.getDefaultOptions();
+        if (!('english-symbols-punctuation-before' in this.settings.ruleConfigs[rule.alias])) {
+          this.settings.ruleConfigs[rule.alias]['english-symbols-punctuation-before'] = defaults['english-symbols-punctuation-before'];
+        }
+
+        if (!('english-symbols-punctuation-after' in this.settings.ruleConfigs[rule.alias])) {
+          this.settings.ruleConfigs[rule.alias]['english-symbols-punctuation-after'] = defaults['english-symbols-punctuation-after'];
+        }
+      }
     }
 
     this.updatePasteOverrideStatus();

--- a/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
@@ -27,8 +27,8 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
       text: string,
       options: SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions,
   ): string {
-    const head = new RegExp(`(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})( *)(\\[[^[]*\\]\\(.*\\)|\`[^\`]*\`|\\w+|[${escapeRegExp(options.englishNonLetterCharactersAfterCJKCharacters)}]|\\*[^*])`, 'gmu');
-    const tail = new RegExp(`(\\[[^[]*\\]\\(.*\\)|\`[^\`]*\`|\\w+|[${escapeRegExp(options.englishNonLetterCharactersBeforeCJKCharacters)})\\]]|[^*]\\*)( *)(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})`, 'gmu');
+    const head = this.buildHeadRegex(options.englishNonLetterCharactersAfterCJKCharacters);
+    const tail = this.buildTailRegex(options.englishNonLetterCharactersBeforeCJKCharacters);
     // inline math, inline code, markdown links, and wiki links are an exception in that even though they are to be ignored we want to keep a space around these types when surrounded by CJK characters
     const regexEscapedIgnoreExceptionPlaceHolders = `${IgnoreTypes.link.placeholder}|${IgnoreTypes.inlineMath.placeholder}|${IgnoreTypes.inlineCode.placeholder}|${IgnoreTypes.wikiLink.placeholder}`.replaceAll('{', '\\{').replaceAll('}', '\\}');
     const ignoreExceptionsHead = new RegExp(`(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})( *)(${regexEscapedIgnoreExceptionPlaceHolders})`, 'gmu');
@@ -46,6 +46,32 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
     newText = updateBoldText(newText, addSpaceAroundChineseJapaneseKoreanAndEnglish);
 
     return newText;
+  }
+  buildHeadRegex(englishPunctuationAndSymbols: string): RegExp {
+    if (englishPunctuationAndSymbols && englishPunctuationAndSymbols !== '') {
+      // strip all whitespace
+      englishPunctuationAndSymbols =englishPunctuationAndSymbols.replaceAll(/\s/g, '');
+    }
+
+    let puncAndSymbolGroup = '';
+    if (englishPunctuationAndSymbols && englishPunctuationAndSymbols.length != 0) {
+      puncAndSymbolGroup = `|[${escapeRegExp(englishPunctuationAndSymbols)}]`;
+    }
+
+    return new RegExp(`(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})( *)(\\[[^[]*\\]\\(.*\\)|\`[^\`]*\`|\\w+${puncAndSymbolGroup}|\\*[^*])`, 'gmu');
+  }
+  buildTailRegex(englishPunctuationAndSymbols: string): RegExp {
+    if (englishPunctuationAndSymbols && englishPunctuationAndSymbols !== '') {
+      // strip all whitespace
+      englishPunctuationAndSymbols =englishPunctuationAndSymbols.replaceAll(/\s/g, '');
+    }
+
+    let puncAndSymbolGroup = '';
+    if (englishPunctuationAndSymbols && englishPunctuationAndSymbols.length != 0) {
+      puncAndSymbolGroup = `|[${escapeRegExp(englishPunctuationAndSymbols)}]`;
+    }
+
+    return new RegExp(`(\\[[^[]*\\]\\(.*\\)|\`[^\`]*\`|\\w+${puncAndSymbolGroup}|[^*]\\*)( *)(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})`, 'gmu');
   }
   get exampleBuilders(): ExampleBuilder<SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions>[] {
     return [

--- a/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
@@ -1,10 +1,14 @@
 import {Options, RuleType} from '../rules';
-import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
 import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {updateBoldText, updateItalicsText} from '../utils/mdast';
+import {escapeRegExp} from '../utils/regex';
 
-class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions implements Options {}
+class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions implements Options {
+  englishNonLetterCharactersAfterCJKCharacters?: string = `-+'"([¥$`;
+  englishNonLetterCharactersBeforeCJKCharacters?: string = `-+;:'"°%$)]`;
+}
 
 @RuleBuilder.register
 export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers extends RuleBuilder<SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions> {
@@ -23,8 +27,8 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
       text: string,
       options: SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions,
   ): string {
-    const head = /(\p{sc=Han}|\p{sc=Katakana}|\p{sc=Hiragana}|\p{sc=Hangul})( *)(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+'"([¥$]|\*[^*])/gmu;
-    const tail = /(\[[^[]*\]\(.*\)|`[^`]*`|\w+|[-+;:'"°%$)\]]|[^*]\*)( *)(\p{sc=Han}|\p{sc=Katakana}|\p{sc=Hiragana}|\p{sc=Hangul})/gmu;
+    const head = new RegExp(`(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})( *)(\\[[^[]*\\]\\(.*\\)|\`[^\`]*\`|\\w+|[${escapeRegExp(options.englishNonLetterCharactersAfterCJKCharacters)}]|\\*[^*])`, 'gmu');
+    const tail = new RegExp(`(\\[[^[]*\\]\\(.*\\)|\`[^\`]*\`|\\w+|[${escapeRegExp(options.englishNonLetterCharactersBeforeCJKCharacters)})\\]]|[^*]\\*)( *)(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})`, 'gmu');
     // inline math, inline code, markdown links, and wiki links are an exception in that even though they are to be ignored we want to keep a space around these types when surrounded by CJK characters
     const regexEscapedIgnoreExceptionPlaceHolders = `${IgnoreTypes.link.placeholder}|${IgnoreTypes.inlineMath.placeholder}|${IgnoreTypes.inlineCode.placeholder}|${IgnoreTypes.wikiLink.placeholder}`.replaceAll('{', '\\{').replaceAll('}', '\\}');
     const ignoreExceptionsHead = new RegExp(`(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})( *)(${regexEscapedIgnoreExceptionPlaceHolders})`, 'gmu');
@@ -139,6 +143,19 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
     ];
   }
   get optionBuilders(): OptionBuilderBase<SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions>[] {
-    return [];
+    return [
+      new TextOptionBuilder({
+        OptionsClass: SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions,
+        nameKey: 'rules.space-between-chinese-japanese-or-korean-and-english-or-numbers.english-symbols-punctuation-before.name',
+        descriptionKey: 'rules.space-between-chinese-japanese-or-korean-and-english-or-numbers.english-symbols-punctuation-before.description',
+        optionsKey: 'englishNonLetterCharactersBeforeCJKCharacters',
+      }),
+      new TextOptionBuilder({
+        OptionsClass: SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbersOptions,
+        nameKey: 'rules.space-between-chinese-japanese-or-korean-and-english-or-numbers.english-symbols-punctuation-after.name',
+        descriptionKey: 'rules.space-between-chinese-japanese-or-korean-and-english-or-numbers.english-symbols-punctuation-after.description',
+        optionsKey: 'englishNonLetterCharactersAfterCJKCharacters',
+      }),
+    ];
   }
 }


### PR DESCRIPTION
Fixes #1072 
Fixes #1036

There were a couple of requests to allow for some variation in how the CJK spacing rule picked up on which characters to consider to be English. It seems that "-" was one that several people were using as a non-English character even though it is not a fullwidth character. So as a compromise, the list of punctuation and symbols to consider English characters is being exposed in two options: before and after characters. This should make it more customizeable to the user's needs.

Changes Made:
- Added some tests for the scenarios mentioned
- Exposed the before and after English symbols and punctuation to users with the caveat that `*` is not exposed and will not be unless there is a really good reason to do so since it could cause issues with markdown formatting.
- Added the ability to fill out the default value onload if it is missing