### PR TITLE
Fix `YAML Key Sort` Not Accounting for Trailing Whitespace on Keys

### DIFF
--- a/__tests__/yaml-key-sort.test.ts
+++ b/__tests__/yaml-key-sort.test.ts
@@ -143,5 +143,61 @@ ruleTest({
         ],
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1202
+      testName: 'Make sure that settings that end in whitespace have them trimmed so they are properly recognized',
+      before: dedent`
+        ---
+        stakeholders:${' '}
+        pr-type:${' '}
+        date-created: Thursday, August 22nd 2024, 6:41:04 pm
+        pr-pipeline-stage:${' '}
+        pr-priority:${' '}
+        modified: Tuesday, October 22nd 2024, 10:58:16 am
+        pr-size:${' '}
+        pr-urgency:${' '}
+        pr-okr:${' '}
+        pr-due-date:${' '}
+        pr-completed-date:${' '}
+        template: "[[Pro New Project Outcome Template]]"
+        related-companies:${' '}
+        created-date: '[[<% tp.file.creation_date("YYYY-MM-DD") %>]]'
+        ---
+      `,
+      after: dedent`
+        ---
+        related-companies:${' '}
+        stakeholders:${' '}
+        pr-pipeline-stage:${' '}
+        pr-priority:${' '}
+        pr-size:${' '}
+        pr-urgency:${' '}
+        pr-type:${' '}
+        pr-okr:${' '}
+        pr-due-date:${' '}
+        pr-completed-date:${' '}
+        template: "[[Pro New Project Outcome Template]]"
+        created-date: '[[<% tp.file.creation_date("YYYY-MM-DD") %>]]'
+        modified: Tuesday, October 22nd 2024, 10:58:16 am
+        date-created: Thursday, August 22nd 2024, 6:41:04 pm
+        ---
+      `,
+      options: {
+        yamlKeyPrioritySortOrder: [
+          'related-companies: ',
+          'stakeholders: ',
+          'pr-pipeline-stage:',
+          'pr-priority:',
+          'pr-size:',
+          'pr-urgency:',
+          'pr-type: ',
+          'pr-okr:',
+          'pr-due-date:',
+          'pr-completed-date: ',
+          'template:',
+          'created-date:',
+          'modified:',
+        ],
+      },
+    },
   ],
 });

--- a/src/rules/yaml-key-sort.ts
+++ b/src/rules/yaml-key-sort.ts
@@ -45,9 +45,12 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
 
     const yamlKeys: string[] = options.yamlKeyPrioritySortOrder;
     let index = 0;
-    for (const key of yamlKeys) {
+    for (let key of yamlKeys) {
+      key = key.trimEnd();
       if (key.endsWith(':')) {
         yamlKeys[index] = key.substring(0, key.length - 1);
+      } else if (key != yamlKeys[index]) {
+        yamlKeys[index] = key;
       }
 
       index++;


### PR DESCRIPTION
Fixes #1202 

There was an issue where Priority Sort would not work if there was a space after the colon assuming there was a colon. So the values are now getting trimmed.

Changes Made:
- Added a test for the scenario provided
- Removed trailing whitespace on key names