### PR TITLE
Update OpenFile to Make it Set Active Focus After API Update

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1021,7 +1021,7 @@ export default class LinterPlugin extends Plugin {
     await this.customCommandsLock.acquire('command', async () => {
       this.currentlyOpeningSidebar = true;
 
-      await sidebarTab.openFile(file);
+      await sidebarTab.openFile(file, {active: true});
       this.rulesRunner.runCustomCommands(this.settings.lintCommands, this.app.commands);
       if (this.customCommandsCallback) {
         await this.customCommandsCallback(file);


### PR DESCRIPTION
Relates to #1297 
Relates to #1295 

There was an issue where running custom commands in the sidebar where it did not focus on the sidebar file and instead kept focus where it was. Thus custom commands were run on the wrong file. This should correct that issue.

Changes Made:
- Pass in that we want the sidebar tab to be active