### PR TITLE
Fix: Live Preview YAML Update Occasional Breaks Frontmatter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -505,7 +505,7 @@ export default class LinterPlugin extends Plugin {
       isBeforeStartIndex = curText.length < startingIndex;
       if (isBeforeStartIndex && curText.length + value.length >= startingIndex && type == DiffMatchPatch.DIFF_INSERT) {
         const valueIndexStart = startingIndex - curText.length;
-        curText = value.substring(0, valueIndexStart);
+        curText += value.substring(0, valueIndexStart);
         value = value.substring(valueIndexStart);
         isBeforeStartIndex = false;
       }


### PR DESCRIPTION
Fixes #1125 

There was an issue where occasionally the update would overlap with the edge of frontmatter. The current text was not properly updated so the insert hit the wrong part of the file. The incorrect update location broke the live preview display since it updated the wrong place.

Changes Made:
- Append text after the frontmatter to to current text instead of just setting the text which causes the wrong update location to be set