### PR TITLE
Fix: Tags Regex Not Allowing Emojis

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -349,5 +349,40 @@ ruleTest({
         howToHandleExistingTags: 'Remove whole tag',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1138
+      testName: 'Make sure that emojis are properly handled as part of the tag',
+      before: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: [text, val2]
+        ---
+        ${''}
+        Regular emoji only: #🦾
+        Emoji at end: #test-🦾
+        Emoji in the middle: #test-🦾-test
+        Emoji at the start: #🦾-test
+        Nested emoji: #test/🦾-blob
+      `,
+      after: dedent`
+        ---
+        title: Note
+        Date: 2023-10-24T23:00:00+08:00
+        lastMod: 2023-11-28T17:36:29+08:00
+        tags: [text, val2, 🦾, test-🦾, test-🦾-test, 🦾-test, test/🦾-blob]
+        ---
+        ${''}
+        Regular emoji only:
+        Emoji at end:
+        Emoji in the middle:
+        Emoji at the start:
+        Nested emoji:
+      `,
+      options: {
+        tagArrayStyle: NormalArrayFormats.SingleLine,
+        howToHandleExistingTags: 'Remove whole tag',
+      },
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -14,7 +14,7 @@ export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
 // based on https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format
-export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[\p{L}\-_\d/]+)/gu;
+export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[\p{L}\-_\d/\p{Emoji_Presentation}]+)/gu;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 export const ellipsisRegex = /(\. ?){2}\./g;


### PR DESCRIPTION
Fixes #1138 

There was an issue when I updated the tag regex to be more in line with what is defined on Obsidian's website that caused emojis to not be matched as tags. So if there was a tag that had the emoji in it, it would not get affected by the tag related rules or it would only partially be affected because it would stop matching at the emoji.

This should be fixed by this change which has UTs that should match the scenarios in question from my understanding.

Changes Made:
- UT added to make sure that emojis are considered a part of the tags now
- Added emoji unicode match to the list of possible values in the tag regex