### PR TITLE
Feat: `Auto-Correct Common Mispellings` Allow Users to Ignore Words with Multiple Capitals

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -265,6 +265,10 @@ export default {
         'name': 'Extra Auto-Correct Source Files',
         'description': 'These are files that have a markdown table in them that have the initial word and the word to correct it to (these are case insensitive corrections). **Note: the tables used should have the starting and ending `|` indicators present for each line.**',
       },
+      'skip-words-with-multiple-capitals': {
+        'name': 'Skip Words with Multiple Capitals',
+        'description': 'Will skip any files that have a capital letter in them other than as the first letter of the word, so acronyms and some other words can benefit from this. It may cause issues with proper nouns being properly fixed.',
+      },
     },
     // add-blank-line-after-yaml.ts
     'add-blank-line-after-yaml': {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -267,7 +267,7 @@ export default {
       },
       'skip-words-with-multiple-capitals': {
         'name': 'Skip Words with Multiple Capitals',
-        'description': 'Will skip any files that have a capital letter in them other than as the first letter of the word, so acronyms and some other words can benefit from this. It may cause issues with proper nouns being properly fixed.',
+        'description': 'Will skip any files that have a capital letter in them other than as the first letter of the word. Acronyms and some other words can benefit from this. It may cause issues with proper nouns being properly fixed.',
       },
     },
     // add-blank-line-after-yaml.ts

--- a/src/rules/auto-correct-common-misspellings.ts
+++ b/src/rules/auto-correct-common-misspellings.ts
@@ -148,18 +148,18 @@ export default class AutoCorrectCommonMisspellings extends RuleBuilder<AutoCorre
         splitter: wordSplitterRegex,
         separator: ', ',
       }),
+      new BooleanOptionBuilder({
+        OptionsClass: AutoCorrectCommonMisspellingsOptions,
+        nameKey: 'rules.auto-correct-common-misspellings.skip-words-with-multiple-capitals.name',
+        descriptionKey: 'rules.auto-correct-common-misspellings.skip-words-with-multiple-capitals.description',
+        optionsKey: 'skipWordsWithMultipleCapitals',
+      }),
       new MdFilePickerOptionBuilder({
         OptionsClass: AutoCorrectCommonMisspellingsOptions,
         nameKey: 'rules.auto-correct-common-misspellings.extra-auto-correct-files.name',
         descriptionKey: 'rules.auto-correct-common-misspellings.extra-auto-correct-files.description',
         // @ts-expect-error since it looks like there is an issue with the types here
         optionsKey: 'extraAutoCorrectFiles',
-      }),
-      new BooleanOptionBuilder({
-        OptionsClass: AutoCorrectCommonMisspellingsOptions,
-        nameKey: 'rules.auto-correct-common-misspellings.skip-words-with-multiple-capitals.name',
-        descriptionKey: 'rules.auto-correct-common-misspellings.skip-words-with-multiple-capitals.description',
-        optionsKey: 'skipWordsWithMultipleCapitals',
       }),
     ];
   }


### PR DESCRIPTION
Fixes #1075 
Fixes #1166 

There were two requests to allow for auto-correct to ignore capital letters. This is mostly to be used to help make sure acronyms are ignored while still allowing non-acronyms for the same words (i.e. hsa to has vs. HSA) to be properly handled.

Changes Made:
- Added option to turn off auto-correct for words with multiple capital letters in them
- Added UTs to check that the rule in question does indeed work