### PR TITLE
Fix Paste Override Not Pasting in File Preview Editor and Race Condition in `YAML Timestamp` Updates via User Edits

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -271,7 +271,7 @@ export default class LinterPlugin extends Plugin {
         this.activeFileChangeDebouncer.set(info.file.path, activeFileDebounceInfo);
         // do not use editor because it already has the change, so if the user removes all changes
         // it would still make an update. We do this here due to a race condition in some situations.
-        activeFileDebounceInfo.originalText =  await this.app.vault.cachedRead(info.file);
+        activeFileDebounceInfo.originalText = await this.app.vault.cachedRead(info.file);
         activeFileDebounceInfo.debounceFn(info.file, editor);
       }
     });


### PR DESCRIPTION
Fixes #1219 

There was an issue reported where when a user tries to paste into a markdown file preview it was pasting in the current document instead. This was caused by not using the editor provided by the `editor-paste` event. Using that editor, fixed the issue. However it showed another issue.

Using the editor from an `editor-paste` event is not 100% reliable for the Linter since it only provides the content linked to by the internal link. That is fine if it links to a file. However if it links to a header, paragraph, or otherwise, it would insert the timestamp change at the start of the linked to text. So there needed to be branching logic in the Linter to handle when the editor was a whole file versus it being in a part of the file. This also showed another issue.

The Linter was occasionally logging a warning saying that it was trying to run a debounce function on a file that was no longer in the map. This was odd since the logic for adding to the map first checked if the value was present. Well, the issue was that between the first `editor-change` event and the second you could have a situation where the cached read of the file's contents had not yet completed. This resulted in two plus additions to the map instead of one. To fix this, the cached read was moved to after the value was added to the map. The reason it needed to move is that the `editor-change` event does not seem to handle waiting async callbacks to complete before starting the next `editor-change` event.

Changes Made:
- Swapped to using the file path for the editor change file's key in the map since it is smaller and should be more restrictive
- Updated the paste event handler to make sure it used the editor of the paste event
- Updated the `editor-change`'s debounced function to make sure it handled partial file editors vs full file editors properly
- Moved cached read of the `editor-changed` file info to after the addition to the map to prevent race conditions where the same file got added to the map more than once causing warnings in the console