### PR TITLE
Fix: Update Tag Regex to Better Conform to Specified Obsidian Tag Spec

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -323,5 +323,31 @@ ruleTest({
         tagArrayStyle: NormalArrayFormats.SingleLine,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1116
+      testName: 'Make sure that ":" is not valid in a tag',
+      before: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: [text, val2]
+        ---
+        ${''}
+        #text:
+      `,
+      after: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: [text, val2]
+        ---
+        :
+      `,
+      options: {
+        tagArrayStyle: NormalArrayFormats.SingleLine,
+        howToHandleExistingTags: 'Remove whole tag',
+      },
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -13,6 +13,7 @@ export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeB
 export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|]+))?\]{2}/g;
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
+// based on https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format
 export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[\p{L}\-_\d/]+)/gu;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -13,7 +13,7 @@ export const codeBlockRegex = new RegExp(`${backtickBlockRegexTemplate}|${tildeB
 export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|]+))?\]{2}/g;
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
-export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[^\s#;.,><?!=+{`\]]+)/g;
+export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[\p{L}\-_\d/]+)/gu;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 export const ellipsisRegex = /(\. ?){2}\./g;


### PR DESCRIPTION
Fixes #1116 

There was an issue where several things were being allowed when they should not have been in the tag regex.

[Here](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format) is the spec.

It says:

You can use any of the following characters in your tags:

- Alphabetical letters
- Numbers
- Underscore (_)
- Hyphen (-)
- Forward slash (/) for [Nested tags](https://help.obsidian.md/Editing+and+formatting/Tags#Nested%20tags)

Changes Made:
- Updated regex to conform better with the spec
- Added a test for the scenario in question
