### PR TITLE
Feat: Update Date Modified on Editor Content Change & Miscellaneous Style and YAML Timestamp Changes

### DIFF
--- a/__integration__/obsidian-mode.test.ts
+++ b/__integration__/obsidian-mode.test.ts
@@ -37,7 +37,7 @@ function edgeCaseSetup(plugin: TestLinterPlugin, _: Editor): Promise<void> {
     'enabled': true,
     'date-created': true,
     'date-created-key': 'created',
-    'force-retention-of-create-value': true,
+    'date-created-source-of-truth': 'file system',
     'date-modified': true,
     'date-modified-key': 'last_modified',
     'format': 'YYYY-MM-DD',

--- a/__tests__/yaml-timestamp.test.ts
+++ b/__tests__/yaml-timestamp.test.ts
@@ -63,12 +63,12 @@ ruleTest({
         format: 'dddd, MMMM Do YYYY, h:mm a ',
         currentTime: moment('Thursday, January 2nd 2020, 12:01 am', 'dddd, MMMM Do YYYY, h:mm a'),
         alreadyModified: false,
-        forceRetentionOfCreatedValue: false,
+        dateCreatedSourceOfTruth: 'frontmatter',
         fileModifiedTime: '2020-01-02T00:00:00-00',
       },
     },
     {
-      testName: 'When the date format changes and `forceRetentionOfCreatedValue = true`, date created value is based on the one in the YAML frontmatter.',
+      testName: 'When the date format changes and `dateCreatedSourceOfTruth = frontmatter`, date created value is based on the one in the YAML frontmatter.',
       before: dedent`
         ---
         created: Wednesday, January 1st 2020, 12:00:00 am
@@ -82,7 +82,7 @@ ruleTest({
       options: {
         dateModified: false,
         dateCreatedKey: 'created',
-        forceRetentionOfCreatedValue: true,
+        dateCreatedSourceOfTruth: 'frontmatter',
         format: 'YYYY, h:mm:ss a',
         locale: 'en',
       },
@@ -359,7 +359,7 @@ ruleTest({
       },
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/745
-      testName: 'When no changes are made, and force retention of creation date is active, do not update date modified when no change in modification time has been made',
+      testName: 'When no changes are made, and frontmatter is the source of truth, do not update date modified when no change in modification time has been made',
       before: dedent`
         ---
         tag: tag1
@@ -383,11 +383,11 @@ ruleTest({
         fileModifiedTime: '2020-02-04T18:00:00-00:00',
         currentTime: moment('Tuesday, February 4th 2020, 6:00:07 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
         alreadyModified: false,
-        forceRetentionOfCreatedValue: true,
+        dateCreatedSourceOfTruth: 'frontmatter',
       },
     },
     {
-      testName: 'When creation date exists and force retention of created date and convert to UTC are true, creation date should remain unchanged',
+      testName: 'When creation date exists and frontmatter is the source of truth and convert to UTC are true, creation date should remain unchanged',
       before: dedent`
         ---
         created: 2019-12-31T14:00:00+00:00
@@ -405,7 +405,7 @@ ruleTest({
         dateModified: false,
         fileCreatedTime: '2020-01-01T09:00:00-05:00', // 9 AM Eastern Standard Time
         currentTime: moment('2020-01-01T21:00:05-05:00', 'YYYY-MM-DDTHH:mm:ssZ'), // 9:00:05 PM EST, same day
-        forceRetentionOfCreatedValue: true,
+        dateCreatedSourceOfTruth: 'frontmatter',
         convertToUTC: true,
       },
     },
@@ -433,6 +433,122 @@ ruleTest({
         fileModifiedTime: '2020-01-01T21:00:00-05:00', // 9 PM Eastern Standard Time, same day
         currentTime: moment('2020-01-01T21:00:05-05:00', 'YYYY-MM-DDTHH:mm:ssZ'), // 9:00:05 PM EST, same day
         convertToUTC: true,
+      },
+    },
+    {
+      testName: 'When changes are made prior to the YAML timestamp rule and user and Linter edits are the source of truth, update date modified',
+      before: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:00 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      after: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:07 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      options: {
+        dateCreatedKey: 'created',
+        dateModifiedKey: 'modified',
+        fileCreatedTime: '2020-01-01T00:00:00-00:00',
+        fileModifiedTime: '2020-02-04T18:00:00-00:00',
+        currentTime: moment('Tuesday, February 4th 2020, 6:00:07 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
+        alreadyModified: true,
+        dateCreatedSourceOfTruth: 'frontmatter',
+        dateModifiedSourceOfTruth: 'user or Linter edits',
+      },
+    },
+    {
+      testName: 'When no changes are made prior to the YAML timestamp rule, the created date format is different from the current format in settings, and user and Linter edits are the source of truth, update date modified',
+      before: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:00 pm
+        created: Wednesday, January 1st 2020, 12:00 am
+        location: "path"
+        ---
+      `,
+      after: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:07 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      options: {
+        dateCreatedKey: 'created',
+        dateModifiedKey: 'modified',
+        fileCreatedTime: '2020-01-01T00:00:00-00:00',
+        fileModifiedTime: '2020-02-04T18:00:00-00:00',
+        currentTime: moment('Tuesday, February 4th 2020, 6:00:07 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
+        alreadyModified: false,
+        dateCreatedSourceOfTruth: 'frontmatter',
+        dateModifiedSourceOfTruth: 'user or Linter edits',
+      },
+    },
+    {
+      testName: 'When no changes are made prior to the YAML timestamp rule, the modified date format is different from the current format in settings, and user and Linter edits are the source of truth, update date modified',
+      before: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      after: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:07 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      options: {
+        dateCreatedKey: 'created',
+        dateModifiedKey: 'modified',
+        fileCreatedTime: '2020-01-01T00:00:00-00:00',
+        fileModifiedTime: '2020-02-04T18:00:00-00:00',
+        currentTime: moment('Tuesday, February 4th 2020, 6:00:07 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
+        alreadyModified: false,
+        dateCreatedSourceOfTruth: 'frontmatter',
+        dateModifiedSourceOfTruth: 'user or Linter edits',
+      },
+    },
+    {
+      testName: 'When no changes are made prior to the YAML timestamp rule, the file system date modified is more than 5 seconds different from the date modified, and user and Linter edits are the source of truth, do not update date modified',
+      before: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:00 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      after: dedent`
+        ---
+        tag: tag1
+        modified: Tuesday, February 4th 2020, 6:00:00 pm
+        created: Wednesday, January 1st 2020, 12:00:00 am
+        location: "path"
+        ---
+      `,
+      options: {
+        dateCreatedKey: 'created',
+        dateModifiedKey: 'modified',
+        fileCreatedTime: '2020-01-01T00:00:00-00:00',
+        fileModifiedTime: '2020-02-05T18:00:00-00:00',
+        currentTime: moment('Tuesday, February 5th 2020, 6:00:07 pm', 'dddd, MMMM Do YYYY, h:mm:ss a'),
+        alreadyModified: false,
+        dateCreatedSourceOfTruth: 'frontmatter',
+        dateModifiedSourceOfTruth: 'user or Linter edits',
       },
     },
   ],

--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -690,10 +690,6 @@ export default {
         'name': 'Schlüssel für das Erstellungsdatum',
         'description': 'Der YAML-Schlüssel, der für das Erstellungsdatum verwendet werden soll',
       },
-      'force-retention-of-create-value': {
-        'name': 'Erzwinge die Beibehaltung des Schlüsselwertes für das Erstellungsdatum',
-        'description': 'Verwendet den Wert im YAML-Frontmatter für das Erstellungsdatum anstelle den Dateimetadaten, was nützlich ist, um zu verhindern, dass Änderungen an Dateimetadaten dazu führen, dass der Wert in einen anderen Wert geändert wird.',
-      },
       'date-modified': {
         'name': 'Änderungsdatum',
         'description': 'Geben Sie das Datum ein, an dem die Datei zuletzt geändert wurde',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -142,7 +142,7 @@ export default {
         'description': 'Display the number of characters changed after linting',
       },
       'lint-on-file-change': {
-        'name': 'Lint on File Change',
+        'name': 'Lint on Focused File Change',
         'description': 'When the a file is closed or a new file is swapped to, the previous file is linted.',
       },
       'display-lint-on-file-change-message': {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -813,9 +813,13 @@ export default {
         'name': 'Date Created Key',
         'description': 'Which YAML key to use for creation date',
       },
-      'force-retention-of-create-value': {
-        'name': 'Force Date Created Key Value Retention',
-        'description': 'Reuses the value in the YAML frontmatter for date created instead of the file metadata which is useful for preventing file metadata changes from causing the value to change to a different value.',
+      'date-created-source-of-truth': {
+        'name': 'Date Created Source of Truth',
+        'description': 'Specifies where to get the date created value from if it is already present in the frontmatter.',
+      },
+      'date-modified-source-of-truth': {
+        'name': 'Date Modified Source of Truth',
+        'description': 'Specifies what way should be used to determine when the date modified should be updated if it is already present in the frontmatter.',
       },
       'date-modified': {
         'name': 'Date Modified',
@@ -918,6 +922,10 @@ export default {
     'after 15 seconds': 'After 15 seconds',
     'after 30 seconds': 'After 30 seconds',
     'after 1 minute': 'After 1 minute',
+    // yaml-timestamp.ts
+    'file system': 'File system',
+    'frontmatter': 'YAML frontmatter',
+    'user or Linter edits': 'Changes in Obsidian',
     // quote-style.ts
     '\'\'': '\'\'', // leave as is
     '‘’': '‘’', // leave as is

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -45,6 +45,9 @@ export default {
     'plugin-unload': 'Unloading plugin',
     'folder-lint': 'Linting folder ',
     'linter-run': 'Running linter',
+    'file-change-yaml-lint-run': 'Running editor content change YAML linting',
+    'file-change-yaml-lint-skipped': 'No file change detected, so YAML linting skipped',
+    'file-change-yaml-lint-warning': 'No file info is present, but debounce ran. Something went wrong somewhere.',
     'paste-link-warning': 'aborted paste lint as the clipboard content is a link and doing so will avoid conflicts with other plugins that modify pasting.',
     'see-console': 'See console for more details.',
     'unknown-error': 'An unknown error occurred during linting.',
@@ -147,7 +150,11 @@ export default {
       },
       'display-lint-on-file-change-message': {
         'name': 'Display Lint on File Change Message',
-        'description': 'Displays a message when `Lint on File Change` occurs',
+        'description': 'Displays a message when `Lint on Focused File Change` occurs',
+      },
+      'timestamp-update-on-file-contents-updated': {
+        'name': 'Update YAML Timestamp on File Contents Update',
+        'description': 'When the currently active file is modified, `YAML Timestamp` is run on the file. This should update the modified file timestamp if it is more than 5 seconds off from the current value.',
       },
       'folders-to-ignore': {
         'name': 'Folders to ignore',
@@ -904,6 +911,13 @@ export default {
     'first-h1': 'First H1',
     'first-h1-or-filename-if-h1-missing': 'First H1 or Filename if H1 is Missing',
     'filename': 'Filename',
+    // settings-data.ts
+    'never': 'Never',
+    'after 5 seconds': 'After 5 seconds',
+    'after 10 seconds': 'After 10 seconds',
+    'after 15 seconds': 'After 15 seconds',
+    'after 30 seconds': 'After 30 seconds',
+    'after 1 minute': 'After 1 minute',
     // quote-style.ts
     '\'\'': '\'\'', // leave as is
     '‘’': '‘’', // leave as is

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -606,10 +606,6 @@ export default {
         'name': 'Clave de fecha de creación',
         'description': 'La clave de YAML para usar para la fecha de creación',
       },
-      'force-retention-of-create-value': {
-        'name': 'Forzar la fecha de creación de la retención del valor clave',
-        'description': 'Reutiliza el valor en el frontmatter del YAML para la fecha de creación en lugar de los metadatos del archivo, lo que es útil para evitar que los cambios en los metadatos del archivo provoquen que el valor cambie a un valor diferente.',
-      },
       'date-modified': {
         'name': 'Fecha modificada',
         'description': 'Inserte la fecha en que se modificó el archivo por última vez',

--- a/src/lang/locale/tr.ts
+++ b/src/lang/locale/tr.ts
@@ -686,10 +686,6 @@ export default {
         'name': 'Oluşturma Tarihi Anahtarı',
         'description': 'Oluşturma tarihi için hangi YAML anahtarını kullanacağı',
       },
-      'force-retention-of-create-value': {
-        'name': 'Oluşturma Tarihi Anahtar Değerinin Korunmasını Zorla',
-        'description': 'Dosya metadatası yerine YAML ön maddesindeki tarihi yeniden kullanır, bu da dosya metadatasındaki değişikliklerin değerin farklı bir değere değişmesine neden olmasını önler.',
-      },
       'date-modified': {
         'name': 'Değiştirme Tarihi',
         'description': 'Dosyanın son değiştirildiği tarihi ekler',

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -750,10 +750,6 @@ export default {
         'name': '创建日期键名',
         'description': '使用哪个 YAML 键来表示创建日期',
       },
-      'force-retention-of-create-value': {
-        'name': '强制保留创建日期值',
-        'description': '沿用 YAML Front-matter 中已有的创建日期，忽略文档元数据。对于文档元数据更改（比如复制文件）导致的创建时间更改非常有用',
-      },
       'date-modified': {
         'name': '修改日期',
         'description': '插入文件的最近一次的修改日期',

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,8 +145,20 @@ export default class LinterPlugin extends Plugin {
         if (!('english-symbols-punctuation-after' in this.settings.ruleConfigs[rule.alias])) {
           this.settings.ruleConfigs[rule.alias]['english-symbols-punctuation-after'] = defaults['english-symbols-punctuation-after'];
         }
+      } else if (rule.alias == 'yaml-timestamp') {
+        const defaults = rule.getDefaultOptions();
+        if ('force-retention-of-create-value' in this.settings.ruleConfigs[rule.alias]) {
+          if (this.settings.ruleConfigs[rule.alias]['force-retention-of-create-value']) {
+            this.settings.ruleConfigs[rule.alias]['date-created-source-of-truth'] = 'frontmatter';
+          } else {
+            this.settings.ruleConfigs[rule.alias]['date-created-source-of-truth'] = defaults['date-created-source-of-truth'];
+          }
+        }
+
+        if (!('date-modified-source-of-truth' in this.settings.ruleConfigs[rule.alias])) {
+          this.settings.ruleConfigs[rule.alias]['date-modified-source-of-truth'] = defaults['date-modified-source-of-truth'];
+        }
       }
-      // TODO: add logic for moving force retention pjk
     }
 
     this.updatePasteOverrideStatus();

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,6 +146,7 @@ export default class LinterPlugin extends Plugin {
           this.settings.ruleConfigs[rule.alias]['english-symbols-punctuation-after'] = defaults['english-symbols-punctuation-after'];
         }
       }
+      // TODO: add logic for moving force retention pjk
     }
 
     this.updatePasteOverrideStatus();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon, htmlToMarkdown, EditorSelection, EditorChange, normalizePath} from 'obsidian';
+import {App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon, htmlToMarkdown, EditorSelection, EditorChange, normalizePath, MarkdownFileInfo, debounce, Debouncer} from 'obsidian';
 import {Options, RuleType, ruleTypeToRules, rules} from './rules';
 import DiffMatchPatch from 'diff-match-patch';
 import dedent from 'ts-dedent';
@@ -14,7 +14,7 @@ import {SettingTab} from './ui/settings';
 import {urlRegex} from './utils/regex';
 import {getTextInLanguage, LanguageStringKey, setLanguage} from './lang/helpers';
 import {RuleAliasSuggest} from './cm6/rule-alias-suggester';
-import {DEFAULT_SETTINGS, LinterSettings} from './settings-data';
+import {AfterFileChangeLintTimes, DEFAULT_SETTINGS, LinterSettings} from './settings-data';
 import AsyncLock from 'async-lock';
 import {warn} from 'loglevel';
 import {CustomAutoCorrectContent} from './ui/linter-components/auto-correct-files-picker-option';
@@ -48,6 +48,12 @@ const langToMomentLocale = {
 
 const userClickTimeout = 0;
 
+type FileChangeUpdateInfo = {
+  debounceFn: Debouncer<[TFile, Editor], Promise<void>>,
+  isRunning: boolean
+  originalText: string
+}
+
 export default class LinterPlugin extends Plugin {
   settings: LinterSettings;
   settingsTab: SettingTab;
@@ -68,6 +74,7 @@ export default class LinterPlugin extends Plugin {
   private fileLintFiles: Set<TFile> = new Set();
   private customCommandsCallback: (file: TFile) => Promise<void> = null;
   private currentlyOpeningSidebar: boolean = false;
+  private activeFileChangeDebouncer: Map<TFile, FileChangeUpdateInfo> = new Map();
 
   async onload() {
     setLanguage(window.localStorage.getItem('language'));
@@ -251,6 +258,31 @@ export default class LinterPlugin extends Plugin {
     this.eventRefs.push(eventRef);
 
     eventRef = this.app.metadataCache.on('changed', (file: TFile) => this.onMetadataCacheUpdatedCallback(file));
+    this.registerEvent(eventRef);
+    this.eventRefs.push(eventRef);
+
+    eventRef = this.app.workspace.on('editor-change', async (editor: Editor, info: MarkdownView | MarkdownFileInfo) => {
+      if (this.settings.lintOnFileContentChangeDelay == AfterFileChangeLintTimes.Never) {
+        return;
+      }
+
+      if (this.shouldIgnoreFile(info.file) || !this.isMarkdownFile(info.file) || !editor.cm) {
+        return;
+      }
+
+      if (this.activeFileChangeDebouncer.has(info.file)) {
+        const activeFileChangeInfo = this.activeFileChangeDebouncer.get(info.file);
+        if (!activeFileChangeInfo.isRunning) {
+          this.activeFileChangeDebouncer.get(info.file).debounceFn(info.file, editor);
+        }
+      } else {
+        this.activeFileChangeDebouncer.set(info.file, {
+          debounceFn: this.createDebouncedFileUpdate(),
+          isRunning: false,
+          originalText: editor.getValue(),
+        });
+      }
+    });
     this.registerEvent(eventRef);
     this.eventRefs.push(eventRef);
 
@@ -478,6 +510,105 @@ export default class LinterPlugin extends Plugin {
       return;
     }
 
+    const changes = this.updateEditor(oldText, newText, editor);
+    const charsAdded = changes.map((change) => change[0] == DiffMatchPatch.DIFF_INSERT ? change[1].length : 0).reduce((a, b) => a + b, 0);
+    const charsRemoved = changes.map((change) => change[0] == DiffMatchPatch.DIFF_DELETE ? change[1].length : 0).reduce((a, b) => a + b, 0);
+
+    this.displayChangedMessage(charsAdded, charsRemoved);
+
+    // run custom commands now since no change was made
+    if (!charsAdded && !charsRemoved) {
+      void this.runCustomCommands(file);
+    } else {
+      this.editorLintFiles.push(file);
+    }
+
+    this.updateFileDebouncerText(file, newText);
+
+    setCollectLogs(false);
+  }
+
+  // based on https://github.com/liamcain/obsidian-calendar-ui/blob/03ceecbf6d88ef260dadf223ee5e483d98d24ffc/src/localization.ts#L85-L109
+  async setOrUpdateMomentInstance() {
+    const obsidianLang: string = localStorage.getItem('language') || 'en';
+    const systemLang = navigator.language?.toLowerCase();
+
+    let momentLocale = langToMomentLocale[obsidianLang as keyof typeof langToMomentLocale];
+
+    if (this.settings.linterLocale !== 'system-default') {
+      momentLocale = this.settings.linterLocale;
+    } else if (systemLang.startsWith(obsidianLang)) {
+      // If the system locale is more specific (en-gb vs en), use the system locale.
+      momentLocale = systemLang;
+    }
+
+    this.momentLocale = momentLocale;
+    const oldLocale = moment.locale();
+    const currentLocale = moment.locale(momentLocale);
+    logDebug(getTextInLanguage('logs.moment-locale-not-found').replace('{MOMENT_LOCALE}', momentLocale).replace('{CURRENT_LOCALE}', currentLocale));
+
+    moment.locale(oldLocale);
+  }
+
+  private createDebouncedFileUpdate(): Debouncer<[TFile, Editor], Promise<void>> {
+    let delay = 5000;
+    switch (this.settings.lintOnFileContentChangeDelay) {
+      case AfterFileChangeLintTimes.After10Seconds:
+        delay = 10000;
+        break;
+      case AfterFileChangeLintTimes.After15Seconds:
+        delay = 15000;
+        break;
+      case AfterFileChangeLintTimes.After30Seconds:
+        delay = 30000;
+        break;
+      case AfterFileChangeLintTimes.After1Minute:
+        delay = 60000;
+        break;
+    }
+
+    return debounce(
+        async (file: TFile, editor: Editor) => {
+          if (!this.activeFileChangeDebouncer.has(file)) {
+            logWarn(getTextInLanguage('logs.file-change-yaml-lint-warning'));
+            return;
+          }
+
+          const activeFileChangeInfo = this.activeFileChangeDebouncer.get(file);
+          activeFileChangeInfo.isRunning = true;
+
+          const oldText = editor.getValue();
+          let newText = oldText;
+          if (oldText != activeFileChangeInfo.originalText ) {
+            logInfo(getTextInLanguage('logs.file-change-yaml-lint-run'));
+            try {
+              newText = this.rulesRunner.runYAMLTimestampByItself(createRunLinterRulesOptions(oldText, file, this.momentLocale, this.settings));
+            } catch (error) {
+              this.handleLintError(file, error, getTextInLanguage('commands.lint-file.error-message') + ' \'{FILE_PATH}\'', false);
+              return;
+            }
+
+            this.updateEditor(oldText, newText, editor);
+          } else {
+            logInfo(getTextInLanguage('logs.file-change-yaml-lint-skipped'));
+          }
+
+          activeFileChangeInfo.isRunning = false;
+          // update text value just in case we retain this and are forced to run another update. It will help weed out other changes.
+          activeFileChangeInfo.originalText = newText;
+
+          // retain active file debounce info, but all others should be safe to remove
+          const activeFile = this.app.workspace.getActiveFile();
+          if (!activeFile || activeFile != file) {
+            this.activeFileChangeDebouncer.delete(file);
+          }
+        },
+        delay,
+        true,
+    );
+  }
+
+  private updateEditor(oldText: string, newText: string, editor: Editor): DiffMatchPatch.Diff[] {
     const dmp = new DiffMatchPatch.diff_match_patch(); // eslint-disable-line new-cap
     const changes = dmp.diff_main(oldText, newText);
     let curText = '';
@@ -514,41 +645,7 @@ export default class LinterPlugin extends Plugin {
       }
     });
 
-    const charsAdded = changes.map((change) => change[0] == DiffMatchPatch.DIFF_INSERT ? change[1].length : 0).reduce((a, b) => a + b, 0);
-    const charsRemoved = changes.map((change) => change[0] == DiffMatchPatch.DIFF_DELETE ? change[1].length : 0).reduce((a, b) => a + b, 0);
-
-    this.displayChangedMessage(charsAdded, charsRemoved);
-
-    // run custom commands now since no change was made
-    if (!charsAdded && !charsRemoved) {
-      void this.runCustomCommands(file);
-    } else {
-      this.editorLintFiles.push(file);
-    }
-
-    setCollectLogs(false);
-  }
-
-  // based on https://github.com/liamcain/obsidian-calendar-ui/blob/03ceecbf6d88ef260dadf223ee5e483d98d24ffc/src/localization.ts#L85-L109
-  async setOrUpdateMomentInstance() {
-    const obsidianLang: string = localStorage.getItem('language') || 'en';
-    const systemLang = navigator.language?.toLowerCase();
-
-    let momentLocale = langToMomentLocale[obsidianLang as keyof typeof langToMomentLocale];
-
-    if (this.settings.linterLocale !== 'system-default') {
-      momentLocale = this.settings.linterLocale;
-    } else if (systemLang.startsWith(obsidianLang)) {
-      // If the system locale is more specific (en-gb vs en), use the system locale.
-      momentLocale = systemLang;
-    }
-
-    this.momentLocale = momentLocale;
-    const oldLocale = moment.locale();
-    const currentLocale = moment.locale(momentLocale);
-    logDebug(getTextInLanguage('logs.moment-locale-not-found').replace('{MOMENT_LOCALE}', momentLocale).replace('{CURRENT_LOCALE}', currentLocale));
-
-    moment.locale(oldLocale);
+    return changes;
   }
 
   private displayChangedMessage(charsAdded: number, charsRemoved: number) {
@@ -737,6 +834,8 @@ export default class LinterPlugin extends Plugin {
         await this.customCommandsCallback(file);
       }
     });
+
+    this.updateFileDebouncerText(file, stripCr(await this.app.vault.read(file)));
   }
 
   /**
@@ -857,5 +956,11 @@ export default class LinterPlugin extends Plugin {
     }
 
     return null;
+  }
+
+  private updateFileDebouncerText(file: TFile, newText: string) {
+    if (this.activeFileChangeDebouncer.has(file)) {
+      this.activeFileChangeDebouncer.get(file).originalText = newText;
+    }
   }
 }

--- a/src/option.ts
+++ b/src/option.ts
@@ -48,6 +48,7 @@ export abstract class Option {
     parseTextToHTMLWithoutOuterParagraph(plugin.app, this.getDescription(), setting.descEl, plugin.settingsTab.component);
 
     setting.settingEl.addClass('linter-no-border');
+    setting.descEl.addClass('linter-no-padding-top');
   }
 }
 

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -288,7 +288,7 @@ export class RulesRunner {
 }
 
 export function createRunLinterRulesOptions(text: string, file: TFile = null, momentLocale: string, settings: LinterSettings): RunLinterRulesOptions {
-  const createdAt = file ? moment(file.stat.ctime): moment();
+  const createdAt = (file && file.stat.ctime !== 0) ? moment(file.stat.ctime): moment();
   createdAt.locale(momentLocale);
   const modifiedAt = file ? moment(file.stat.mtime): moment();
   modifiedAt.locale(momentLocale);

--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -270,6 +270,21 @@ export class RulesRunner {
 
     return newText;
   }
+
+  runYAMLTimestampByItself(runOptions: RunLinterRulesOptions): string {
+    let newText = runOptions.oldText;
+
+    const currentTime = runOptions.getCurrentTime();
+    [newText] = YamlTimestamp.applyIfEnabled(newText, runOptions.settings, this.disabledRules, {
+      fileCreatedTime: runOptions.fileInfo.createdAtFormatted,
+      fileModifiedTime: runOptions.fileInfo.modifiedAtFormatted,
+      currentTime: currentTime,
+      alreadyModified: true,
+      locale: runOptions.momentLocale,
+    });
+
+    return newText;
+  }
 }
 
 export function createRunLinterRulesOptions(text: string, file: TFile = null, momentLocale: string, settings: LinterSettings): RunLinterRulesOptions {

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -1,5 +1,5 @@
 import {Options, RuleType} from '../rules';
-import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, MomentFormatOptionBuilder, OptionBuilderBase, TextOptionBuilder} from './rule-builder';
+import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, MomentFormatOptionBuilder, OptionBuilderBase, TextOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
 import {formatYAML, initYAML} from '../utils/yaml';
 import {moment} from 'obsidian';
@@ -399,11 +399,21 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
         descriptionKey: 'rules.yaml-timestamp.date-created-key.description',
         optionsKey: 'dateCreatedKey',
       }),
-      new BooleanOptionBuilder({
+      new DropdownOptionBuilder<YamlTimestampOptions, DateCreatedSourceOfTruth>({
         OptionsClass: YamlTimestampOptions,
-        nameKey: 'rules.yaml-timestamp.force-retention-of-create-value.name',
-        descriptionKey: 'rules.yaml-timestamp.force-retention-of-create-value.description',
-        optionsKey: 'forceRetentionOfCreatedValue',
+        nameKey: 'rules.yaml-timestamp.date-created-source-of-truth.name',
+        descriptionKey: 'rules.yaml-timestamp.date-created-source-of-truth.description',
+        optionsKey: 'dateCreatedSourceOfTruth',
+        records: [
+          {
+            value: 'file system',
+            description: 'The file system date created value is used to set the value of date created in the frontmatter',
+          },
+          {
+            value: 'frontmatter',
+            description: 'When a value is present in the frontmatter for date created, this value is used as the value for the date created',
+          },
+        ],
       }),
       new BooleanOptionBuilder({
         OptionsClass: YamlTimestampOptions,
@@ -416,6 +426,22 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
         nameKey: 'rules.yaml-timestamp.date-modified-key.name',
         descriptionKey: 'rules.yaml-timestamp.date-modified-key.description',
         optionsKey: 'dateModifiedKey',
+      }),
+      new DropdownOptionBuilder<YamlTimestampOptions, DateModifiedSourceOfTruth>({
+        OptionsClass: YamlTimestampOptions,
+        nameKey: 'rules.yaml-timestamp.date-modified-source-of-truth.name',
+        descriptionKey: 'rules.yaml-timestamp.date-modified-source-of-truth.description',
+        optionsKey: 'dateModifiedSourceOfTruth',
+        records: [
+          {
+            value: 'file system',
+            description: 'The file system date modified value is used to set the value of date modified in the frontmatter',
+          },
+          {
+            value: 'user or Linter edits',
+            description: 'When a value is present in the frontmatter for date modified, date modified is kept as is unless the user or the Linter makes a change to the file',
+          },
+        ],
       }),
       new MomentFormatOptionBuilder({
         OptionsClass: YamlTimestampOptions,

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -14,6 +14,15 @@ export type CommonStyles = {
   removeUnnecessaryEscapeCharsForMultiLineArrays: boolean;
 }
 
+export enum AfterFileChangeLintTimes {
+  Never = 'never',
+  After5Seconds = 'after 5 seconds',
+  After10Seconds = 'after 10 seconds',
+  After15Seconds = 'after 15 seconds',
+  After30Seconds = 'after 30 seconds',
+  After1Minute = 'after 1 minute',
+}
+
 export interface LinterSettings {
   ruleConfigs: {
     [ruleName: string]: Options;
@@ -22,8 +31,9 @@ export interface LinterSettings {
   displayChanged: boolean;
   settingsConvertedToConfigKeyValues: boolean;
   recordLintOnSaveLogs: boolean;
-  lintOnFileChange: boolean,
-  displayLintOnFileChangeNotice: boolean,
+  lintOnFileChange: boolean;
+  displayLintOnFileChangeNotice: boolean;
+  lintOnFileContentChangeDelay: string;
   foldersToIgnore: string[];
   filesToIgnore: FileToIgnore[];
   linterLocale: string;
@@ -42,6 +52,7 @@ export const DEFAULT_SETTINGS: Partial<LinterSettings> = {
   displayChanged: true,
   lintOnFileChange: false,
   displayLintOnFileChangeNotice: false,
+  lintOnFileContentChangeDelay: AfterFileChangeLintTimes.Never,
   settingsConvertedToConfigKeyValues: false,
   foldersToIgnore: [],
   filesToIgnore: [],

--- a/src/styles.css
+++ b/src/styles.css
@@ -246,6 +246,13 @@ textarea.full-width {
 }
 
 /**
+* Settings item padding top removal to make toggles and other elements line up with description when no info is present
+*/
+.linter-no-padding-top {
+  padding-top: 0px;
+}
+
+/**
 * Custom row
 */
 .custom-row-description {

--- a/src/typings/moment-parseformat.d.ts
+++ b/src/typings/moment-parseformat.d.ts
@@ -1,3 +1,4 @@
 declare module 'moment-parseformat' {
   function parseFormat(format: string, options?: any): string;
+  export = parseFormat;
 }

--- a/src/ui/components/base-setting.ts
+++ b/src/ui/components/base-setting.ts
@@ -64,6 +64,7 @@ export abstract class BaseSetting<T> {
   protected parseNameAndDescription() {
     parseTextToHTMLWithoutOuterParagraph(this.plugin.app, this.name, this.setting.nameEl, this.plugin.settingsTab.component);
     parseTextToHTMLWithoutOuterParagraph(this.plugin.app, this.description, this.setting.descEl, this.plugin.settingsTab.component);
+    this.setting.descEl.addClass('linter-no-padding-top');
   }
 
   abstract display(): void;

--- a/src/ui/components/toggle-setting.ts
+++ b/src/ui/components/toggle-setting.ts
@@ -2,10 +2,11 @@ import {Setting} from 'obsidian';
 import LinterPlugin from 'src/main';
 import {LinterSettingsKeys} from 'src/settings-data';
 import {BaseSetting} from './base-setting';
+import {LanguageStringKey} from 'src/lang/helpers';
 
 export class ToggleSetting extends BaseSetting<boolean> {
   setting: Setting;
-  constructor(containerEl: HTMLDivElement, name: string, description: string, keyToUpdate: LinterSettingsKeys, plugin: LinterPlugin) {
+  constructor(containerEl: HTMLDivElement, name: LanguageStringKey, description: LanguageStringKey, keyToUpdate: LinterSettingsKeys, plugin: LinterPlugin) {
     super(containerEl, name, description, keyToUpdate, plugin);
     this.display();
   }

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -9,6 +9,7 @@ import {NumberInputSetting} from 'src/ui/components/number-input-setting';
 import {ToggleSetting} from 'src/ui/components/toggle-setting';
 import {FolderIgnoreOption} from '../folder-ignore-option';
 import {FilesToIgnoreOption} from '../files-to-ignore-option';
+import {AfterFileChangeLintTimes} from 'src/settings-data';
 
 export class GeneralTab extends Tab {
   constructor(navEl: HTMLElement, settingsEl: HTMLElement, isMobile: boolean, plugin: LinterPlugin, private app: App) {
@@ -28,6 +29,22 @@ export class GeneralTab extends Tab {
 
     tempDiv = this.contentEl.createDiv();
     this.addSettingSearchInfoForGeneralSettings(new ToggleSetting(tempDiv, 'tabs.general.display-lint-on-file-change-message.name', 'tabs.general.display-lint-on-file-change-message.description', 'displayLintOnFileChangeNotice', this.plugin));
+
+    const yamlTimestampTimeOptions: DropdownRecordInfo = {
+      isForEnum: true,
+      values: [
+        AfterFileChangeLintTimes.Never,
+        AfterFileChangeLintTimes.After5Seconds,
+        AfterFileChangeLintTimes.After10Seconds,
+        AfterFileChangeLintTimes.After15Seconds,
+        AfterFileChangeLintTimes.After30Seconds,
+        AfterFileChangeLintTimes.After1Minute,
+      ],
+      descriptions: [],
+    };
+
+    tempDiv = this.contentEl.createDiv();
+    this.addSettingSearchInfoForGeneralSettings(new DropdownSetting(tempDiv, 'tabs.general.timestamp-update-on-file-contents-updated.name', 'tabs.general.timestamp-update-on-file-contents-updated.description', 'lintOnFileContentChangeDelay', this.plugin, yamlTimestampTimeOptions));
 
     const sysLocale = navigator.language?.toLowerCase();
     const localeValues = ['system-default'];


### PR DESCRIPTION
Fixes #183 
Fixes #890 
Fixes #1161 
Fixes #1162 
May fix #995

There has been some level of desire for the ability to make the date modified be set whenever the user makes a change to the editor/file via Obsidian. In order to do this, there is a need to know whenever the editor is updated. When it is, it will set off a debounced action to update the date modified so long as the user does not remove the changes by the time that the debounced function runs.

There were also some style changes made to cut down some on the whitespace that was present, but not necessary.

There was also a wording update to try to make things clearer that the lint on file change only happens when focused file changes.

Changes Made:
- Updated `Lint on File Change` to `Lint on Focused File Change`
- Adds ability to run the YAML timestamp rule x seconds after the last editor change (it tries to keep from updating the date modified if no net changes were made in the editor between when the first change was made and the debounce ran)
- Tries to make sure that the other linting logic at the end updates the original file text for any debounce functions that exist to try to keep from unnecessarily adding a another timestamp update if it is not necessary
- Adds a dropdown for determining the source of truth for date modified and date created

TODO:
- [x] Swap boolean setting for trusting created date in the YAML as the source of truth to a dropdown
- [x] Add a similar option for date modified where only changes in Obsidian are recorded
- [x] Try to account for no valid created date provided (0 as the ctime should instead be now)