### PR TITLE
Fix: `yaml-title-alias` Does Not Respect Multiline Format when Initially Empty with Preserve Existing Format Used

### DIFF
--- a/__tests__/yaml-title-alias.test.ts
+++ b/__tests__/yaml-title-alias.test.ts
@@ -1391,5 +1391,28 @@ ruleTest({
         defaultEscapeCharacter: '"',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1085
+      testName: 'Make sure that if the aliases section is empty and the default format for arrays is multiline, then it should use multiline as the output',
+      before: dedent`
+        ---
+        aliases: []
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases:
+          - Filename
+        aliases2: Filename
+        ---
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.MultiLine,
+        defaultEscapeCharacter: '"',
+        preserveExistingAliasesSectionStyle: true,
+        aliasHelperKey: 'aliases2',
+        keepAliasThatMatchesTheFilename: true,
+        fileName: 'Filename',
+      },
+    },
   ],
 });

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -77,7 +77,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
       let currentAliasStyle: NormalArrayFormats | SpecialArrayFormats = NormalArrayFormats.MultiLine;
       const isEmpty = aliasesValue === '';
       let isSingleString = false;
-      if (!aliasesValue.includes('\n')) {
+      if (!aliasesValue.includes('\n') && !(aliasesValue === '[]' && options.aliasArrayStyle === NormalArrayFormats.MultiLine)) {
         if (aliasesValue.match(/^\[.*\]/) === null) {
           // Note that the value here is just really a placeholder to indicate it is not single-line or multi-line
           currentAliasStyle = SpecialArrayFormats.SingleStringToSingleLine;


### PR DESCRIPTION
Fixes #1085 

There was a reported issue where `yaml-title-alias` did not seem to be working when the aliases section was empty, default aliases section style was multiline, and the setting for preserving the style of the aliases section was set to true. The fix was to make sure that we assume that `[]` is not tied to any one type. So if that is the value for aliases and the default style for aliases is multiline, we will assume it is meant to be a multiline array.

Changes Made:
- Added a UT for the scenario in question
- Made sure to only consider the aliases section to be single line if there are no new lines in the values and the aliases value is not a blank yaml array with a default aliases section style of multiline