### PR TITLE
Fix `Add Blank Line After YAML` Only Working When YAML Already Exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "16.x"
 
       - name: Build plugin and minfy css
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn.lock
 !__mocks__/*.js
 !/.eslintrc.js
 !babel.config.js
+!postcss.config.js

--- a/__integration__/yaml-rule.test.ts
+++ b/__integration__/yaml-rule.test.ts
@@ -1,5 +1,6 @@
 import TestLinterPlugin, {IntegrationTestCase} from './main.test';
-import {Editor} from 'obsidian';
+import {Editor, TFile} from 'obsidian';
+import moment from 'moment';
 
 function addBlankLineAfterSetup(plugin: TestLinterPlugin, _: Editor): Promise<void> {
   plugin.plugin.settings.ruleConfigs['add-blank-line-after-yaml'] = {
@@ -8,6 +9,53 @@ function addBlankLineAfterSetup(plugin: TestLinterPlugin, _: Editor): Promise<vo
 
   return;
 }
+
+function addBlankLineAfterYAMLConflictWithYAMLTimestampInsert(plugin: TestLinterPlugin): Promise<void> {
+  plugin.plugin.settings.ruleConfigs['add-blank-line-after-yaml'] = {
+    'enabled': true,
+  };
+  plugin.plugin.settings.ruleConfigs['yaml-timestamp'] = {
+    'enabled': true,
+    'date-created': true,
+    'date-created-key': 'created',
+    'date-created-source-of-truth': 'file system',
+    'date-modified': true,
+    'date-modified-key': 'last_modified',
+    'format': 'YYYY-MM-DD',
+  };
+
+  return;
+}
+
+function addBlankLineAfterYAMLConflictWithYAMLTimestampInsertExpectedTextModifications(text: string, file: TFile):string {
+  text = text.replace('{{created_date}}', moment(file.stat.ctime ?? '').format('YYYY-MM-DD'));
+  text = text.replace('{{modified_date}}', moment().format('YYYY-MM-DD'));
+
+  return text;
+}
+
+function addBlankLineAfterYAMLConflictWithYAMLTimestampUpdate(plugin: TestLinterPlugin): Promise<void> {
+  plugin.plugin.settings.ruleConfigs['add-blank-line-after-yaml'] = {
+    'enabled': true,
+  };
+  plugin.plugin.settings.ruleConfigs['yaml-timestamp'] = {
+    'enabled': true,
+    'date-created': false,
+    'date-modified': true,
+    'date-modified-key': 'last_modified',
+    'date-modified-source-of-truth': 'user or Linter edits',
+    'format': 'YYYY-MM-DD',
+  };
+
+  return;
+}
+
+function addBlankLineAfterYAMLConflictWithYAMLTimestampUpdateExpectedTextModifications(text: string):string {
+  text = text.replace('{{modified_date}}', moment().format('YYYY-MM-DD'));
+
+  return text;
+}
+
 
 export const obsidianYAMLRuleTestCases: IntegrationTestCase[] = [
   {
@@ -19,5 +67,17 @@ export const obsidianYAMLRuleTestCases: IntegrationTestCase[] = [
     name: 'Updating a file with yaml and no blanks for adding blank lines after yaml should get updated',
     filePath: 'yaml-rules/add-blank-line-after-yaml/yaml.md',
     setup: addBlankLineAfterSetup,
+  },
+  {
+    name: 'Updating a file with no yaml where YAML Timestamp Adds a Date Created, should properly update the YAML with a blank line after the frontmatter',
+    filePath: 'yaml-rules/add-blank-line-after-yaml/no-yaml-timestamp-addition.md',
+    setup: addBlankLineAfterYAMLConflictWithYAMLTimestampInsert,
+    modifyExpected: addBlankLineAfterYAMLConflictWithYAMLTimestampInsertExpectedTextModifications,
+  },
+  {
+    name: 'Updating a file with yaml where YAML Timestamp will only be updated if a change is made to the file, should properly add the missing blank line and update the date modified timestamp',
+    filePath: 'yaml-rules/add-blank-line-after-yaml/yaml-timestamp-update.md',
+    setup: addBlankLineAfterYAMLConflictWithYAMLTimestampUpdate,
+    modifyExpected: addBlankLineAfterYAMLConflictWithYAMLTimestampUpdateExpectedTextModifications,
   },
 ];

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: [
+    require('cssnano')({
+      preset: 'default',
+    }),
+  ],
+};

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -152,7 +152,7 @@ export default {
       },
       'lint-on-file-change': {
         'name': 'Lint on Focused File Change',
-        'description': 'When the a file is closed or a new file is swapped to, the previous file is linted.',
+        'description': 'When a file is closed or a new file is swapped to, the previous file is linted.',
       },
       'display-lint-on-file-change-message': {
         'name': 'Display Lint on File Change Message',

--- a/src/rules/add-blank-line-after-yaml.ts
+++ b/src/rules/add-blank-line-after-yaml.ts
@@ -13,6 +13,8 @@ export default class AddBlankLineAfterYAML extends RuleBuilder<AddBlankLineAfter
       nameKey: 'rules.add-blank-line-after-yaml.name',
       descriptionKey: 'rules.add-blank-line-after-yaml.description',
       type: RuleType.YAML,
+      // needs to run before YAML timestamp if the YAML is present, but after it otherwise
+      hasSpecialExecutionOrder: true,
     });
   }
   get OptionsClass(): new () => AddBlankLineAfterYAMLOptions {

--- a/test-vault/yaml-rules/add-blank-line-after-yaml/no-yaml-timestamp-addition.linted.md
+++ b/test-vault/yaml-rules/add-blank-line-after-yaml/no-yaml-timestamp-addition.linted.md
@@ -1,0 +1,6 @@
+---
+created: {{created_date}}
+last_modified: {{modified_date}}
+---
+
+Content here.

--- a/test-vault/yaml-rules/add-blank-line-after-yaml/no-yaml-timestamp-addition.md
+++ b/test-vault/yaml-rules/add-blank-line-after-yaml/no-yaml-timestamp-addition.md
@@ -1,0 +1,1 @@
+Content here.

--- a/test-vault/yaml-rules/add-blank-line-after-yaml/yaml-timestamp-update.linted.md
+++ b/test-vault/yaml-rules/add-blank-line-after-yaml/yaml-timestamp-update.linted.md
@@ -1,0 +1,5 @@
+---
+last_modified: {{modified_date}}
+---
+
+Content here.

--- a/test-vault/yaml-rules/add-blank-line-after-yaml/yaml-timestamp-update.md
+++ b/test-vault/yaml-rules/add-blank-line-after-yaml/yaml-timestamp-update.md
@@ -1,0 +1,4 @@
+---
+last_modified: 2024-10-11
+---
+Content here.


### PR DESCRIPTION
Fixes #1188 
Relates to #1199 

There was an issue with running the Linter rule `Add Blank Line after YAML` where it was not adding a blank line after the YAML if it was added by say `YAML Timestamp`. The issue was caused by the YAML being added long after the rule had run. This meant it could not add the blank line. To fix this, the rule needs to run before `YAML Timestamp` if the YAML is present since there could be a modification that needs to cause a timestamp update. However if there is no YAML frontmatter present, then it can run after `YAML Timestamp` since it will either create the frontmatter or no frontmatter will exist by the time the Linter's rules run.

There was also a change to make the release compiled version of the plugin be `16.x` since that is the minimum version that should be supported by plugins at this time.

There was also a small fix of a typo in a setting's wording.

It also adds a fix to the minification of the styles which was previously not merged due to the gitignore.

Changes Made:
- Fixed a small typo (see #1199)
- Adds proper minification for styles.css
- Adds some integration tests for the scenario in question
- Runs `Add Blank Line After YAML` either before or after `YAML Timestamp` depending upon the situation in question
