### PR TITLE
Cleanup: Remove Examples from Plugin Build and Fix Load Bug for Custom Replacements

### DIFF
--- a/docs/additional-info/rules/auto-correct-common-misspellings.md
+++ b/docs/additional-info/rules/auto-correct-common-misspellings.md
@@ -26,7 +26,7 @@ The following is a table with custom misspellings:
 ##### Current Limitations
 
 
-- The list of custom replacements is only loaded when the plugin initially loads or when the file is added to the list of files that include custom misspellings
+- The list of custom replacements is only loaded when the plugin first lints a file or when the file is added to the list of files that include custom misspellings
     * This means that making a change to a file that is already in the list of custom misspelling files will not work unless the Linter is reloaded or the file is removed and re-added to the list of custom misspelling files
 - There is no way to specify that a word is to always be capitalized
     - This is due to how the auto-correct rule was designed as it sets the first letter of the replacement word to the case of the first letter of the word being replaced

--- a/docs/docs/settings/content-rules.md
+++ b/docs/docs/settings/content-rules.md
@@ -48,7 +48,7 @@ The following is a table with custom misspellings:
 ##### Current Limitations
 
 
-- The list of custom replacements is only loaded when the plugin initially loads or when the file is added to the list of files that include custom misspellings
+- The list of custom replacements is only loaded when the plugin first lints a file or when the file is added to the list of files that include custom misspellings
     * This means that making a change to a file that is already in the list of custom misspelling files will not work unless the Linter is reloaded or the file is removed and re-added to the list of custom misspelling files
 - There is no way to specify that a word is to always be capitalized
     - This is due to how the auto-correct rule was designed as it sets the first letter of the replacement word to the case of the first letter of the word being replaced

--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
     "ts-node": "^10.9.2",
     "tslib": "^2.4.1",
     "typescript": "^5.4.2",
-    "unified-lint-rule": "^2.1.1"
+    "unified-lint-rule": "^2.1.1",
+    "@babel/plugin-transform-private-methods": "^7.23.3",
+    "@types/js-yaml": "^4.0.5"
   },
   "dependencies": {
-    "@babel/plugin-transform-private-methods": "^7.23.3",
-    "@popperjs/core": "^2.11.6",
-    "@types/js-yaml": "^4.0.5",
     "async-lock": "^1.4.1",
+    "@popperjs/core": "^2.11.6",
     "diff-match-patch": "^1.0.5",
     "js-yaml": "^4.1.0",
     "loglevel": "^1.9.1",

--- a/src/rules/auto-correct-common-misspellings.ts
+++ b/src/rules/auto-correct-common-misspellings.ts
@@ -39,8 +39,8 @@ export default class AutoCorrectCommonMisspellings extends RuleBuilder<AutoCorre
 
     if (options.extraAutoCorrectFiles) {
       for (let i = 0; i < options.extraAutoCorrectFiles.length; i++) {
-        if (options.extraAutoCorrectFiles[i].customReplacements?.has(lowercasedWord)) {
-          return this.determineCorrectedWord(word, options.extraAutoCorrectFiles[i].customReplacements?.get(lowercasedWord));
+        if (options.extraAutoCorrectFiles[i].customReplacements && options.extraAutoCorrectFiles[i].customReplacements.has(lowercasedWord)) {
+          return this.determineCorrectedWord(word, options.extraAutoCorrectFiles[i].customReplacements.get(lowercasedWord));
         }
       }
     }

--- a/src/rules/auto-correct-common-misspellings.ts
+++ b/src/rules/auto-correct-common-misspellings.ts
@@ -39,7 +39,7 @@ export default class AutoCorrectCommonMisspellings extends RuleBuilder<AutoCorre
 
     if (options.extraAutoCorrectFiles) {
       for (let i = 0; i < options.extraAutoCorrectFiles.length; i++) {
-        if (options.extraAutoCorrectFiles[i].customReplacements && options.extraAutoCorrectFiles[i].customReplacements.has(lowercasedWord)) {
+        if (options.extraAutoCorrectFiles[i].customReplacements instanceof Map && options.extraAutoCorrectFiles[i].customReplacements?.has(lowercasedWord)) {
           return this.determineCorrectedWord(word, options.extraAutoCorrectFiles[i].customReplacements.get(lowercasedWord));
         }
       }


### PR DESCRIPTION
There were examples in the main.js that was generated that were not being minified/removed. Since they are not actually being used by the Linter in the actual plugin, it is best to just go ahead and force it to be removed when building the plugin.

While the plugin had the examples removed, I noticed that there was an issue where the `npm run dev` was not watching the files, so I fixed that as well.

There was also an issue with loading custom replacements on vault load where it would not actually load the files. That should now be fixed now since the loading of custom replacements is now moved to the first time the Linter tries to run after loading.