### PR TITLE
Fix Rule Order Edge Case Between `Paragraph Blank Lines` and `Consecutive Blank Lines`

### DIFF
--- a/src/rules-runner.ts
+++ b/src/rules-runner.ts
@@ -32,6 +32,7 @@ import {CustomAutoCorrectContent} from './ui/linter-components/auto-correct-file
 import AutoCorrectCommonMisspellings from './rules/auto-correct-common-misspellings';
 import {yamlRegex} from './utils/regex';
 import AddBlankLineAfterYAML from './rules/add-blank-line-after-yaml';
+import ConsecutiveBlankLines from './rules/consecutive-blank-lines';
 
 export type RunLinterRulesOptions = {
   oldText: string,
@@ -170,6 +171,8 @@ export class RulesRunner {
     });
 
     [newText] = TrailingSpaces.applyIfEnabled(newText, runOptions.settings, this.disabledRules);
+
+    [newText] = ConsecutiveBlankLines.applyIfEnabled(newText, runOptions.settings, this.disabledRules);
 
     const yaml = newText.match(yamlRegex);
     if (yaml != null) {

--- a/src/rules/consecutive-blank-lines.ts
+++ b/src/rules/consecutive-blank-lines.ts
@@ -13,6 +13,7 @@ export default class ConsecutiveBlankLines extends RuleBuilder<ConsecutiveBlankL
       descriptionKey: 'rules.consecutive-blank-lines.description',
       type: RuleType.SPACING,
       ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag],
+      hasSpecialExecutionOrder: true, // runs after most rules to cleanup any leftover spacing https://github.com/platers/obsidian-linter/issues/1225
     });
   }
   get OptionsClass(): new () => ConsecutiveBlankLinesOptions {


### PR DESCRIPTION
Fixes #1225 

There was an issue where running Paragraph Blank Lines when you had something like the following:
``` markdown
Here is a paragraph.  // note the two spaces at the end of this line
  // note the the two spaces at the end of this line
Another paragraph here.
```

It would add a blank lines between the the two paragraphs. However because `Consecutive Blank Lines` ran before `Paragraph Blank Lines` it was unable to clean up those blank lines.

To fix this, the order was changed to make sure `Consecutive Blank Lines` runs after `Paragraph Blank Lines`.

Changes Made:
- Moved the order around so `Consecutive Blank Lines` runs after `Paragraph Blank Lines`.
