### PR TITLE
Fix: YAML Timestamp Overwrites Created Date When Retention Set and Timezone in Format when Current Timezone Is Different

### DIFF
--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -102,7 +102,10 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
       textModified = true;
     } else if (keyWithValueFound) {
       const createdDateString = this.getYAMLTimestampString(text, created_match, options.dateCreatedKey);
-      if (options.forceRetentionOfCreatedValue) {
+
+      // @ts-expect-error
+      const actualFormat = parseFormat(createdDateString);
+      if (options.forceRetentionOfCreatedValue && options.format !== actualFormat) {
         const yamlCreatedDateTime = this.parseValueToCurrentFormatIfPossible(createdDateString, options.format, options.locale);
         if (yamlCreatedDateTime == null) {
           throw new Error(getTextInLanguage('logs.invalid-date-format-error').replace('{DATE}', createdDateString).replace('{FILE_NAME}', options.fileName));
@@ -117,7 +120,7 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
 
           textModified = true;
         }
-      } else {
+      } else if (!options.forceRetentionOfCreatedValue) {
         const createdDateTime = moment(createdDateString, options.format, options.locale, true);
         if (createdDateTime == undefined || !createdDateTime.isValid()) {
           text = text.replace(
@@ -178,7 +181,7 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
       return desiredFormatDate;
     }
 
-    // @ts-ignore
+    // @ts-expect-error
     const actualFormat = parseFormat(timestamp);
     if (actualFormat != undefined) {
       const date = moment(timestamp, actualFormat);


### PR DESCRIPTION
Fixes #1077 

There was a bug where if you met the following the conditions it would change the timezone of your created key for YAML Timestamp:
- Have a created date retention set
- Have a timezone indicator in the format
- Be in a different current timezone (DST counts) than when the original value was set

If you met these conditions, it would overwrite your original value for the create date.

Changes Made:
- If retention of created date is set, check if the actual and current formats are the same, if so, do nothing. Otherwise, see about making an update.
- Swapped from `ts-ignore` to `ts-expect-error` to just make it clearer that I am expecting an error when using the parse logic