### PR TITLE
fix: footnote-after-punctuation containing hyphen

### DIFF
--- a/__tests__/footnote-after-punctuation.test.ts
+++ b/__tests__/footnote-after-punctuation.test.ts
@@ -1,11 +1,11 @@
 import dedent from 'ts-dedent';
 import FootnoteAfterPunctuation from '../src/rules/footnote-after-punctuation';
-import { ruleTest } from './common';
+import {ruleTest} from './common';
 
 ruleTest({
   RuleBuilderClass: FootnoteAfterPunctuation,
   testCases: [
-        { // fixes https://github.com/platers/obsidian-linter/issues/1112
+    { // fixes https://github.com/platers/obsidian-linter/issues/1112
       testName: 'Simple case',
       before: dedent`
         Some text[^test-me].
@@ -18,5 +18,5 @@ ruleTest({
         Some text.[^test]
       `,
     },
-],
+  ],
 });

--- a/__tests__/footnote-after-punctuation.test.ts
+++ b/__tests__/footnote-after-punctuation.test.ts
@@ -1,0 +1,22 @@
+import dedent from 'ts-dedent';
+import FootnoteAfterPunctuation from '../src/rules/footnote-after-punctuation';
+import { ruleTest } from './common';
+
+ruleTest({
+  RuleBuilderClass: FootnoteAfterPunctuation,
+  testCases: [
+        { // fixes https://github.com/platers/obsidian-linter/issues/1112
+      testName: 'Simple case',
+      before: dedent`
+        Some text[^test-me].
+        Some text[^test.me].
+        Some text[^test].
+      `,
+      after: dedent`
+        Some text.[^test-me]
+        Some text.[^test.me]
+        Some text.[^test]
+      `,
+    },
+],
+});

--- a/src/rules/footnote-after-punctuation.ts
+++ b/src/rules/footnote-after-punctuation.ts
@@ -19,7 +19,9 @@ export default class FootnoteAfterPunctuation extends RuleBuilder<FootnoteAfterP
     return FootnoteAfterPunctuationOptions;
   }
   apply(text: string, options: FootnoteAfterPunctuationOptions): string {
-    return text.replace(/(\[\^\w+\]) ?([,.;!:?])/gm, '$2$1');
+    // Matches a footnote reference containing any text except newlines and the
+    // terminating ].
+    return text.replace(/(\[\^[^\]]+\]) ?([,.;!:?])/gm, '$2$1');
   }
   get exampleBuilders(): ExampleBuilder<FootnoteAfterPunctuationOptions>[] {
     return [


### PR DESCRIPTION
This allows symbols to appear in footnote references without breaking the `footnote-after-punctuation` lint.

The old regex used `\w` so it only matched references that consisted of words, digits and whitespaces - I swapped it to accept anything except newlines and the reference terminating `]` character, so now it accepts all symbols too.

I'm not sure how to include tests for this but I'm happy to if you can point me in the right direction :+1:

Fixes https://github.com/platers/obsidian-linter/issues/1112.

---

* fix: footnote-after-punctuation containing hyphen (10b7dac)
      
      Fixes the footnote-after-punctuation rewriting for footnote references
      that contain hyphens (or other symbols):
      
        * Bananas[^test].
        * Bananas[^test-me].
        * Bananas[^test.2].
      
      Is now rewrote to:
      
        * Bananas.[^test]
        * Bananas.[^test-me]   <-- fixed
        * Bananas.[^test.2]    <-- fixed
      
      Fixes https://github.com/platers/obsidian-linter/issues/1112.