### PR TITLE
Chore: Swap Off of Deprectated `MarkdownRender.renderMarkdown` to `MarkdownRender.render`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     '@typescript-eslint',
     'jest',
     'unicorn',
+    "deprecation",
   ],
   'rules': {
     'camelcase': 'off',
@@ -37,5 +38,6 @@ module.exports = {
         'argsIgnorePattern': '(^_)|(options)',
       },
     ],
+    "deprecation/deprecation": "warn",
   },
 };

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -27,11 +27,11 @@ const mockedPlugins = [replace({
     // remove the use of obsidian in the options to allow for docs.js to run
     'import {Setting} from \'obsidian\';': '',
     // remove the use of obsidian in settings helper to allow for docs.js to run
-    'import {Component, MarkdownRenderer} from \'obsidian\';': '',
+    'import {App, Component, MarkdownRenderer} from \'obsidian\';': '',
     // remove the use of obsidian in the auto-correct files picker to allow for docs.js to run
     'import {Setting, Component, App, TFile, normalizePath, ExtraButtonComponent} from \'obsidian\';': '',
     // remove the use of obsidian in add custom row to allow for docs.js to run
-    'import {Component, Setting} from \'obsidian\';': '',
+    'import {App, Component, Setting} from \'obsidian\';': '',
     // remove the use of obsidian in suggest to allow for docs.js to run
     'import {App, ISuggestOwner, Scope} from \'obsidian\';': '',
     // remove the use of obsidian in md file suggester to allow for docs.js to run

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "esbuild-plugin-replace": "^1.3.0",
         "eslint": "^8.57.0",
         "eslint-config-google": "^0.14.0",
+        "eslint-plugin-deprecation": "^3.0.0",
         "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-unicorn": "^51.0.1",
         "jest": "^29.3.1",
@@ -5254,6 +5255,157 @@
       },
       "peerDependencies": {
         "eslint": ">=5.16.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-3.0.0.tgz",
+      "integrity": "sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^7.0.0",
+        "ts-api-utils": "^1.3.0",
+        "tslib": "^2.3.1"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0",
+        "typescript": "^4.2.4 || ^5.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
+      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
+      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/utils": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.2.0.tgz",
+      "integrity": "sha512-YfHpnMAGb1Eekpm3XRK8hcMwGLGsnT6L+7b2XyRv6ouDuJU1tZir1GS2i0+VXRatMwSI1/UfcyPe53ADkU+IuA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "7.2.0",
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/typescript-estree": "7.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
+      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-deprecation/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-jest": {
@@ -14170,6 +14322,100 @@
       "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-deprecation": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-3.0.0.tgz",
+      "integrity": "sha512-JuVLdNg/uf0Adjg2tpTyYoYaMbwQNn/c78P1HcccokvhtRphgnRjZDKmhlxbxYptppex03zO76f97DD/yQHv7A==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^7.0.0",
+        "ts-api-utils": "^1.3.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
+          "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "7.2.0",
+            "@typescript-eslint/visitor-keys": "7.2.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
+          "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
+          "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "7.2.0",
+            "@typescript-eslint/visitor-keys": "7.2.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "minimatch": "9.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.2.0.tgz",
+          "integrity": "sha512-YfHpnMAGb1Eekpm3XRK8hcMwGLGsnT6L+7b2XyRv6ouDuJU1tZir1GS2i0+VXRatMwSI1/UfcyPe53ADkU+IuA==",
+          "dev": true,
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.4.0",
+            "@types/json-schema": "^7.0.12",
+            "@types/semver": "^7.5.0",
+            "@typescript-eslint/scope-manager": "7.2.0",
+            "@typescript-eslint/types": "7.2.0",
+            "@typescript-eslint/typescript-estree": "7.2.0",
+            "semver": "^7.5.4"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
+          "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "7.2.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
+        }
+      }
     },
     "eslint-plugin-jest": {
       "version": "27.9.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "esbuild-plugin-replace": "^1.3.0",
     "eslint": "^8.57.0",
     "eslint-config-google": "^0.14.0",
+    "eslint-plugin-deprecation": "^3.0.0",
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-unicorn": "^51.0.1",
     "jest": "^29.3.1",

--- a/src/option.ts
+++ b/src/option.ts
@@ -44,8 +44,8 @@ export abstract class Option {
   }
 
   protected parseNameAndDescriptionAndRemoveSettingBorder(setting: Setting, plugin: LinterPlugin) {
-    parseTextToHTMLWithoutOuterParagraph(this.getName(), setting.nameEl, plugin.settingsTab.component);
-    parseTextToHTMLWithoutOuterParagraph(this.getDescription(), setting.descEl, plugin.settingsTab.component);
+    parseTextToHTMLWithoutOuterParagraph(plugin.app, this.getName(), setting.nameEl, plugin.settingsTab.component);
+    parseTextToHTMLWithoutOuterParagraph(plugin.app, this.getDescription(), setting.descEl, plugin.settingsTab.component);
 
     setting.settingEl.addClass('linter-no-border');
   }

--- a/src/ui/components/add-custom-refreshable-row.ts
+++ b/src/ui/components/add-custom-refreshable-row.ts
@@ -1,4 +1,4 @@
-import {Component, Setting} from 'obsidian';
+import {App, Component, Setting} from 'obsidian';
 import {parseTextToHTMLWithoutOuterParagraph} from '../helpers';
 
 /**
@@ -16,6 +16,7 @@ export abstract class AddCustomRefreshableRow {
     public warning: string,
     private addInputTooltip: string,
     private refreshBtnTooltip: string,
+    protected app: App,
     protected saveSettings: () => void,
     private onAddInput: () => void,
     private onRefresh: () => Promise<void>) {
@@ -26,7 +27,7 @@ export abstract class AddCustomRefreshableRow {
 
     const descriptionAndWarningContainer = this.containerEl.createDiv({cls: 'setting-item-description'});
 
-    parseTextToHTMLWithoutOuterParagraph(this.description, descriptionAndWarningContainer.createEl('p', {cls: 'custom-row-description'}), this.parentComponent);
+    parseTextToHTMLWithoutOuterParagraph(this.app, this.description, descriptionAndWarningContainer.createEl('p', {cls: 'custom-row-description'}), this.parentComponent);
 
     new Setting(this.containerEl)
         .addButton((cb)=>{

--- a/src/ui/components/add-custom-row.ts
+++ b/src/ui/components/add-custom-row.ts
@@ -1,4 +1,4 @@
-import {Component, Setting} from 'obsidian';
+import {App, Component, Setting} from 'obsidian';
 import {parseTextToHTMLWithoutOuterParagraph} from '../helpers';
 
 /**
@@ -15,6 +15,7 @@ export abstract class AddCustomRow {
     public description: string,
     public warning: string,
     private addInputBtnText: string,
+    protected app: App,
     protected saveSettings: () => void,
     private onAddInput: () => void) {
   }
@@ -24,7 +25,7 @@ export abstract class AddCustomRow {
 
     const descriptionAndWarningContainer = this.containerEl.createDiv({cls: 'setting-item-description'});
 
-    parseTextToHTMLWithoutOuterParagraph(this.description, descriptionAndWarningContainer.createEl('p', {cls: 'custom-row-description'}), this.parentComponent);
+    parseTextToHTMLWithoutOuterParagraph(this.app, this.description, descriptionAndWarningContainer.createEl('p', {cls: 'custom-row-description'}), this.parentComponent);
 
     new Setting(this.containerEl)
         .addButton((cb)=>{

--- a/src/ui/components/base-setting.ts
+++ b/src/ui/components/base-setting.ts
@@ -62,8 +62,8 @@ export abstract class BaseSetting<T> {
   }
 
   protected parseNameAndDescription() {
-    parseTextToHTMLWithoutOuterParagraph(this.name, this.setting.nameEl, this.plugin.settingsTab.component);
-    parseTextToHTMLWithoutOuterParagraph(this.description, this.setting.descEl, this.plugin.settingsTab.component);
+    parseTextToHTMLWithoutOuterParagraph(this.plugin.app, this.name, this.setting.nameEl, this.plugin.settingsTab.component);
+    parseTextToHTMLWithoutOuterParagraph(this.plugin.app, this.description, this.setting.descEl, this.plugin.settingsTab.component);
   }
 
   abstract display(): void;

--- a/src/ui/helpers.ts
+++ b/src/ui/helpers.ts
@@ -1,7 +1,7 @@
-import {Component, MarkdownRenderer} from 'obsidian';
+import {App, Component, MarkdownRenderer} from 'obsidian';
 
-export function parseTextToHTMLWithoutOuterParagraph(text: string, containerEl: HTMLElement, component: Component) {
-  void MarkdownRenderer.renderMarkdown(text, containerEl, '', component);
+export function parseTextToHTMLWithoutOuterParagraph(app: App, text: string, containerEl: HTMLElement, component: Component) {
+  void MarkdownRenderer.render(app, text, containerEl, '', component);
 
   let htmlString = containerEl.innerHTML.trim();
   if (htmlString.startsWith('<p>')) {

--- a/src/ui/linter-components/auto-correct-files-picker-option.ts
+++ b/src/ui/linter-components/auto-correct-files-picker-option.ts
@@ -10,7 +10,7 @@ export type CustomAutoCorrectContent = {filePath: string, customReplacements: Ma
 export class AutoCorrectFilesPickerOption extends AddCustomRefreshableRow {
   private selectedFiles: string[] = [];
 
-  constructor(containerEl: HTMLElement, parentComponent: Component, public filesPicked: CustomAutoCorrectContent[], private app: App, saveSettings: () => void, name: LanguageStringKey, description: LanguageStringKey) {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public filesPicked: CustomAutoCorrectContent[], app: App, saveSettings: () => void, name: LanguageStringKey, description: LanguageStringKey) {
     super(
         containerEl,
         parentComponent,
@@ -19,6 +19,7 @@ export class AutoCorrectFilesPickerOption extends AddCustomRefreshableRow {
         getTextInLanguage('options.custom-auto-correct.warning-text').replace('{NAME}', getTextInLanguage('rules.auto-correct-common-misspellings.name')),
         getTextInLanguage('options.custom-auto-correct.add-new-replacement-file-tooltip'),
         getTextInLanguage('options.custom-auto-correct.refresh-tooltip-text'),
+        app,
         saveSettings,
         ()=>{
           this.selectedFiles = [];

--- a/src/ui/linter-components/custom-command-option.ts
+++ b/src/ui/linter-components/custom-command-option.ts
@@ -6,13 +6,14 @@ import CommandSuggester from '../suggesters/command-suggester';
 export type LintCommand = { id: string, name: string };
 
 export class CustomCommandOption extends AddCustomRow {
-  constructor(containerEl: HTMLElement, parentComponent: Component, public lintCommands: LintCommand[], private app: App, saveSettings: () => void) {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public lintCommands: LintCommand[], app: App, saveSettings: () => void) {
     super(containerEl,
         parentComponent,
         getTextInLanguage('options.custom-command.name'),
         getTextInLanguage('options.custom-command.description'),
         getTextInLanguage('options.custom-command.warning'),
         getTextInLanguage('options.custom-command.add-input-button-text'),
+        app,
         saveSettings,
         () => {
           const newCommand = {id: '', name: ''};

--- a/src/ui/linter-components/custom-replace-option.ts
+++ b/src/ui/linter-components/custom-replace-option.ts
@@ -1,4 +1,4 @@
-import {Setting, Component} from 'obsidian';
+import {App, Setting, Component} from 'obsidian';
 import {getTextInLanguage} from 'src/lang/helpers';
 import {AddCustomRow} from '../components/add-custom-row';
 export type CustomReplace = {label: string, find: string, replace: string, flags: string};
@@ -6,7 +6,7 @@ export type CustomReplace = {label: string, find: string, replace: string, flags
 const defaultFlags = 'gm';
 
 export class CustomReplaceOption extends AddCustomRow {
-  constructor(containerEl: HTMLElement, parentComponent: Component, public regexes: CustomReplace[], saveSettings: () => void) {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public regexes: CustomReplace[], app: App, saveSettings: () => void) {
     super(
         containerEl,
         parentComponent,
@@ -14,6 +14,7 @@ export class CustomReplaceOption extends AddCustomRow {
         getTextInLanguage('options.custom-replace.description'),
         getTextInLanguage('options.custom-replace.warning'),
         getTextInLanguage('options.custom-replace.add-input-button-text'),
+        app,
         saveSettings,
         ()=>{
           const newRegex = {label: '', find: '', replace: '', flags: defaultFlags};

--- a/src/ui/linter-components/files-to-ignore-option.ts
+++ b/src/ui/linter-components/files-to-ignore-option.ts
@@ -1,4 +1,4 @@
-import {Setting, Component} from 'obsidian';
+import {App, Setting, Component} from 'obsidian';
 import {getTextInLanguage} from 'src/lang/helpers';
 import {AddCustomRow} from '../components/add-custom-row';
 export type FileToIgnore = {label: string, match: string, flags: string};
@@ -6,7 +6,7 @@ export type FileToIgnore = {label: string, match: string, flags: string};
 const defaultFlags = 'i';
 
 export class FilesToIgnoreOption extends AddCustomRow {
-  constructor(containerEl: HTMLElement, parentComponent: Component, public filesToIgnore: FileToIgnore[], saveSettings: () => void) {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public filesToIgnore: FileToIgnore[], app: App, saveSettings: () => void) {
     super(
         containerEl,
         parentComponent,
@@ -14,6 +14,7 @@ export class FilesToIgnoreOption extends AddCustomRow {
         getTextInLanguage('tabs.general.files-to-ignore.description'),
         getTextInLanguage('tabs.general.files-to-ignore.warning'),
         getTextInLanguage('tabs.general.files-to-ignore.add-input-button-text'),
+        app,
         saveSettings,
         ()=>{
           const newRegex = {label: '', match: '', flags: defaultFlags};

--- a/src/ui/linter-components/folder-ignore-option.ts
+++ b/src/ui/linter-components/folder-ignore-option.ts
@@ -1,10 +1,10 @@
-import {Setting, Component, App} from 'obsidian';
+import {App, Setting, Component} from 'obsidian';
 import {getTextInLanguage} from 'src/lang/helpers';
 import {AddCustomRow} from '../components/add-custom-row';
 import FolderSuggester from '../suggesters/folder-suggester';
 
 export class FolderIgnoreOption extends AddCustomRow {
-  constructor(containerEl: HTMLElement, parentComponent: Component, public foldersToIgnore: string[], private app: App, saveSettings: () => void) {
+  constructor(containerEl: HTMLElement, parentComponent: Component, public foldersToIgnore: string[], app: App, saveSettings: () => void) {
     super(
         containerEl,
         parentComponent,
@@ -12,6 +12,7 @@ export class FolderIgnoreOption extends AddCustomRow {
         getTextInLanguage('tabs.general.folders-to-ignore.description'),
         null,
         getTextInLanguage('tabs.general.folders-to-ignore.add-input-button-text'),
+        app,
         saveSettings,
         ()=>{
           const newFolderToIgnore = '';

--- a/src/ui/linter-components/tab-components/custom-tab.ts
+++ b/src/ui/linter-components/tab-components/custom-tab.ts
@@ -18,7 +18,7 @@ export class CustomTab extends Tab {
     this.addSettingSearchInfo(customCommandEl, customCommands.name, customCommands.description.replaceAll('\n', ' ') + customCommands.warning.replaceAll('\n', ' '));
 
     const customReplaceEl = this.contentEl.createDiv();
-    const customRegexes = new CustomReplaceOption(customReplaceEl, this.plugin.settingsTab.component, this.plugin.settings.customRegexes, () => {
+    const customRegexes = new CustomReplaceOption(customReplaceEl, this.plugin.settingsTab.component, this.plugin.settings.customRegexes, this.app, () => {
       void this.plugin.saveSettings();
     });
     this.addSettingSearchInfo(customReplaceEl, customRegexes.name, customRegexes.description.replaceAll('\n', ' ') + customRegexes.warning.replaceAll('\n', ' '));

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -45,7 +45,7 @@ export class DebugTab extends Tab {
     const logDisplay = new TextBoxFull(tempDiv, settingName, '');
     logDisplay.inputEl.setText(logsFromLastRun.join('\n'));
 
-    parseTextToHTMLWithoutOuterParagraph(settingDesc, logDisplay.descEl, this.plugin.settingsTab.component);
+    parseTextToHTMLWithoutOuterParagraph(this.plugin.app, settingDesc, logDisplay.descEl, this.plugin.settingsTab.component);
 
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
   }

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -104,7 +104,7 @@ export class GeneralTab extends Tab {
     this.addSettingSearchInfo(folderIgnoreEl, folderIgnore.name, folderIgnore.description.replaceAll('\n', ' '));
 
     const filesToIgnoreEl = this.contentEl.createDiv();
-    const filesToIgnore = new FilesToIgnoreOption(filesToIgnoreEl, this.plugin.settingsTab.component, this.plugin.settings.filesToIgnore, () => {
+    const filesToIgnore = new FilesToIgnoreOption(filesToIgnoreEl, this.plugin.settingsTab.component, this.plugin.settings.filesToIgnore, this.app, () => {
       void this.plugin.saveSettings();
     });
 


### PR DESCRIPTION
Recently I noticed that `MarkdownRender.renderMarkdown` is marked as deprecated. So I decided to move to the recommended replacement. It looks to work, but did require changing a little of how the internals work to pass around an instance of the app a little more. This should make it so we don't get caught in any nasty issue with the logic being removed entirely and us getting caught flat footed.

Also adds a warning to linting to hopefully realize when deprecated functions are used in the code.