### PR TITLE
Fix: `blockquote-style` Removes Spaces from List Item Code and Math Blocks

### DIFF
--- a/__tests__/blockquote-style.test.ts
+++ b/__tests__/blockquote-style.test.ts
@@ -102,7 +102,7 @@ ruleTest({
       before: dedent`
         > Example blockquote
         >Wrongly indented line
-        > 
+        >
         >\`\`\`javascript
         > function greet() {
         >     console.log("Hello mom!")
@@ -112,12 +112,68 @@ ruleTest({
       after: dedent`
         > Example blockquote
         > Wrongly indented line
-        > 
-        > \`\`\`javascript
+        > ${''}
+        >\`\`\`javascript
         > function greet() {
         >     console.log("Hello mom!")
         > }
         > \`\`\`
+      `,
+      options: {style: 'space'},
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1087
+      testName: 'Math blocks in a blockquote should not have their spacing affected since that can remove indentation for lists',
+      before: dedent`
+        >[!INFO] Linter sublist latex repro
+        > text
+        > - list item 1
+        >     $$
+        >     f = ma
+        >     $$
+        >     - sublist item 1
+        >         $$
+        >         y = ax + b
+        >         $$
+      `,
+      after: dedent`
+        > [!INFO] Linter sublist latex repro
+        > text
+        > - list item 1
+        >     $$
+        >     f = ma
+        >     $$
+        >     - sublist item 1
+        >         $$
+        >         y = ax + b
+        >         $$
+      `,
+      options: {style: 'space'},
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1087
+      testName: 'Code blocks in a blockquote should not have their spacing affected since that can remove indentation for lists',
+      before: dedent`
+        >[!INFO] Linter sublist code repro
+        > text
+        > - list item 1
+        >     \`\`\`
+        >     f = ma
+        >     \`\`\`
+        >     - sublist item 1
+        >         \`\`\`
+        >         y = ax + b
+        >         \`\`\`
+      `,
+      after: dedent`
+        > [!INFO] Linter sublist code repro
+        > text
+        > - list item 1
+        >     \`\`\`
+        >     f = ma
+        >     \`\`\`
+        >     - sublist item 1
+        >         \`\`\`
+        >         y = ax + b
+        >         \`\`\`
       `,
       options: {style: 'space'},
     },

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -20,7 +20,7 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
       descriptionKey: 'rules.blockquote-style.description',
       type: RuleType.CONTENT,
       hasSpecialExecutionOrder: true, // to make sure we run after the other rules to make sure all blockquotes are affected and follow the same style
-      ruleIgnoreTypes: [IgnoreTypes.html, IgnoreTypes.code],
+      ruleIgnoreTypes: [IgnoreTypes.html, IgnoreTypes.code, IgnoreTypes.math],
     });
   }
   get OptionsClass(): new () => BlockquoteStyleOptions {
@@ -79,8 +79,15 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
       }
 
       const restOfLine = newBlockquote.substring(startOfRestOfLine, endOfRestOfLine);
+      // we need to ignore code and math blocks to prevent changing values in the display
+      if (restOfLine.includes(IgnoreTypes.math.placeholder) || restOfLine.includes(IgnoreTypes.code.placeholder)) {
+        currentIndex++;
+        continue;
+      }
+
       const isListItemMarker = startsWithListMarkerRegex.test(restOfLine);
       updatedStartOfLine = startOfLineModification(startOfLine, isListItemMarker);
+
 
       // since start of index refers to where the new line character is
       startOfIndex++;


### PR DESCRIPTION
Fixes #1087 

There was a reported bug where running the Linter would remove whitespace from list item math blocks. It was found that this also affected code blocks. In order to fix this, `blockquote-style` now ignores code and math block lines in blockquotes.

Changes Made:
- Added UTs for the scenarios in question
- Fixed a broken UT since we could no longer support the way things were done previously
- Updated logic to ignore math and code blocks when in a blockquote