### PR TITLE
Fix Trailing Spaces Breaking List Items and Checklist Items

### DIFF
--- a/__tests__/trailing-spaces.test.ts
+++ b/__tests__/trailing-spaces.test.ts
@@ -98,5 +98,61 @@ ruleTest({
         [[File with  spaces]]
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/868
+      testName: 'A list item with no content should not have the space indicating it is a list item removed',
+      before: dedent`
+        - List item 1
+        -${' '}
+        -${'   '}
+      `,
+      after: dedent`
+        - List item 1
+        -${' '}
+        -${' '}
+      `,
+    },
+    { // relates to for https://github.com/platers/obsidian-linter/issues/868
+      testName: 'Make sure that checklists are properly handled with trailing spaces',
+      before: dedent`
+        - [ ] List item 1
+        - [ ]${' '}
+        - [ ] ${'   '}
+      `,
+      after: dedent`
+        - [ ] List item 1
+        - [ ]${' '}
+        - [ ]${' '}
+      `,
+    },
+    { // relates to for https://github.com/platers/obsidian-linter/issues/868
+      testName: 'Make sure that indented lists are properly handled with trailing spaces',
+      before: dedent`
+        Text here
+        - List item 1
+          -${' '}
+          -${'   '}
+      `,
+      after: dedent`
+        Text here
+        - List item 1
+          -${' '}
+          -${' '}
+      `,
+    },
+    { // relates to for https://github.com/platers/obsidian-linter/issues/868
+      testName: 'Make sure that ordered lists are properly handled with trailing spaces',
+      before: dedent`
+        Text here
+        1. List item 1
+        2.${' '}
+        3.${'   '}
+      `,
+      after: dedent`
+        Text here
+        1. List item 1
+        2.${' '}
+        3.${' '}
+      `,
+    },
   ],
 });

--- a/src/rules/trailing-spaces.ts
+++ b/src/rules/trailing-spaces.ts
@@ -1,7 +1,8 @@
-import {IgnoreTypes} from '../utils/ignore-types';
+import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
+import {updateListItemText} from '../utils/mdast';
 
 class TrailingSpacesOptions implements Options {
   twoSpaceLineBreak: boolean = false;
@@ -22,14 +23,27 @@ export default class TrailingSpaces extends RuleBuilder<TrailingSpacesOptions> {
     return TrailingSpacesOptions;
   }
   apply(text: string, options: TrailingSpacesOptions): string {
-    if (!options.twoSpaceLineBreak) {
-      return text.replace(/[ \t]+$/gm, '');
-    } else {
-      text = text.replace(/(\S)[ \t]$/gm, '$1'); // one whitespace
-      text = text.replace(/(\S)[ \t]{3,}$/gm, '$1'); // three or more whitespaces
-      text = text.replace(/(\S)( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
-      return text;
-    }
+    text = ignoreListOfTypes([IgnoreTypes.list], text, (text: string): string => {
+      if (!options.twoSpaceLineBreak) {
+        return text.replace(/[ \t]+$/gm, '');
+      } else {
+        text = text.replace(/(\S)[ \t]$/gm, '$1'); // one whitespace
+        text = text.replace(/(\S)[ \t]{3,}$/gm, '$1'); // three or more whitespaces
+        text = text.replace(/(\S)( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
+        return text;
+      }
+    });
+
+    return updateListItemText(text, (text: string): string => {
+      if (!options.twoSpaceLineBreak) {
+        return text.replace(/[ \t]+$/gm, '');
+      } else {
+        text = text.replace(/(\S)[ \t]$/gm, '$1'); // one whitespace
+        text = text.replace(/(\S)[ \t]{3,}$/gm, '$1'); // three or more whitespaces
+        text = text.replace(/(\S)( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
+        return text;
+      }
+    }, true);
   }
   get exampleBuilders(): ExampleBuilder<TrailingSpacesOptions>[] {
     return [


### PR DESCRIPTION
Fixes #868 

There was an issue where empty ordered, checklist, and list items were being broken by trailing spaces. This was because it did not ignore the first space after the indicator. This should be fixed with this latest change.

Changes Made:
- Added UTs for several scenarios
- Made sure to handle list items in particular and handle the case where a list item is empty