### PR TITLE
Feat: Add Ability to Ignore Files and Folders from Popup Menu and Commands

### DIFF
--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -32,11 +32,23 @@ export default {
     'paste-as-plain-text': {
       'name': 'Paste as Plain Text & without Modifications',
     },
+    'ignore-folder': {
+      'name': 'Ignore folder',
+    },
+    'ignore-file': {
+      'name': 'Ignore file',
+    },
     'lint-file-pop-up-menu-text': {
       'name': 'Lint file',
     },
     'lint-folder-pop-up-menu-text': {
       'name': 'Lint folder',
+    },
+    'ignore-file-pop-up-menu-text': {
+      'name': 'Ignore file in Linter',
+    },
+    'ignore-folder-pop-up-menu-text': {
+      'name': 'Ignore folder in Linter',
     },
   },
 

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -136,10 +136,27 @@ const successSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="
   <polyline points="20 6 9 17 4 12"/>
 </svg>`;
 
+// https://lucide.dev/icons/file-x
+const ignoreFileSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-file-x">
+  <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/>
+  <path d="M14 2v4a2 2 0 0 0 2 2h4"/>
+  <path d="m14.5 12.5-5 5"/>
+  <path d="m9.5 12.5 5 5"/>
+</svg>`;
+
+// https://lucide.dev/icons/folder-x
+const ignoreFolderSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-folder-x">
+  <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>
+  <path d="m9.5 10.5 5 5"/>
+  <path d="m14.5 10.5-5 5"/>
+</svg>`;
+
 // exported SVG info
 export const iconInfo: Record<string, {id: string, source: string}> = {
   folder: {id: 'lint-folder', source: lintFolderSVG},
+  ignoreFolder: {id: 'lint-ignore-folder', source: ignoreFolderSVG},
   file: {id: 'lint-file', source: lintFileSVG},
+  ignoreFile: {id: 'lint-ignored-file', source: ignoreFileSVG},
   vault: {id: 'lint-vault', source: lintVaultSVG},
   whitespace: {id: 'lint-whitespace', source: whitespaceSVG},
   math: {id: 'lint-math', source: mathSVG},


### PR DESCRIPTION
Fixes #1106 

Changes Made:
- Added the ability to ignore a file from the click context menu for a file and hid the ability to lint and ignore a file if it is currently ignored
- Added the ability to ignore a folder form the click context menu for a folder and hid the ability to lint and ignore the folder if it is currently ignored