### PR TITLE
Fix: Ignore Images for `Quote Style`

### DIFF
--- a/__tests__/quote-style.test.ts
+++ b/__tests__/quote-style.test.ts
@@ -123,5 +123,17 @@ ruleTest({
         singleQuoteStyle: SingleQuoteStyles.SmartQuote,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1109
+      testName: 'Make sure quotes in markdown image links get ignored',
+      before: dedent`
+        ![link](https://test.it 'Test title')
+      `,
+      after: dedent`
+        ![link](https://test.it 'Test title')
+      `,
+      options: {
+        singleQuoteStyle: SingleQuoteStyles.SmartQuote,
+      },
+    },
   ],
 });

--- a/src/rules/quote-style.ts
+++ b/src/rules/quote-style.ts
@@ -29,7 +29,7 @@ export default class QuoteStyle extends RuleBuilder<QuoteStyleOptions> {
       nameKey: 'rules.quote-style.name',
       descriptionKey: 'rules.quote-style.description',
       type: RuleType.CONTENT,
-      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.templaterCommand],
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.inlineCode, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.math, IgnoreTypes.inlineMath, IgnoreTypes.html, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.templaterCommand, IgnoreTypes.image],
     });
   }
   get OptionsClass(): new () => QuoteStyleOptions {


### PR DESCRIPTION
Fixes #1109 

There was an issue where `Quote Style` could affect the link to an image if it contained quotes. To prevent this, we will ignore images.

Changes Made:
- Added a UT for the situation in question
- Added images to the ignore list for `Quote Style`