### PR TITLE
Update ChangeLog Categories for PRs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,3 @@
-# .github/release.yml
-
 changelog:
   categories:
     - title: 'Features'
@@ -9,7 +7,8 @@ changelog:
       labels:
         - 'bug'
     - title: 'Documentation'
-      label: 'documentation'
+      labels:
+        - 'documentation'
     - title: 'Maintenance'
       labels:
         - 'github'


### PR DESCRIPTION
Here is another change to make the categories on the autogenerated github release data easier to follow. It should fix an issue with documentation not being labeled correctly.