### PR TITLE
Update Mermaid Diagram on How the Linter Works

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,12 +19,12 @@ The Linter follows the following basic steps when it is run on a file:
 
 ``` mermaid
 graph TD
-    start[User initiates linting of file or files] --> run-linter-rules
-    run-linter-rules[If file is not ignored, run Linter rules and Custom Commands*] --> handle-error
+    start["1. User initiates linting of file or files"] --> run-linter-rules
+    run-linter-rules["2. If file is not ignored, run Linter rules and Custom Commands*"] --> handle-error
     handle-error{Did an error happen?} -- No --> update-file
     handle-error -- Yes --> log-error
-    log-error[3. Display error and log to dev console] --> done
-    update-file[Update file contents**] --> done
+    log-error["3. Display error and log to dev console"] --> done
+    update-file["3. Update file contents**"] --> done
     done[Done]
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,12 +19,12 @@ The Linter follows the following basic steps when it is run on a file:
 
 ``` mermaid
 graph TD
-    start[1. User initiates linting of file or files] --> run-linter-rules
-    run-linter-rules[2. If file is not ignored, run Linter rules and Custom Commands*] --> handle-error
+    start[User initiates linting of file or files] --> run-linter-rules
+    run-linter-rules[If file is not ignored, run Linter rules and Custom Commands*] --> handle-error
     handle-error{Did an error happen?} -- No --> update-file
     handle-error -- Yes --> log-error
     log-error[3. Display error and log to dev console] --> done
-    update-file[3. Update file contents**] --> done
+    update-file[Update file contents**] --> done
     done[Done]
 ```
 
@@ -32,7 +32,7 @@ graph TD
     *Currently custom commands only run when a single file is linted.
 
     **This is a bit of a simplification as the file is updated after running Linter rules, but before Custom Commands run
-    if no error has ocurred.
+    if no error has occurred.
 
 ### 1. User Initiates Linting of File or Files
 


### PR DESCRIPTION
Relates to #1301 

There seems to be a discrepancy between mkdocs locally and and what is supported in mermaid on github pages. To fix this, I am swapping to plaintext instead of allowing the logic to be interpreted as markdown. Hopefully that will fix the issue.