### PR TITLE
Fix Table Recognition So It Does Not Match Table Rows with Just Dashes in Them

### DIFF
--- a/__tests__/empty-line-around-tables.test.ts
+++ b/__tests__/empty-line-around-tables.test.ts
@@ -121,5 +121,40 @@ ruleTest({
         content
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1235
+      testName: 'Make sure that we do not break a table apart when it rows with just dashes in them',
+      before: dedent`
+        | test  |
+        |:-----:|
+        |  ---  |
+        |  one  |
+        |  two  |
+        |  ---  |
+        |  ---  |
+        | three |
+        |  ---  |
+        |  ---  |
+        |  ---  |
+        |  ---  |
+        | four  |
+        | five  |
+      `,
+      after: dedent`
+        | test  |
+        |:-----:|
+        |  ---  |
+        |  one  |
+        |  two  |
+        |  ---  |
+        |  ---  |
+        | three |
+        |  ---  |
+        |  ---  |
+        |  ---  |
+        |  ---  |
+        | four  |
+        | five  |
+      `,
+    },
   ],
 });

--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -232,6 +232,27 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
     expectedTablesInText: 2,
     expectedPositions: [{startIndex: 35, endIndex: 112}, {startIndex: 0, endIndex: 33}],
   },
+  { // accounts for https://github.com/platers/obsidian-linter/issues/1235
+    name: 'handle tables with --- in a row',
+    text: dedent`
+      | test  |
+      |:-----:|
+      |  ---  |
+      |  one  |
+      |  two  |
+      |  ---  |
+      |  ---  |
+      | three |
+      |  ---  |
+      |  ---  |
+      |  ---  |
+      |  ---  |
+      | four  |
+      | five  |
+    `,
+    expectedTablesInText: 1,
+    expectedPositions: [{startIndex: 0, endIndex: 140}],
+  },
 ];
 
 describe('Get All Tables in Text', () => {

--- a/__tests__/get-all-tables-in-text.test.ts
+++ b/__tests__/get-all-tables-in-text.test.ts
@@ -251,7 +251,7 @@ const getTablesInTextTestCases: tablesInTextTestCase[] = [
       | five  |
     `,
     expectedTablesInText: 1,
-    expectedPositions: [{startIndex: 0, endIndex: 140}],
+    expectedPositions: [{startIndex: 0, endIndex: 139}],
   },
 ];
 

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -1000,6 +1000,17 @@ export function getAllTablesInText(text: string): {startIndex: number, endIndex:
       continue;
     }
 
+    // need to check that two lines before the separator line does not start and end with a pipe
+    if (startOfPreviousLine !== 0) {
+      const startOfTwoLinesPrior = getStartOfLineIndex(text, startOfPreviousLine - 1);
+      const twoLinesPrior = text.substring(startOfTwoLinesPrior, startOfPreviousLine - 1);
+      if (twoLinesPrior.startsWith('|') || twoLinesPrior.endsWith('|')) {
+        // the match is at best a row in a table
+        continue;
+      }
+    }
+
+
     let end = match.index + match[0].length;
 
     if (end >= text.length - 1) {


### PR DESCRIPTION
Fixes #1235 

There was an issue reported around tables getting messed up if some of the rows were filled with hyphens/dashes. This was caused by looking for the separator row and not checking that two lines prior was not also a part of the table. So I added that check to see if the line two lines prior either started or ended with `|`. If it does, then we know that it is a table row and we will skip this as a table addition. This seems to allow the table recognition logic to work for this scenario.

Changes Made:
- Added UTs for the table recognition and the adding of blank lines around the table
- Updated the table recognition code to check two lines prior to the potential separator line to see if it is a part of the table as well and skip that potential separator if it is a part of the table