### PR TITLE
Feat: Add Ability to Ignore Files Via Regex

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -147,6 +147,16 @@ export default {
         'add-input-button-text': 'Add another folder to ignore',
         'delete-tooltip': 'Delete',
       },
+      'files-to-ignore': {
+        'name': 'Files to ignore',
+        'description': 'Files to ignore when linting all files or linting on save.',
+        'file-search-placeholder-text': 'regex for file to ignore',
+        'add-input-button-text': 'Add another file to ignore regex',
+        'delete-tooltip': 'Delete',
+        'label-placeholder-text': 'label',
+        'flags-placeholder-text': 'flags',
+        'warning': 'Use this with caution if you do not know regex. Also, please make sure that if you use lookbehinds in your regex on iOS mobile that you are on a version that supports using them.',
+      },
       'override-locale': {
         'name': 'Override locale',
         'description': 'Set this if you want to use a locale different from the default',
@@ -211,7 +221,7 @@ export default {
       // custom-replace-option.ts
       'name': 'Custom Regex Replacement',
       'description': 'Custom regex replacement can be used to replace anything that matches the find regex with the replacement value. The replace and find values will need to be valid regex values.',
-      'warning': 'Use this with caution if you do not know regex. Also, please make sure that you do not use lookbehinds in your regex on iOS mobile as that will cause linting to fail since that is not supported on that platform.',
+      'warning': 'Use this with caution if you do not know regex. Also, please make sure that if you use lookbehinds in your regex on iOS mobile that you are on a version that supports using them.',
       'add-input-button-text': 'Add new regex replacement',
       'regex-to-find-placeholder-text': 'regex to find',
       'flags-placeholder-text': 'flags',

--- a/src/main.ts
+++ b/src/main.ts
@@ -347,6 +347,18 @@ export default class LinterPlugin extends Plugin {
         return true;
       }
     }
+
+    for (const fileToIgnore of this.settings.filesToIgnore) {
+      if (!fileToIgnore.match) {
+        continue;
+      }
+
+      const fileNameRegex = new RegExp(`${fileToIgnore.match}`, fileToIgnore.flags);
+      if (fileNameRegex.test(file.path)) {
+        return true;
+      }
+    }
+
     return false;
   }
 

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -1,6 +1,7 @@
 import {Options} from './rules';
 import {LintCommand} from './ui/linter-components/custom-command-option';
 import {CustomReplace} from './ui/linter-components/custom-replace-option';
+import {FileToIgnore} from './ui/linter-components/files-to-ignore-option';
 import {NestedKeyOf} from './utils/nested-keyof';
 import {NormalArrayFormats, QuoteCharacter, SpecialArrayFormats, TagSpecificArrayFormats} from './utils/yaml';
 
