### PR TITLE
Feat: `Line Break at Document End` No Longer Adds Blank Line at End of Empty Notes

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -510,7 +510,7 @@ export default {
     // line-break-at-document-end.ts
     'line-break-at-document-end': {
       'name': 'Line Break at Document End',
-      'description': 'Ensures that there is exactly one line break at the end of a document.',
+      'description': 'Ensures that there is exactly one line break at the end of a document if the note is not empty.',
     },
     // move-footnotes-to-the-bottom.ts
     'move-footnotes-to-the-bottom': {

--- a/src/rules/line-break-at-document-end.ts
+++ b/src/rules/line-break-at-document-end.ts
@@ -17,6 +17,10 @@ export default class LineBreakAtDocumentEnd extends RuleBuilder<LineBreakAtDocum
     return LineBreakAtDocumentEndOptions;
   }
   apply(text: string, options: LineBreakAtDocumentEndOptions): string {
+    if (text.length === 0) {
+      return text;
+    }
+
     text = text.replace(/\n+$/g, '');
     text += '\n';
     return text;
@@ -45,6 +49,11 @@ export default class LineBreakAtDocumentEnd extends RuleBuilder<LineBreakAtDocum
           Lorem ipsum dolor sit amet, consectetur adipiscing elit.
           ${''}
         `,
+      }),
+      new ExampleBuilder({ // https://github.com/platers/obsidian-linter/issues/1228
+        description: 'Empty files will not have a blank line added',
+        before: dedent``,
+        after: dedent``,
       }),
     ];
   }


### PR DESCRIPTION
Fixes #1228 

There was an issue/edge case in `Line Break at Document End` that was never really addressed. This issue was that an empty note would have a blank line added to it. This is not really the intent of the rule and is annoying when no other content is present. Thus it is being removed.

Changes Made:
- Added an example showing this behavior (also counts as a UT)
- Updated the logic in `Line Break at Document End` to return the current text if there is no content
- Updated the rule description to mention that this is the case