### PR TITLE
Fix UTC Not Properly Handled by YAML Timestamp When Format is Not Expected Format But Is UTC

### DIFF
--- a/__tests__/remove-multiple-spaces.test.ts
+++ b/__tests__/remove-multiple-spaces.test.ts
@@ -240,7 +240,7 @@ ruleTest({
       `,
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/1203
-      testName: 'A nested callout/blockquote should not have list item proceeding space removed',
+      testName: 'Make sure that remove multiple spaces works when it comes right after a list with a sublist in it',
       before: dedent`
         - first item
              - xxxxxxxxxxxxxxxxxxxxxxxxx

--- a/src/rules/yaml-timestamp.ts
+++ b/src/rules/yaml-timestamp.ts
@@ -204,7 +204,7 @@ export default class YamlTimestamp extends RuleBuilder<YamlTimestampOptions> {
       date.locale(locale);
 
       const formattedDateStr = utc ? date.utc().format(format) : date.format(format);
-      return moment(formattedDateStr, format, locale, true);
+      return utc ? moment.utc(formattedDateStr, format, locale, true): moment(formattedDateStr, format, locale, true);
     }
 
     return null;


### PR DESCRIPTION
Fixes #1265 

There seems to have been an issue with UTC parsing. If the value in the frontmatter was UTC, but not in the desired format and the desired format was UTC, then there was an issue where it would try to fix the UTC value and ended up parsing it out as non-UTC in the end instead of as UTC. This caused the value to be off by the UTC offset in the related issue.

Changes Made:
- Fixed a UT name (not related)
- Added a change to parse the value as utc if the current expected value should be utc which fixed the offset issue