### PR TITLE
Fix an Issue with Removing Trailing Spaces not Working on Empty Lists Items with No List Item Spaces

### DIFF
--- a/__tests__/trailing-spaces.test.ts
+++ b/__tests__/trailing-spaces.test.ts
@@ -154,5 +154,20 @@ ruleTest({
         3.${' '}
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1329
+      testName: 'Make sure that we properly handle an empty list item when it is empty and has no spaces in it',
+      before: dedent`
+        Some text
+        ${''}
+        -
+        ${''}
+      `,
+      after: dedent`
+        Some text
+        ${''}
+        -
+        ${''}
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -616,7 +616,9 @@ export function updateListItemText(text: string, func:(text: string) => string, 
         startIndex++;
       }
 
-      startIndex++;
+      if (startIndex < position.position.end.offset) {
+        startIndex++;
+      }
     } else {
       // get the actual start of the list item leaving only 1 whitespace between the indicator and the text
       while (startIndex > 0 && text.charAt(startIndex - 1).trim() === '') {


### PR DESCRIPTION
Fixes #1329 

There was an issue where if a list indicator was present with no whitespace or content after it, it would cause an error where the start index was a higher value than the end index. That caused an issue with setting the value.

Changes Made:
- Add a test for the scenario in question
- Update logic for starting index to not get incremented once more if the start is equal to the end