### PR TITLE
Protect Against Null Reference

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -232,7 +232,11 @@ export default class LinterPlugin extends Plugin {
       icon: iconInfo.folder.id,
       editorCheckCallback: (checking: Boolean, _, ctx) => {
         if (checking) {
-          return !ctx.file.parent.isRoot();
+          if (ctx && ctx.file && ctx.file instanceof TFile && ctx.file.parent) {
+            return !ctx.file.parent.isRoot();
+          }
+
+          return false;
         }
 
         this.createFolderLintModal(ctx.file.parent);


### PR DESCRIPTION
Relates to #1182 

There was a report that calling parent on a tfile was causing an issue since it was null. So I added a set of protective checks.