### PR TITLE
Fix List Ignore Type Ignoring More than It Should when Sublists Are Present

### DIFF
--- a/__tests__/remove-multiple-spaces.test.ts
+++ b/__tests__/remove-multiple-spaces.test.ts
@@ -239,6 +239,21 @@ ruleTest({
         > > - e.g., \`Customer\` class might have \`getName\`, \`getAddress\`, but also \`sendEmail\` that sends an email to the customer → Weird; not a major responsibility of the customer → ==not cohesive
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1203
+      testName: 'A nested callout/blockquote should not have list item proceeding space removed',
+      before: dedent`
+        - first item
+             - xxxxxxxxxxxxxxxxxxxxxxxxx
+
+        test    test
+      `,
+      after: dedent`
+        - first item
+             - xxxxxxxxxxxxxxxxxxxxxxxxx
+
+        test test
+      `,
+    },
   ],
 });
 

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -81,8 +81,12 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
  * @return {string[]} The mdast nodes values replaced
  */
 function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): IgnoreResults {
-  const positions: Position[] = getPositions(type, text);
+  let positions: Position[] = getPositions(type, text);
   const replacedValues: string[] = [];
+
+  if (type === MDAstTypes.List) {
+    positions = removeOverlappingPositions(positions);
+  }
 
   for (const position of positions) {
     const valueToReplace = text.substring(position.start.offset, position.end.offset);
@@ -196,4 +200,23 @@ function replaceCustomIgnore(text: string, customIgnorePlaceholder: string): Ign
   }
 
   return {newText: text, replacedValues: replacedSections};
+}
+
+function removeOverlappingPositions(positions: Position[]): Position[] {
+  if (positions.length < 2) {
+    return positions;
+  }
+
+  let lastPosition: Position = positions.pop();
+  let currentPosition: Position = null;
+  const result: Position[] = [lastPosition];
+  while (positions.length > 0) {
+    currentPosition = positions.pop();
+    if (lastPosition.start.offset >= currentPosition.end.offset || currentPosition.start.offset >= lastPosition.end.offset) {
+      result.unshift(currentPosition);
+      lastPosition = currentPosition;
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
Fixes #1259 

There was an issue where a list with a sublist would occasionally ignore more than it should of as part of the list ignore. This would cause unexpected results as seen on the bug report. To fix this, we need to remove overlapping positions in the position list. This allows for just ignoring the list in question instead of the sublist and then the list which caused more than what was intended to be ignored.

Changes Made:
- Added a UT for the scenario in question
- Updated the ignore MdAST type logic for lists to just ignore non-overlapping positions