### PR TITLE
Fix: RAM Usage Larger Than It Should Be

### DIFF
--- a/src/rules/rule-builder.ts
+++ b/src/rules/rule-builder.ts
@@ -6,6 +6,9 @@ import {IgnoreType, IgnoreTypes} from '../utils/ignore-types';
 import {LinterSettings} from 'src/settings-data';
 import {App} from 'obsidian';
 
+// limit the amount of text that can be written to the logs to try to prevent memory issues
+const maxFileSizeLength = 10000;
+
 export abstract class RuleBuilderBase {
   static #ruleMap = new Map<string, Rule>();
   static #ruleBuilderMap = new Map<string, RuleBuilderBase>();
@@ -32,7 +35,12 @@ export abstract class RuleBuilderBase {
       try {
         const newText = rule.apply(text, options);
         timingEnd(rule.alias);
-        logDebug(newText);
+
+        if (newText.length > maxFileSizeLength) {
+          logDebug(newText.slice(0, maxFileSizeLength -1) + '...');
+        } else {
+          logDebug(newText);
+        }
 
         return [newText, true];
       } catch (error) {

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -3,7 +3,6 @@ import {getAllCustomIgnoreSectionsInText, getAllTablesInText, getPositions, MDAs
 import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
 
-// export type IgnoreResults = {replacedValues: string[], newText: string};
 export type IgnoreFunction = ((text: string, placeholder: string) => [string[], string]);
 export type IgnoreType = {replaceAction: MDAstTypes | RegExp | IgnoreFunction, placeholder: string};
 

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -3,8 +3,8 @@ import {getAllCustomIgnoreSectionsInText, getAllTablesInText, getPositions, MDAs
 import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
 
-export type IgnoreResults = {replacedValues: string[], newText: string};
-export type IgnoreFunction = ((text: string, placeholder: string) => IgnoreResults);
+// export type IgnoreResults = {replacedValues: string[], newText: string};
+export type IgnoreFunction = ((text: string, placeholder: string) => [string[], string]);
 export type IgnoreType = {replaceAction: MDAstTypes | RegExp | IgnoreFunction, placeholder: string};
 
 export const IgnoreTypes: Record<string, IgnoreType> = {
@@ -40,19 +40,18 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
   let setOfPlaceholders: {placeholder: string, replacedValues: string[]}[] = [];
 
   // replace ignore blocks with their placeholders
+  let replaceValues: string[] = [];
   for (const ignoreType of ignoreTypes) {
-    let ignoredResult: IgnoreResults;
     if (typeof ignoreType.replaceAction === 'string') { // mdast
-      ignoredResult = replaceMdastType(text, ignoreType.placeholder, ignoreType.replaceAction);
+      [replaceValues, text] = replaceMdastType(text, ignoreType.placeholder, ignoreType.replaceAction);
     } else if (ignoreType.replaceAction instanceof RegExp) {
-      ignoredResult = replaceRegex(text, ignoreType.placeholder, ignoreType.replaceAction);
+      [replaceValues, text] = replaceRegex(text, ignoreType.placeholder, ignoreType.replaceAction);
     } else if (typeof ignoreType.replaceAction === 'function') {
       const ignoreFunc: IgnoreFunction = ignoreType.replaceAction;
-      ignoredResult = ignoreFunc(text, ignoreType.placeholder);
+      [replaceValues, text] = ignoreFunc(text, ignoreType.placeholder);
     }
 
-    text = ignoredResult.newText;
-    setOfPlaceholders.push({replacedValues: ignoredResult.replacedValues, placeholder: ignoreType.placeholder});
+    setOfPlaceholders.push({replacedValues: replaceValues, placeholder: ignoreType.placeholder});
   }
 
   text = func(text);
@@ -80,7 +79,7 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
  * @return {string} The text with mdast nodes types specified replaced
  * @return {string[]} The mdast nodes values replaced
  */
-function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): IgnoreResults {
+function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): [string[], string] {
   let positions: Position[] = getPositions(type, text);
   const replacedValues: string[] = [];
 
@@ -91,13 +90,16 @@ function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): 
   for (const position of positions) {
     const valueToReplace = text.substring(position.start.offset, position.end.offset);
     replacedValues.push(valueToReplace);
+  }
+
+  for (const position of positions) {
     text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, placeholder);
   }
 
   // Reverse the replaced values so that they are in the same order as the original text
   replacedValues.reverse();
 
-  return {newText: text, replacedValues};
+  return [replacedValues, text];
 }
 
 /**
@@ -108,7 +110,7 @@ function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): 
  * @return {string} The text with regex matches replaced
  * @return {string[]} The regex matches replaced
  */
-function replaceRegex(text: string, placeholder: string, regex: RegExp): IgnoreResults {
+function replaceRegex(text: string, placeholder: string, regex: RegExp): [string[], string] {
   const regexMatches = text.match(regex);
   const textMatches: string[] = [];
   if (regex.flags.includes('g')) {
@@ -127,7 +129,7 @@ function replaceRegex(text: string, placeholder: string, regex: RegExp): IgnoreR
     }
   }
 
-  return {newText: text, replacedValues: textMatches};
+  return [textMatches, text];
 }
 
 /**
@@ -137,10 +139,12 @@ function replaceRegex(text: string, placeholder: string, regex: RegExp): IgnoreR
  * @return {string} The text with links replaced
  * @return {string[]} The regular markdown links replaced
  */
-function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): IgnoreResults {
+function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): [string[], string] {
   const positions: Position[] = getPositions(MDAstTypes.Link, text);
   const replacedRegularLinks: string[] = [];
 
+
+  const positionsToReplace: Position [] = [];
   for (const position of positions) {
     if (position == undefined) {
       continue;
@@ -152,17 +156,21 @@ function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): Ign
       continue;
     }
 
+    positionsToReplace.push(position);
     replacedRegularLinks.push(regularLink);
+  }
+
+  for (const position of positionsToReplace) {
     text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, regularLinkPlaceholder);
   }
 
   // Reverse the regular links so that they are in the same order as the original text
   replacedRegularLinks.reverse();
 
-  return {newText: text, replacedValues: replacedRegularLinks};
+  return [replacedRegularLinks, text];
 }
 