@@ -24,6 +25,7 @@ export interface LinterSettings {
   lintOnFileChange: boolean,
   displayLintOnFileChangeNotice: boolean,
   foldersToIgnore: string[];
+  filesToIgnore: FileToIgnore[];
   linterLocale: string;
   logLevel: string;
   lintCommands: LintCommand[];
@@ -42,6 +44,7 @@ export const DEFAULT_SETTINGS: Partial<LinterSettings> = {
   displayLintOnFileChangeNotice: false,
   settingsConvertedToConfigKeyValues: false,
   foldersToIgnore: [],
+  filesToIgnore: [],
   linterLocale: 'system-default',
   logLevel: 'ERROR',
   lintCommands: [],

--- a/src/styles.css
+++ b/src/styles.css
@@ -185,7 +185,7 @@ textarea.full-width {
 /**
 * Custom regex replacement
 */
-.linter-custom-regex-replacement-container div:last-child{
+.linter-custom-regex-replacement-container div:last-child {
   border: none;
 }
 .linter-custom-regex-replacement {
@@ -208,6 +208,25 @@ textarea.full-width {
 }
 .linter-custom-regex-replacement-label-input {
   width: 50%;
+}
+
+/**
+* Files to ignore
+*/
+.linter-files-to-ignore-container div:last-child {
+  border: none;
+}
+.linter-files-to-ignore {
+  margin-bottom: 15px;
+  border: none;
+  border-bottom: var(--hr-thickness) solid;
+  border-color: var(--hr-color);
+}
+.linter-files-to-ignore-normal-input {
+  width: 40%;
+}
+.linter-files-to-ignore-flags {
+  width: 15%;
 }
 
 /**

--- a/src/ui/linter-components/files-to-ignore-option.ts
+++ b/src/ui/linter-components/files-to-ignore-option.ts
@@ -1,0 +1,76 @@
+import {Setting, Component} from 'obsidian';
+import {getTextInLanguage} from 'src/lang/helpers';
+import {AddCustomRow} from '../components/add-custom-row';
+export type FileToIgnore = {label: string, match: string, flags: string};
+
+const defaultFlags = 'i';
+
+export class FilesToIgnoreOption extends AddCustomRow {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public filesToIgnore: FileToIgnore[], saveSettings: () => void) {
+    super(
+        containerEl,
+        parentComponent,
+        getTextInLanguage('tabs.general.files-to-ignore.name'),
+        getTextInLanguage('tabs.general.files-to-ignore.description'),
+        getTextInLanguage('tabs.general.files-to-ignore.warning'),
+        getTextInLanguage('tabs.general.files-to-ignore.add-input-button-text'),
+        saveSettings,
+        ()=>{
+          const newRegex = {label: '', match: '', flags: defaultFlags};
+          this.filesToIgnore.push(newRegex);
+          this.saveSettings();
+          this.addFileToIgnore(newRegex, this.filesToIgnore.length - 1, true);
+        });
+    this.display();
+    this.inputElDiv.addClass('linter-files-to-ignore-container');
+  }
+
+  protected showInputEls(): void {
+    this.filesToIgnore.forEach((regex, index) => {
+      this.addFileToIgnore(regex, index);
+    });
+  }
+
+  private addFileToIgnore(regex: FileToIgnore, index: number, focusOnCommand: boolean = false) {
+    const newRegexDiv = this.inputElDiv.createDiv({cls: 'linter-files-to-ignore'});
+    new Setting(newRegexDiv).addText((cb) => {
+      cb.setPlaceholder(getTextInLanguage('tabs.general.files-to-ignore.label-placeholder-text'))
+          .setValue(regex.label)
+          .onChange((value) => {
+            this.filesToIgnore[index].label = value;
+            this.saveSettings();
+          });
+
+      cb.inputEl.addClass('linter-files-to-ignore-normal-input');
+      if (focusOnCommand) {
+        cb.inputEl.focus();
+      }
+    }).addText((cb) => {
+      cb.setPlaceholder(getTextInLanguage('tabs.general.files-to-ignore.file-search-placeholder-text'))
+          .setValue(regex.match)
+          .onChange((value) => {
+            this.filesToIgnore[index].match = value;
+            this.saveSettings();
+          });
+
+      cb.inputEl.addClass('linter-files-to-ignore-normal-input');
+    }).addText((cb) => {
+      cb.setPlaceholder(getTextInLanguage('tabs.general.files-to-ignore.flags-placeholder-text'))
+          .setValue(regex.flags)
+          .onChange((value) => {
+            this.filesToIgnore[index].flags = value;
+            this.saveSettings();
+          });
+
+      cb.inputEl.addClass('linter-files-to-ignore-flags');
+    }).addExtraButton((cb)=>{
+      cb.setIcon('cross')
+          .setTooltip(getTextInLanguage('tabs.general.files-to-ignore.delete-tooltip'))
+          .onClick(()=>{
+            this.filesToIgnore.splice(index, 1);
+            this.saveSettings();
+            this.resetInputEls();
+          });
+    });
+  }
+}

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -8,6 +8,7 @@ import {DropdownRecordInfo, DropdownSetting} from 'src/ui/components/dropdown-se
 import {NumberInputSetting} from 'src/ui/components/number-input-setting';
 import {ToggleSetting} from 'src/ui/components/toggle-setting';
 import {FolderIgnoreOption} from '../folder-ignore-option';
+import {FilesToIgnoreOption} from '../files-to-ignore-option';
 
 export class GeneralTab extends Tab {
   constructor(navEl: HTMLElement, settingsEl: HTMLElement, isMobile: boolean, plugin: LinterPlugin, private app: App) {
@@ -99,6 +100,14 @@ export class GeneralTab extends Tab {
     const folderIgnore = new FolderIgnoreOption(folderIgnoreEl, this.plugin.settingsTab.component, this.plugin.settings.foldersToIgnore, this.app, () => {
       this.plugin.saveSettings();
     });
+
     this.addSettingSearchInfo(folderIgnoreEl, folderIgnore.name, folderIgnore.description.replaceAll('\n', ' '));
+
+    const filesToIgnoreEl = this.contentEl.createDiv();
+    const filesToIgnore = new FilesToIgnoreOption(filesToIgnoreEl, this.plugin.settingsTab.component, this.plugin.settings.filesToIgnore, () => {
+      this.plugin.saveSettings();
+    });
+
+    this.addSettingSearchInfo(filesToIgnoreEl, filesToIgnore.name, filesToIgnore.description.replaceAll('\n', ' '));
   }
 }


### PR DESCRIPTION
Fixes #1000 

There is a desire for being able to ignore files based on a regex match. This regex will affect the path and is just a simple regex match comparison.

Changes Made:
- Updated wording around iOS mobile
- Added component and wording for files to ignore