### PR TITLE
Hide Unreachable Settings

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -152,10 +152,6 @@ export default {
         'name': 'Display Lint on File Change Message',
         'description': 'Displays a message when `Lint on Focused File Change` occurs',
       },
-      'timestamp-update-on-file-contents-updated': {
-        'name': 'Update YAML Timestamp on File Contents Update',
-        'description': 'When the currently active file is modified, `YAML Timestamp` is run on the file. This should update the modified file timestamp if it is more than 5 seconds off from the current value.',
-      },
       'folders-to-ignore': {
         'name': 'Folders to ignore',
         'description': 'Folders to ignore when linting all files or linting on save.',
@@ -848,6 +844,10 @@ export default {
       'convert-to-utc': {
         'name': 'Convert Local Time to UTC',
         'description': 'Uses UTC equivalent for saved dates instead of local time',
+      },
+      'update-on-file-contents-updated': {
+        'name': 'Update YAML Timestamp on File Contents Update',
+        'description': 'When the currently active note is modified, `YAML Timestamp` is run on the note. This should update the modified note timestamp if it is more than 5 seconds off from the current value.',
       },
     },
     // yaml-title-alias.ts

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -56,7 +56,17 @@ export class Rule {
   ) {
     this.ruleHeading = this.getName().toLowerCase().replaceAll(' ', '-');
 
-    options.unshift(new BooleanOption('enabled', this.descriptionKey, '' as LanguageStringKey, false));
+    options.unshift(new BooleanOption('enabled', this.descriptionKey, '' as LanguageStringKey, false, alias, (value: boolean) => {
+      if (options.length > 1) {
+        for (let i = 1; i < options.length; i++) {
+          if (value) {
+            options[i].unhide();
+          } else {
+            options[i].hide();
+          }
+        }
+      }
+    }));
     for (const option of options) {
       option.ruleAlias = alias;
     }

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -7,7 +7,7 @@ import {escapeDollarSigns} from '../utils/regex';
 import {insert} from '../utils/strings';
 import parseFormat from 'moment-parseformat';
 import {getTextInLanguage} from '../lang/helpers';
-import {AfterFileChangeLintTimes} from 'src/settings-data';
+import {AfterFileChangeLintTimes} from '../settings-data';
 
 type DateCreatedSourceOfTruth = 'file system' | 'frontmatter';
 type DateModifiedSourceOfTruth = 'file system' | 'user or Linter edits';

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -7,6 +7,7 @@ import {escapeDollarSigns} from '../utils/regex';
 import {insert} from '../utils/strings';
 import parseFormat from 'moment-parseformat';
 import {getTextInLanguage} from '../lang/helpers';
+import {AfterFileChangeLintTimes} from 'src/settings-data';
 
 type DateCreatedSourceOfTruth = 'file system' | 'frontmatter';
 type DateModifiedSourceOfTruth = 'file system' | 'user or Linter edits';
@@ -28,6 +29,10 @@ class YamlTimestampOptions implements Options {
   dateModifiedKey?: string = 'date modified';
 
   convertToUTC?: boolean = false;
+
+  // This is not used in the rule itself. It is used for running this rule as a standalone when
+  // editor content is updated.
+  timestampUpdateOnFileContentUpdated?: AfterFileChangeLintTimes =AfterFileChangeLintTimes.Never;
 
   @RuleBuilder.noSettingControl()
     fileModifiedTime?: string;
@@ -454,6 +459,38 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
         nameKey: 'rules.yaml-timestamp.convert-to-utc.name',
         descriptionKey: 'rules.yaml-timestamp.convert-to-utc.description',
         optionsKey: 'convertToUTC',
+      }),
+      new DropdownOptionBuilder<YamlTimestampOptions, AfterFileChangeLintTimes>({
+        OptionsClass: YamlTimestampOptions,
+        nameKey: 'rules.yaml-timestamp.update-on-file-contents-updated.name',
+        descriptionKey: 'rules.yaml-timestamp.update-on-file-contents-updated.description',
+        optionsKey: 'timestampUpdateOnFileContentUpdated',
+        records: [
+          {
+            value: AfterFileChangeLintTimes.Never,
+            description: AfterFileChangeLintTimes.Never,
+          },
+          {
+            value: AfterFileChangeLintTimes.After5Seconds,
+            description: AfterFileChangeLintTimes.After5Seconds,
+          },
+          {
+            value: AfterFileChangeLintTimes.After10Seconds,
+            description: AfterFileChangeLintTimes.After10Seconds,
+          },
+          {
+            value: AfterFileChangeLintTimes.After15Seconds,
+            description: AfterFileChangeLintTimes.After15Seconds,
+          },
+          {
+            value: AfterFileChangeLintTimes.After30Seconds,
+            description: AfterFileChangeLintTimes.After30Seconds,
+          },
+          {
+            value: AfterFileChangeLintTimes.After1Minute,
+            description: AfterFileChangeLintTimes.After1Minute,
+          },
+        ],
       }),
     ];
   }