-function replaceTags(text: string, placeholder: string): IgnoreResults {
+function replaceTags(text: string, placeholder: string): [string[], string] {
   const replacedValues: string[] = [];
 
   text = text.replace(tagWithLeadingWhitespaceRegex, (_, whitespace, tag) => {
@@ -170,10 +178,10 @@ function replaceTags(text: string, placeholder: string): IgnoreResults {
     return whitespace + placeholder;
   });
 
-  return {newText: text, replacedValues: replacedValues};
+  return [replacedValues, text];
 }
 
-function replaceTables(text: string, tablePlaceholder: string): IgnoreResults {
+function replaceTables(text: string, tablePlaceholder: string): [string[], string] {
   const tablePositions = getAllTablesInText(text);
 
   const replacedTables: string[] = new Array(tablePositions.length);
@@ -181,14 +189,17 @@ function replaceTables(text: string, tablePlaceholder: string): IgnoreResults {
   const length = replacedTables.length;
   for (const tablePosition of tablePositions) {
     replacedTables[length - 1 - index++] = text.substring(tablePosition.startIndex, tablePosition.endIndex);
+  }
+
+  for (const tablePosition of tablePositions) {
     text = replaceTextBetweenStartAndEndWithNewValue(text, tablePosition.startIndex, tablePosition.endIndex, tablePlaceholder);
   }
 
-  return {newText: text, replacedValues: replacedTables};
+  return [replacedTables, text];
 }
 
 
-function replaceCustomIgnore(text: string, customIgnorePlaceholder: string): IgnoreResults {
+function replaceCustomIgnore(text: string, customIgnorePlaceholder: string): [string[], string] {
   const customIgnorePositions = getAllCustomIgnoreSectionsInText(text);
 
   const replacedSections: string[] = new Array(customIgnorePositions.length);
@@ -196,10 +207,13 @@ function replaceCustomIgnore(text: string, customIgnorePlaceholder: string): Ign
   const length = replacedSections.length;
   for (const customIgnorePosition of customIgnorePositions) {
     replacedSections[length - 1 - index++] = text.substring(customIgnorePosition.startIndex, customIgnorePosition.endIndex);
+  }
+
+  for (const customIgnorePosition of customIgnorePositions) {
     text = replaceTextBetweenStartAndEndWithNewValue(text, customIgnorePosition.startIndex, customIgnorePosition.endIndex, customIgnorePlaceholder);
   }
 
-  return {newText: text, replacedValues: replacedSections};
+  return [replacedSections, text];
 }
 
 function removeOverlappingPositions(positions: Position[]): Position[] {


### PR DESCRIPTION
Relates to #1268 

An issue was reported where the Linter would cause Obsidian to freeze on a large file. I thought it would be like the others where it froze because the Linter was long running. And while that is partially the cause, I encountered an issue where Obsidian would crash on me due to high RAM usage (an OOM error). After debugging the process and trying to figure out what was going on, I was able to determine that using `substring` on a string was creating a pointer to it. So I was accidentally keeping around many references to the original copy of the string I was then updating in the ignore types logic. This meant that since the file in question was about .9MB, I was getting this file's size roughly duplicated for each value replaced. In the file, it was more than 300 times. To fix this, it is best to first get all of the substrings and then update the string. This way we only keep one extra instance of the text present. This drastically reduced the RAM usage.

I also added some logic to limit the amount of characters from a file that can be logged to also help keep RAM usage low.

Changes Made:
- Capped file content character size to keep in the logs for each rule that runs
- Updated the ignore types logic to make sure that it would not unnecessarily retain copies of strings it did not need to keep around (yay hidden pointers!)