### PR TITLE
Feat: add additional ordered list options

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -893,6 +893,7 @@ export default {
     'SILENT': 'silent',
     'ascending': 'ascending',
     'lazy': 'lazy',
+    'keep': 'keep',
     'Nothing': 'Nothing',
     'Remove hashtag': 'Remove hashtag',
     'Remove whole tag': 'Remove whole tag',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -551,6 +551,10 @@ export default {
         'name': 'Ordered List Indicator End Style',
         'description': 'The ending character of an ordered list indicator',
       },
+      'keep-start': {
+        'name': 'Keep Start',
+        'description': 'Whether to keep the starting number of an ordered list',
+      },
     },
     // paragraph-blank-lines.ts
     'paragraph-blank-lines': {

--- a/src/rules/ordered-list-style.ts
+++ b/src/rules/ordered-list-style.ts
@@ -1,12 +1,13 @@
 import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
-import RuleBuilder, {DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
+import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
 import {OrderListItemEndOfIndicatorStyles, OrderListItemStyles, updateOrderedListItemIndicators} from '../utils/mdast';
 
 class OrderedListStyleOptions implements Options {
   numberStyle?: OrderListItemStyles = OrderListItemStyles.Ascending;
   listEndStyle?: OrderListItemEndOfIndicatorStyles = OrderListItemEndOfIndicatorStyles.Period;
+  keepStart?: boolean;
 }
 
 @RuleBuilder.register
@@ -23,7 +24,7 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
     return OrderedListStyleOptions;
   }
   apply(text: string, options: OrderedListStyleOptions): string {
-    return updateOrderedListItemIndicators(text, options.numberStyle, options.listEndStyle);
+    return updateOrderedListItemIndicators(text, options.numberStyle, options.listEndStyle, options.keepStart);
   }
   get exampleBuilders(): ExampleBuilder<OrderedListStyleOptions>[] {
     return [
@@ -131,6 +132,97 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
           numberStyle: OrderListItemStyles.Lazy,
         },
       }),
+      new ExampleBuilder({
+        description: 'Ordered lists have list items set to ascending numerical order using initial indicator number when Number Style is `ascending` and `keepStart` is enabled',
+        before: dedent`
+          1. Item 1
+          2. Item 2
+          4. Item 3
+          ${''}
+          Some text here
+          ${''}
+          4. Item 4
+          5. Item 5
+          7. Item 6
+        `,
+        after: dedent`
+          1. Item 1
+          2. Item 2
+          3. Item 3
+          ${''}
+          Some text here
+          ${''}
+          4. Item 4
+          5. Item 5
+          6. Item 6
+        `,
+        options: {
+          numberStyle: OrderListItemStyles.Ascending,
+          keepStart: true,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Nested ordered lists have list items set to ascending numerical order using initial indicator number when Number Style is `ascending` and `keepStart` is enabled',
+        before: dedent`
+          4. Item 4
+          2. Item 5
+            2. Subitem 2
+            5. Subitem 3
+            2. Subitem 4
+          4. Item 6
+        `,
+        after: dedent`
+          4. Item 4
+          5. Item 5
+            2. Subitem 2
+            3. Subitem 3
+            4. Subitem 4
+          6. Item 6
+        `,
+        options: {
+          keepStart: true,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Ordered lists have list items set to initial indicator number when Number Style is `lazy` and `keepStart` is enabled',
+        before: dedent`
+          2. Item 2
+          5. Item 3
+          4. Item 4
+        `,
+        after: dedent`
+          2. Item 2
+          2. Item 3
+          2. Item 4
+        `,
+        options: {
+          numberStyle: OrderListItemStyles.Lazy,
+          keepStart: true,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Nested ordered lists have list items set to initial indicator number when Number Style is `lazy` and `keepStart` is enabled',
+        before: dedent`
+          4. Item 4
+          2. Item 5
+            2. Subitem 2
+            5. Subitem 3
+            2. Subitem 4
+          4. Item 6
+        `,
+        after: dedent`
+          4. Item 4
+          4. Item 5
+            2. Subitem 2
+            2. Subitem 3
+            2. Subitem 4
+          4. Item 6
+        `,
+        options: {
+          numberStyle: OrderListItemStyles.Lazy,
+          keepStart: true,
+        },
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<OrderedListStyleOptions>[] {
@@ -147,7 +239,7 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
           },
           {
             value: OrderListItemStyles.Lazy,
-            description: 'Makes sure ordered list item indicators all are the number 1',
+            description: 'Makes sure ordered list item indicators all are the same',
           },
         ],
       }),
@@ -166,6 +258,12 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
             description: 'Makes sure ordered list item indicators end in \')\' (i.e. `1)`)',
           },
         ],
+      }),
+      new BooleanOptionBuilder<OrderedListStyleOptions>({
+        OptionsClass: OrderedListStyleOptions,
+        nameKey: 'rules.ordered-list-style.keep-start.name',
+        descriptionKey: 'rules.ordered-list-style.keep-start.description',
+        optionsKey: 'keepStart',
       }),
     ];
   }

--- a/src/rules/ordered-list-style.ts
+++ b/src/rules/ordered-list-style.ts
@@ -223,6 +223,28 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
           keepStart: true,
         },
       }),