--- a/src/settings-data.ts
+++ b/src/settings-data.ts
@@ -33,7 +33,6 @@ export interface LinterSettings {
   recordLintOnSaveLogs: boolean;
   lintOnFileChange: boolean;
   displayLintOnFileChangeNotice: boolean;
-  lintOnFileContentChangeDelay: string;
   foldersToIgnore: string[];
   filesToIgnore: FileToIgnore[];
   linterLocale: string;
@@ -52,7 +51,6 @@ export const DEFAULT_SETTINGS: Partial<LinterSettings> = {
   displayChanged: true,
   lintOnFileChange: false,
   displayLintOnFileChangeNotice: false,
-  lintOnFileContentChangeDelay: AfterFileChangeLintTimes.Never,
   settingsConvertedToConfigKeyValues: false,
   foldersToIgnore: [],
   filesToIgnore: [],

--- a/src/ui/components/text-box-full.ts
+++ b/src/ui/components/text-box-full.ts
@@ -1,7 +1,9 @@
 import {Notice, setIcon} from 'obsidian';
 import {getTextInLanguage} from 'src/lang/helpers';
+import {hideEl, unhideEl} from '../helpers';
 
 export class TextBoxFull {
+  settingEl: HTMLDivElement;
   nameEl: HTMLDivElement;
   descEl: HTMLDivElement;
   inputContainerEl: HTMLDivElement;
@@ -13,8 +15,8 @@ export class TextBoxFull {
   }
 
   display() {
-    const settingEl = this.containerEl.createDiv();
-    const infoEl = settingEl.createDiv('setting-item-info');
+    this.settingEl = this.containerEl.createDiv();
+    const infoEl = this.settingEl.createDiv('setting-item-info');
 
     this.nameEl = infoEl.createDiv('setting-item-name');
     this.nameEl.setText(this.name);
@@ -22,7 +24,7 @@ export class TextBoxFull {
     this.descEl = infoEl.createDiv('setting-item-description');
     this.descEl.setText(this.description);
 
-    this.inputContainerEl = settingEl.createDiv('full-width-textbox-input-wrapper');
+    this.inputContainerEl = this.settingEl.createDiv('full-width-textbox-input-wrapper');
     this.inputContainerEl.onmouseover = () => {
       if (this.getInput().trim() != '') {
         this.copyEl.removeClass('linter-visually-hidden');
@@ -56,5 +58,13 @@ export class TextBoxFull {
     }, (reason: any) => {
       new Notice(`${getTextInLanguage('notice-text.copy-to-clipboard-failed') + reason}`, 0);
     });
+  }
+
+  hide() {
+    hideEl(this.settingEl);
+  }
+
+  unhide() {
+    unhideEl(this.settingEl);
   }
 }

--- a/src/ui/components/toggle-setting.ts
+++ b/src/ui/components/toggle-setting.ts
@@ -3,10 +3,11 @@ import LinterPlugin from 'src/main';
 import {LinterSettingsKeys} from 'src/settings-data';
 import {BaseSetting} from './base-setting';
 import {LanguageStringKey} from 'src/lang/helpers';
+import {hideEl, unhideEl} from '../helpers';
 
 export class ToggleSetting extends BaseSetting<boolean> {
   setting: Setting;
-  constructor(containerEl: HTMLDivElement, name: LanguageStringKey, description: LanguageStringKey, keyToUpdate: LinterSettingsKeys, plugin: LinterPlugin) {
+  constructor(containerEl: HTMLDivElement, name: LanguageStringKey, description: LanguageStringKey, keyToUpdate: LinterSettingsKeys, plugin: LinterPlugin, private onChange?: (value: boolean) => void) {
     super(containerEl, name, description, keyToUpdate, plugin);
     this.display();
   }
@@ -17,10 +18,22 @@ export class ToggleSetting extends BaseSetting<boolean> {
           toggle
               .setValue(this.getBoolean())
               .onChange(async (value) => {
+                if (this.onChange) {
+                  this.onChange(value);
+                }
+
                 void this.saveValue(value);
               });
         });
 
     this.parseNameAndDescription();
+  }
+
+  hide() {
+    hideEl(this.setting.settingEl);
+  }
+
+  unhide() {
+    unhideEl(this.setting.settingEl);
   }
 }

--- a/src/ui/linter-components/tab-components/debug-tab.ts
+++ b/src/ui/linter-components/tab-components/debug-tab.ts
@@ -36,16 +36,28 @@ export class DebugTab extends Tab {
 
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
 
+    let logDisplay: TextBoxFull = null;
     tempDiv = this.contentEl.createDiv();
-    this.addSettingSearchInfoForGeneralSettings(new ToggleSetting(tempDiv, 'tabs.debug.log-collection.name', 'tabs.debug.log-collection.description', 'recordLintOnSaveLogs', this.plugin));
+    const recordLintOnSaveLogsSetting = new ToggleSetting(tempDiv, 'tabs.debug.log-collection.name', 'tabs.debug.log-collection.description', 'recordLintOnSaveLogs', this.plugin, (value: boolean) => {
+      if (value) {
+        logDisplay.unhide();
+      } else {
+        logDisplay.hide();
+      }
+    });
+    this.addSettingSearchInfoForGeneralSettings(recordLintOnSaveLogsSetting);
 
     tempDiv = this.contentEl.createDiv();
     settingName = getTextInLanguage('tabs.debug.linter-logs.name');
     settingDesc = getTextInLanguage('tabs.debug.linter-logs.description');
-    const logDisplay = new TextBoxFull(tempDiv, settingName, '');
+    logDisplay = new TextBoxFull(tempDiv, settingName, '');
     logDisplay.inputEl.setText(logsFromLastRun.join('\n'));
 
     parseTextToHTMLWithoutOuterParagraph(this.plugin.app, settingDesc, logDisplay.descEl, this.plugin.settingsTab.component);
+
+    if (!recordLintOnSaveLogsSetting.getBoolean()) {
+      logDisplay.hide();
+    }
 
     this.addSettingSearchInfo(tempDiv, settingName, settingDesc);
   }

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -9,7 +9,6 @@ import {NumberInputSetting} from 'src/ui/components/number-input-setting';
 import {ToggleSetting} from 'src/ui/components/toggle-setting';
 import {FolderIgnoreOption} from '../folder-ignore-option';
 import {FilesToIgnoreOption} from '../files-to-ignore-option';
-import {AfterFileChangeLintTimes} from 'src/settings-data';
 
 export class GeneralTab extends Tab {
   constructor(navEl: HTMLElement, settingsEl: HTMLElement, isMobile: boolean, plugin: LinterPlugin, private app: App) {
@@ -54,22 +53,6 @@ export class GeneralTab extends Tab {
     if (!lintOnActiveFileChangeSetting.getBoolean()) {
       displayLintOnActiveFileChangeSetting.hide();
     }
-
-    const yamlTimestampTimeOptions: DropdownRecordInfo = {
-      isForEnum: true,
-      values: [
-        AfterFileChangeLintTimes.Never,
-        AfterFileChangeLintTimes.After5Seconds,
-        AfterFileChangeLintTimes.After10Seconds,
-        AfterFileChangeLintTimes.After15Seconds,
-        AfterFileChangeLintTimes.After30Seconds,
-        AfterFileChangeLintTimes.After1Minute,
-      ],
-      descriptions: [],
-    };
-
-    tempDiv = this.contentEl.createDiv();
-    this.addSettingSearchInfoForGeneralSettings(new DropdownSetting(tempDiv, 'tabs.general.timestamp-update-on-file-contents-updated.name', 'tabs.general.timestamp-update-on-file-contents-updated.description', 'lintOnFileContentChangeDelay', this.plugin, yamlTimestampTimeOptions));
 
     const sysLocale = navigator.language?.toLowerCase();
     const localeValues = ['system-default'];

--- a/src/ui/linter-components/tab-components/general-tab.ts
+++ b/src/ui/linter-components/tab-components/general-tab.ts
@@ -19,16 +19,41 @@ export class GeneralTab extends Tab {
 
   display(): void {
     let tempDiv = this.contentEl.createDiv();
-    this.addSettingSearchInfoForGeneralSettings(new ToggleSetting(tempDiv, 'tabs.general.lint-on-save.name', 'tabs.general.lint-on-save.description', 'lintOnSave', this.plugin));
+
+    let displayCharactersChangedSetting: ToggleSetting = null;
+    const lintOnSaveSetting = new ToggleSetting(tempDiv, 'tabs.general.lint-on-save.name', 'tabs.general.lint-on-save.description', 'lintOnSave', this.plugin, (value: boolean) => {
+      if (value) {
+        displayCharactersChangedSetting.unhide();
+      } else {
+        displayCharactersChangedSetting.hide();
+      }
+    });
+    this.addSettingSearchInfoForGeneralSettings(lintOnSaveSetting);
 
     tempDiv = this.contentEl.createDiv();
-    this.addSettingSearchInfoForGeneralSettings(new ToggleSetting(tempDiv, 'tabs.general.display-message.name', 'tabs.general.display-message.description', 'displayChanged', this.plugin));
+    displayCharactersChangedSetting = new ToggleSetting(tempDiv, 'tabs.general.display-message.name', 'tabs.general.display-message.description', 'displayChanged', this.plugin);
+    this.addSettingSearchInfoForGeneralSettings(displayCharactersChangedSetting);
+    if (!lintOnSaveSetting.getBoolean()) {
+      displayCharactersChangedSetting.hide();
+    }
+
+    let displayLintOnActiveFileChangeSetting: ToggleSetting = null;
+    tempDiv = this.contentEl.createDiv();
+    const lintOnActiveFileChangeSetting = new ToggleSetting(tempDiv, 'tabs.general.lint-on-file-change.name', 'tabs.general.lint-on-file-change.description', 'lintOnFileChange', this.plugin, (value: boolean) => {
+      if (value) {
+        displayLintOnActiveFileChangeSetting.unhide();
+      } else {
+        displayLintOnActiveFileChangeSetting.hide();
+      }
+    });
+    this.addSettingSearchInfoForGeneralSettings(lintOnActiveFileChangeSetting);
 
     tempDiv = this.contentEl.createDiv();
-    this.addSettingSearchInfoForGeneralSettings(new ToggleSetting(tempDiv, 'tabs.general.lint-on-file-change.name', 'tabs.general.lint-on-file-change.description', 'lintOnFileChange', this.plugin));
-
-    tempDiv = this.contentEl.createDiv();
-    this.addSettingSearchInfoForGeneralSettings(new ToggleSetting(tempDiv, 'tabs.general.display-lint-on-file-change-message.name', 'tabs.general.display-lint-on-file-change-message.description', 'displayLintOnFileChangeNotice', this.plugin));
+    displayLintOnActiveFileChangeSetting = new ToggleSetting(tempDiv, 'tabs.general.display-lint-on-file-change-message.name', 'tabs.general.display-lint-on-file-change-message.description', 'displayLintOnFileChangeNotice', this.plugin);
+    this.addSettingSearchInfoForGeneralSettings(displayLintOnActiveFileChangeSetting);
+    if (!lintOnActiveFileChangeSetting.getBoolean()) {
+      displayLintOnActiveFileChangeSetting.hide();
+    }
 
     const yamlTimestampTimeOptions: DropdownRecordInfo = {
       isForEnum: true,

--- a/src/ui/linter-components/tab-components/rule-tab.ts
+++ b/src/ui/linter-components/tab-components/rule-tab.ts
@@ -1,7 +1,8 @@
 import LinterPlugin from 'src/main';
 import {Tab} from './tab';
 import {Rule} from 'src/rules';
-import {SearchOptionInfo} from 'src/option';
+import {BooleanOption, SearchOptionInfo} from 'src/option';
+import {Setting} from 'obsidian';
 
 export class RuleTab extends Tab {
   constructor(navEl: HTMLElement, settingsEl: HTMLElement, ruleTypeName: string, private rules: Rule[], isMobile: boolean, plugin: LinterPlugin) {
@@ -13,14 +14,24 @@ export class RuleTab extends Tab {
     for (const rule of this.rules) {
       const ruleDiv = this.contentEl.createDiv();
       ruleDiv.id = rule.alias;
-      ruleDiv.createEl(this.isMobile ? 'h4' : 'h3', {}, (el) => {
-        el.innerHTML = `<a href="${rule.getURL()}">${rule.getName()}</a>`;
-      });
+
+      new Setting(ruleDiv).setHeading().settingEl.innerHTML = `<a href="${rule.getURL()}">${rule.getName()}</a>`;
 
       const optionInfo = [] as SearchOptionInfo[];
+      let isFirstOption = true;
+      let hideOnLoad = false;
       for (const option of rule.options) {
         option.display(ruleDiv, this.plugin.settings, this.plugin);
         optionInfo.push(option.getSearchInfo());
+
+        if (isFirstOption) {
+          isFirstOption = false;
+          if (option instanceof BooleanOption) {
+            hideOnLoad = !this.plugin.settings.ruleConfigs[option.ruleAlias][option.configKey];
+          }
+        } else if (hideOnLoad) {
+          option.hide();
+        }
       }
 
       this.addSettingSearchInfo(ruleDiv, rule.getName().toLowerCase(), rule.getDescription().toLowerCase(), optionInfo, ruleDiv.id);

--- a/src/ui/linter-components/tab-components/tab.ts
+++ b/src/ui/linter-components/tab-components/tab.ts
@@ -1,7 +1,7 @@
 import {iconInfo} from 'src/ui/icons';
 import LinterPlugin from 'src/main';
 import {RuleType} from 'src/rules';
-import {setIcon} from 'obsidian';
+import {setIcon, Setting} from 'obsidian';
 import {settingSearchInfo} from './tab-searcher';
 import {SearchOptionInfo} from 'src/option';
 import {hideEl, unhideEl} from 'src/ui/helpers';
@@ -59,7 +59,7 @@ export abstract class Tab {
     this.contentEl = settingsEl.createDiv('linter-tab-settings');
     this.contentEl.id = name.toLowerCase().replace(' ', '-');
 
-    this.headingEl = this.contentEl.createEl('h2', {text: nameInLanguage});
+    this.headingEl = new Setting(this.contentEl).setName(nameInLanguage).setHeading().nameEl;
     hideEl(this.headingEl);
   }
 


### PR DESCRIPTION
Relates to #1187 

This year it was shown how we can hide settings that are dependent on one another in plugins. So I decided I could do this in the Linter, as such I took a stab at it. There may be some wonkiness with search since searching for rules will still bring up rules that have hidden settings even if their displayed settings do not have the text that is being searched on. This change will also hopefully make things easier for new users to navigate the settings since unreachable settings should be hidden.

There may be a couple of general settings that can still benefit from being disabled based on the Linter rules they depend on. I am mostly thinking about lint on file content change.