### PR TITLE
Fix: capitalize-headings, yaml-title, yaml-title-alias require two lint passes to resolve

### DIFF
--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -21,6 +21,7 @@ import {LintCommand} from './ui/linter-components/custom-command-option';
 import {convertStringVersionOfEscapeCharactersToEscapeCharacters} from './utils/strings';
 import {getTextInLanguage} from './lang/helpers';
 import CapitalizeHeadings from './rules/capitalize-headings';
+import YamlTitle from './rules/yaml-title';
 import BlockquoteStyle from './rules/blockquote-style';
 import {IgnoreTypes, ignoreListOfTypes} from './utils/ignore-types';
 import MoveMathBlockIndicatorsToOwnLine from './rules/move-math-block-indicators-to-own-line';
@@ -115,6 +116,11 @@ export class RulesRunner {
     const postRuleLogText = getTextInLanguage('logs.post-rules');
     timingBegin(postRuleLogText);
     [newText] = CapitalizeHeadings.applyIfEnabled(newText, runOptions.settings, this.disabledRules);
+
+    [newText] = YamlTitle.applyIfEnabled(newText, runOptions.settings, this.disabledRules, {
+      fileName: runOptions.fileInfo.name,
+      defaultEscapeCharacter: runOptions.settings.commonStyles.escapeCharacter,
+    });
 
     [newText] = BlockquoteStyle.applyIfEnabled(newText, runOptions.settings, this.disabledRules);
 

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -22,6 +22,7 @@ import {convertStringVersionOfEscapeCharactersToEscapeCharacters} from './utils/
 import {getTextInLanguage} from './lang/helpers';
 import CapitalizeHeadings from './rules/capitalize-headings';
 import YamlTitle from './rules/yaml-title';
+import YamlTitleAlias from './rules/yaml-title-alias';
 import BlockquoteStyle from './rules/blockquote-style';
 import {IgnoreTypes, ignoreListOfTypes} from './utils/ignore-types';
 import MoveMathBlockIndicatorsToOwnLine from './rules/move-math-block-indicators-to-own-line';
@@ -120,6 +121,13 @@ export class RulesRunner {
     [newText] = YamlTitle.applyIfEnabled(newText, runOptions.settings, this.disabledRules, {
       fileName: runOptions.fileInfo.name,
       defaultEscapeCharacter: runOptions.settings.commonStyles.escapeCharacter,
+    });
+
+    [newText] = YamlTitleAlias.applyIfEnabled(newText, runOptions.settings, this.disabledRules, {
+      fileName: runOptions.fileInfo.name,
+      aliasArrayStyle: runOptions.settings.commonStyles.aliasArrayStyle,
+      defaultEscapeCharacter: runOptions.settings.commonStyles.escapeCharacter,
+      removeUnnecessaryEscapeCharsForMultiLineArrays: runOptions.settings.commonStyles.removeUnnecessaryEscapeCharsForMultiLineArrays,
     });
 
     [newText] = BlockquoteStyle.applyIfEnabled(newText, runOptions.settings, this.disabledRules);

--- a/src/rules/yaml-title-alias.ts
+++ b/src/rules/yaml-title-alias.ts
@@ -32,6 +32,7 @@ export default class YamlTitleAlias extends RuleBuilder<YamlTitleAliasOptions> {
       nameKey: 'rules.yaml-title-alias.name',
       descriptionKey: 'rules.yaml-title-alias.description',
       type: RuleType.YAML,
+      hasSpecialExecutionOrder: true, // this rule must run after capitalize-headings in order to update the alias correctly
     });
   }
   get OptionsClass(): new () => YamlTitleAliasOptions {

--- a/src/rules/yaml-title.ts
+++ b/src/rules/yaml-title.ts
@@ -27,6 +27,7 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
       nameKey: 'rules.yaml-title.name',
       descriptionKey: 'rules.yaml-title.description',
       type: RuleType.YAML,
+      hasSpecialExecutionOrder: true, // this rule must run after capitalize-headings in order to update the title correctly
     });
   }
   get OptionsClass(): new () => YamlTitleOptions {


### PR DESCRIPTION
Fixes #1130 

I moved the yaml-title and yaml-title-alias rules to the runAfterRegularRules method. They immediately follow the capitalize-headings rule.