+      new ExampleBuilder({
+        description: 'Ordered lists items are not modified when Number Style is `keep`',
+        before: dedent`
+          4. Item 4
+          2. Item 5
+            2. Subitem 2
+            5. Subitem 3
+            2. Subitem 4
+          4. Item 6
+        `,
+        after: dedent`
+          4. Item 4
+          2. Item 5
+            2. Subitem 2
+            5. Subitem 3
+            2. Subitem 4
+          4. Item 6
+        `,
+        options: {
+          numberStyle: OrderListItemStyles.Keep,
+        },
+      }),
     ];
   }
   get optionBuilders(): OptionBuilderBase<OrderedListStyleOptions>[] {
@@ -240,6 +262,10 @@ export default class OrderedListStyle extends RuleBuilder<OrderedListStyleOption
           {
             value: OrderListItemStyles.Lazy,
             description: 'Makes sure ordered list item indicators all are the same',
+          },
+          {
+            value: OrderListItemStyles.Keep,
+            description: 'Keeps ordered list item indicators as they are',
           },
         ],
       }),

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -39,6 +39,7 @@ export enum MDAstTypes {
 export enum OrderListItemStyles {
   Ascending = 'ascending',
   Lazy = 'lazy',
+  Keep = 'keep',
 }
 
 export enum OrderListItemEndOfIndicatorStyles {
@@ -693,7 +694,7 @@ export function updateOrderedListItemIndicators(text: string, orderedListStyle: 
 
     let lastItemListIndicatorLevel = -1;
     listText = listText.replace(/^(( |\t|> )*)((\d+(\.|\)))|[-*+])([^\n]*)$/gm, (listItem: string, $1: string = '', _$2: string, $3: string, _$4: string, _$5: string, $6: string) => {
-      let listItemIndicatorNumber = keepStart ? Number(_$4) : 1;
+      let listItemIndicatorNumber = (orderedListStyle === OrderListItemStyles.Keep || keepStart) ? Number(_$4) : 1;
       const listItemIndicatorLevel = getListItemLevel($1);
       // when dealing with a value that is not an int reset all values greater than or equal to the current list level
       if (!/^\d/.test($3)) {

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -659,7 +659,7 @@ export function ensureEmptyLinesAroundBlockquotes(text: string): string {
   return text;
 }
 
-export function updateOrderedListItemIndicators(text: string, orderedListStyle: OrderListItemStyles, orderedListEndStyle: OrderListItemEndOfIndicatorStyles): string {
+export function updateOrderedListItemIndicators(text: string, orderedListStyle: OrderListItemStyles, orderedListEndStyle: OrderListItemEndOfIndicatorStyles, keepStart: boolean): string {
   const positions: Position[] = getPositions(MDAstTypes.List, text);
   if (!positions) {
     return text;
@@ -693,8 +693,7 @@ export function updateOrderedListItemIndicators(text: string, orderedListStyle: 
 
     let lastItemListIndicatorLevel = -1;
     listText = listText.replace(/^(( |\t|> )*)((\d+(\.|\)))|[-*+])([^\n]*)$/gm, (listItem: string, $1: string = '', _$2: string, $3: string, _$4: string, _$5: string, $6: string) => {
-      let listItemIndicatorNumber = 1;
-
+      let listItemIndicatorNumber = keepStart ? Number(_$4) : 1;
       const listItemIndicatorLevel = getListItemLevel($1);
       // when dealing with a value that is not an int reset all values greater than or equal to the current list level
       if (!/^\d/.test($3)) {
@@ -708,9 +707,11 @@ export function updateOrderedListItemIndicators(text: string, orderedListStyle: 
         if (orderedListStyle === OrderListItemStyles.Ascending) {
           listItemIndicatorNumber = preListIndicatorLevelsToIndicatorNumber.get(listItemIndicatorLevel) + 1;
           preListIndicatorLevelsToIndicatorNumber.set(listItemIndicatorLevel, listItemIndicatorNumber);
+        } else if (keepStart) {
+          listItemIndicatorNumber = preListIndicatorLevelsToIndicatorNumber.get(listItemIndicatorLevel);
         }
       } else {
-        preListIndicatorLevelsToIndicatorNumber.set(listItemIndicatorLevel, 1);
+        preListIndicatorLevelsToIndicatorNumber.set(listItemIndicatorLevel, listItemIndicatorNumber);
       }
 
       // if we have removed an indentation level then go ahead and remove the last set of sublist info for any levels between those two levels


### PR DESCRIPTION
Closes #744. 

This PR adds two new options to enable the following Ordered List Style linter behaviors:

1. Ordered list numbering is left as-is. This is useful if you want to enable Ordered List Indicator End Style / other potential future options but want manual control over numbers.
2. Ordered list numbering keeps the initial indicator number from each list. (This is the behavior I was looking for, though I didn't realize at first that it's slightly different from what was requested in #744.)

I initially implemented the 2nd behavior as an additional Number Style choice, but to my surprise, Obsidian actually handles lazy numbering when a list starts at a value other than 1 (it increments from there). I don't know how useful this behavior is in practice, but let me know if there's anything you'd like me to change. 