### PR TITLE
Fix: Blockquotes Joined When Code Block Ends/Starts Two Same Level Blockquotes

### DIFF
--- a/__tests__/empty-line-around-code-fences.test.ts
+++ b/__tests__/empty-line-around-code-fences.test.ts
@@ -144,5 +144,30 @@ ruleTest({
         > > \`\`\`
       `,
     },
+    { // fixes https://github.com/platers/obsidian-linter/issues/1074
+      testName: 'Make sure that a nested callout with a code block does not get joined together',
+      before: dedent`
+        > [!multi-column]
+        >
+        > > \`\`\`
+        > > some query or basic code-block
+        > > \`\`\`
+        >
+        > > \`\`\`
+        > > another query or basic code-block
+        > > \`\`\`
+      `,
+      after: dedent`
+        > [!multi-column]
+        >
+        > > \`\`\`
+        > > some query or basic code-block
+        > > \`\`\`
+        >
+        > > \`\`\`
+        > > another query or basic code-block
+        > > \`\`\`
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -616,7 +616,7 @@ export function ensureEmptyLinesAroundFencedCodeBlocks(text: string): string {
 
   for (const position of positions) {
     const codeBlock = text.substring(position.start.offset, position.end.offset);
-    if (!codeBlock.startsWith('```')) {
+    if (!codeBlock.startsWith('```') && ! codeBlock.startsWith(`~~~`)) {
       continue;
     }
 

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -49,6 +49,7 @@ export const startsWithListMarkerRegex = new RegExp(`^\\s*(-|\\*|\\+|\\d+[.)]|- 
 
 export const footnoteDefinitionIndicatorAtStartOfLine = /^(\[\^[^\]]*\]) ?([,.;!:?])/gm;
 export const calloutRegex = /^(>\s*)+\[![^\s]*\]/m;
+export const codeBlockBlockquoteRegex = /^\n?(>\s*)+((```)|(~~~))/m;
 
 export const unicodeLetterRegex = RegExp(/\p{L}/, 'u');
 


### PR DESCRIPTION
Fixes #1074 

There was a scenario where if a blockquote was next to another one, it was getting joined if there was a table in it. This was not desired and could cause funky results, so it has been updated to not do this where possible.

Changse Made:
- Added tests for the scenarios in question
- Updated the logic to make sure a blockquote which starts or ends in a code block is not joined with the next blockqoute