### PR TITLE
Fix Lots of Locale Not Found Warnings in the Console for Unsupported Locale

### DIFF
--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -86,19 +86,20 @@ export const localeToFileName: { [k: string]: string} = {
 
 export type LanguageStringKey = NestedKeyOf<LanguageStrings>
 
-let lang = 'en';
+const defaultLang = 'en';
+let lang = defaultLang;
 let locale = localeMap[lang];
 
 export function setLanguage(newLang: string) {
   lang = newLang;
-  locale = localeMap[lang || 'en'];
+  locale = localeMap[lang];
+  if (!locale) {
+    logWarn(`locale not found for '${lang}'`);
+    locale = localeMap[defaultLang];
+  }
 }
 
 export function getTextInLanguage(str: LanguageStringKey): string {
-  if (!locale) {
-    logWarn(`locale not found for '${lang}'`);
-  }
-
   const text: unknown = (locale && getString<LanguageStrings>(locale, str)) || getString<LanguageStrings>(en, str);
 
   return text as string;


### PR DESCRIPTION
Fixes #1220 

There was an issue reported where the Linter was logging a lot of warnings to the console when the desired locale had no equivalent translation. The reason was that we did this each time a string was retrieved instead of just when we set the language.

Changes Made:
- Moved locale not supported warning to `setLanguage`