### PR TITLE
Fix: `Format Tags in YAML` Should Only Match `tag` or `tags` YAML Value.

### DIFF
--- a/__tests__/format-tags-in-yaml.test.ts
+++ b/__tests__/format-tags-in-yaml.test.ts
@@ -1,0 +1,34 @@
+import dedent from 'ts-dedent';
+import FormatTagsInYaml from '../src/rules/format-tags-in-yaml';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: FormatTagsInYaml,
+  testCases: [
+    { // fixes https://github.com/platers/obsidian-linter/issues/1155
+      testName: 'Make sure that when a tags array is empty and the next line has a hashtag it is not affected',
+      before: dedent`
+        ---
+        created: 2024-08-29T19:28:47+02:00
+        updated: 2024-08-29T19:48:06+02:00
+        title: Share note Test
+        aliases: 
+        tags: []
+        share_link: https://share.note.sx/r0w1vdtw#goaVfYU2NExAphdG8oHzVUZ2h8E22JDbJHC5BBEsZPo
+        share_updated: 2024-08-29T19:37:28+02:00
+        ---
+      `,
+      after: dedent`
+        ---
+        created: 2024-08-29T19:28:47+02:00
+        updated: 2024-08-29T19:48:06+02:00
+        title: Share note Test
+        aliases: 
+        tags: []
+        share_link: https://share.note.sx/r0w1vdtw#goaVfYU2NExAphdG8oHzVUZ2h8E22JDbJHC5BBEsZPo
+        share_updated: 2024-08-29T19:37:28+02:00
+        ---
+      `,
+    },
+  ],
+});

--- a/src/rules/format-tags-in-yaml.ts
+++ b/src/rules/format-tags-in-yaml.ts
@@ -21,7 +21,7 @@ export default class FormatTagsInYaml extends RuleBuilder<FormatTagsInYamlOption
   apply(text: string, options: FormatTagsInYamlOptions): string {
     return formatYAML(text, (text) => {
       return text.replace(
-          new RegExp(`\\n(${OBSIDIAN_TAG_KEY_PLURAL}|${OBSIDIAN_TAG_KEY_SINGULAR}):(.*?)(?=\\n(?:[A-Za-z-]+?:|---))`, 's'),
+          new RegExp(`^(${OBSIDIAN_TAG_KEY_PLURAL}|${OBSIDIAN_TAG_KEY_SINGULAR}):[ \\t]*(\\S.*|(?:(?:\\n *- \\S.*)|((?:\\n *- *))*|(\\n([ \\t]+[^\\n]*))*)*)\\n`, 'm'),
           function(tagsYAML) {
             return tagsYAML.replaceAll('#', '');
           },


### PR DESCRIPTION
Fixes #1155 

There was an issue where `Format Tags in YAML` was matching on more than just the value for the `tag` or `tags` key if that key was directly or shortly thereafter followed by a value that had a `#` in it. Updating the regex to better match how regex values are identified elsewhere seems to fix this issue.

Changes Made:
- Added a UT for the scenario in question
- Updated regex to match more closely what is done to get a YAML key's value elsewhere