### PR TITLE
fix: correct regex pattern for title matching in yaml-title rule

### DIFF
--- a/__tests__/yaml-title.test.ts
+++ b/__tests__/yaml-title.test.ts
@@ -357,5 +357,22 @@ ruleTest({
         # [test \#4](github.com/platers/obsidian-linter)
       `,
     },
+    {
+      testName: 'Only matches and replaces the correct title key, not similar keys',
+      before: dedent`
+        ---
+        title2: ShouldNotChange
+        title: ShouldChange
+        ---
+        # Hello world
+      `,
+      after: dedent`
+        ---
+        title2: ShouldNotChange
+        title: Hello world
+        ---
+        # Hello world
+      `,
+    },
   ],
 });

--- a/src/rules/yaml-title.ts
+++ b/src/rules/yaml-title.ts
@@ -51,7 +51,7 @@ export default class YamlTitle extends RuleBuilder<YamlTitleOptions> {
     title = escapeStringIfNecessaryAndPossible(title, options.defaultEscapeCharacter);
 
     return formatYAML(text, (text) => {
-      const title_match_str = `\n${options.titleKey}.*\n`;
+      const title_match_str = `\n${options.titleKey}:.*\n`;
       const title_match = new RegExp(title_match_str);
       if (title_match.test(text)) {
         text = text.replace(


### PR DESCRIPTION
The yaml-title rule adds a title key to the frontmatter or replaces it if it already exists.
I noticed that if other keys start with the title key (e.g., titleTemplate, one of the VitePress's frontmatter config), they might be incorrectly replaced — especially if they appear before title.
So I updated the regex to match the exact title key and avoid this issue.
Thanks for reviewing.