### PR TITLE
Fix `YAML Timestamp` Debounce not Starting with the First Character Change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -259,13 +259,16 @@ export default class LinterPlugin extends Plugin {
           this.activeFileChangeDebouncer.get(info.file).debounceFn(info.file, editor);
         }
       } else {
-        this.activeFileChangeDebouncer.set(info.file, {
+        const activeFileDebounceInfo = {
           debounceFn: this.createDebouncedFileUpdate(),
           isRunning: false,
           // do not use editor because it already has the change, so if the user removes all changes
           // it would still make an update
           originalText: await this.app.vault.cachedRead(info.file),
-        });
+        };
+
+        this.activeFileChangeDebouncer.set(info.file, activeFileDebounceInfo);
+        activeFileDebounceInfo.debounceFn(info.file, editor);
       }
     });
     this.registerEvent(eventRef);


### PR DESCRIPTION
Relates to #1199 

There was an issue mentioned where the `YAML Timestamp` logic was not having the debounced logic run when a single character was updated. It seems that the debounce function is not automatically started once created, so it needs to be called after creation in this case.

Changes Made:
- Immediately called the debounce function instead of just instantiating it
  - Should allow for the debounce function to start its timer immediately once the first editor change happens 