### PR TITLE
Update Release Note Generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+# .github/release.yml
+
+changelog:
+  categories:
+    - title: 'Features'
+      labels:
+        - 'enhancement'
+    - title: 'Bugs'
+      labels:
+        - 'bug'
+    - title: 'Documentation'
+      label: 'documentation'
+    - title: 'Maintenance'
+      labels:
+        - 'github'
+        - 'dependencies'
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,6 @@ jobs:
 
           gh release create "$tag" \
             --title="$tag" \
+            --generate-notes \
             --draft \
             main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}.zip


### PR DESCRIPTION
This is an attempt to get release notes generating in a format that will save me more time when creating a release. If it does not work, we can rollback.

Essentially what the change should do is twofold:
- Automatically generate the release

This should make it so that I have less to do when filling out the information on the release (just the tag and description hopefully).

- Auto group the PRs into categories