### PR TITLE
Update `Heading Blank Lines` Wording to Be a Little Clearer

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -465,10 +465,10 @@ export default {
     // heading-blank-lines.ts
     'heading-blank-lines': {
       'name': 'Heading blank lines',
-      'description': 'All headings have a blank line both before and after (except where the heading is at the beginning or end of the document).',
+      'description': 'All headings have one blank line both before and after (except where the heading is at the beginning or end of the document).',
       'bottom': {
         'name': 'Bottom',
-        'description': 'Insert a blank line after headings',
+        'description': 'Ensures one blank line after headings',
       },
       'empty-line-after-yaml': {
         'name': 'Empty Line Between YAML and Header',

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -344,7 +344,7 @@ export default {
       'description': 'Todos los encabezados tienen una línea en blanco antes y después (excepto cuando el encabezado está al principio o al final del documento).',
       'bottom': {
         'name': 'Abajo',
-        'description': 'Insertar una línea en blanco después de los encabezados',
+        'description': 'Asegura una línea en blanco después de los encabezados',
       },
       'empty-line-after-yaml': {
         'name': 'Línea vacía entre el YAML y el encabezado',


### PR DESCRIPTION
Fixes #1146

Update the wording for `Heading Blank Lines` to make the wording specific using `one` instead of `a` to make it clearer that there will be just one line around the headings.
