### PR TITLE
Fix ITs Not Running Properly and `'` and `-` Being Considered to be Words and Letters

### DIFF
--- a/__integration__/main.test.ts
+++ b/__integration__/main.test.ts
@@ -60,7 +60,7 @@ export default class TestLinterPlugin extends Plugin {
           await t.setup(this, activeLeaf.editor);
         }
 
-        this.plugin.runLinterEditor(activeLeaf.editor);
+        await this.plugin.runLinterEditor(activeLeaf.editor);
         await t.assertions(activeLeaf.editor);
 
         console.log('✅', t.name);
@@ -133,7 +133,7 @@ export default class TestLinterPlugin extends Plugin {
         await t.setup(this, activeLeaf.editor);
       }
 
-      testPlugin.plugin.runLinterEditor(activeLeaf.editor);
+      await testPlugin.plugin.runLinterEditor(activeLeaf.editor);
     } catch (e) {
       console.log('❌', t.name);
       console.error(e);

--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -194,5 +194,19 @@ ruleTest({
         style: 'ALL CAPS',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1148
+      testName: `Make sure that a header with a dash or single quote as an entry before the first letter get skipped as the first letter`,
+      before: dedent`
+        # 135 - a Letter Arrived
+        # 135 ' a Letter Arrived
+      `,
+      after: dedent`
+        # 135 - A Letter Arrived
+        # 135 ' A Letter Arrived
+      `,
+      options: {
+        style: 'First letter',
+      },
+    },
   ],
 });

--- a/src/rules/capitalize-headings.ts
+++ b/src/rules/capitalize-headings.ts
@@ -425,7 +425,7 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
       for (let j = 1; j < headerWords.length; j++) {
         // based on https://stackoverflow.com/a/62032796 "/\p{L}/u" accounts for all unicode letters across languages
         const isWord = headerWords[j].match(/^[\p{L}'-]{1,}[.?!,:;\d]*$/u);
-        if (!isWord) {
+        if (!isWord || headerWords[j] === '-' || headerWords[j] === '\'') {
           continue;
         }
 


### PR DESCRIPTION
Fixes #1148 

There was an issue with the Integration tests not running in order all of the time. This was caused by the recent change to loading files in for custom auto-correct files. Fixed it by awaiting the function called in the ITs.

There was also an issue with headers capitalization where `'` and `-` by themselves would be considered words and would cause other issues with capitalization. Checking for these two cases seems to fix the issue.