### PR TITLE
Fix Linter Using `null` for Current Language

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-linter",
-  "version": "1.27.1",
+  "version": "1.29.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-linter",
-      "version": "1.27.1",
+      "version": "1.29.2",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
@@ -58,7 +58,7 @@
         "eslint-plugin-unicorn": "^51.0.1",
         "jest": "^29.3.1",
         "moment": "^2.30.1",
-        "obsidian": "^1.5.7-1",
+        "obsidian": "^1.8.7",
         "postcss": "^8.4.47",
         "postcss-cli": "^11.0.0",
         "ts-node": "^10.9.2",
@@ -9611,10 +9611,11 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.5.7-1",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
-      "integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+      "integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
@@ -18541,9 +18542,9 @@
       }
     },
     "obsidian": {
-      "version": "1.5.7-1",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
-      "integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+      "integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
       "dev": true,
       "requires": {
         "@types/codemirror": "5.60.8",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-unicorn": "^51.0.1",
     "jest": "^29.3.1",
     "moment": "^2.30.1",
-    "obsidian": "^1.5.7-1",
+    "obsidian": "^1.8.7",
     "postcss": "^8.4.47",
     "postcss-cli": "^11.0.0",
     "ts-node": "^10.9.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon, htmlToMarkdown, EditorSelection, EditorChange, normalizePath, MarkdownFileInfo, debounce, Debouncer} from 'obsidian';
+import {App, Editor, EventRef, MarkdownView, Menu, Notice, Plugin, TAbstractFile, TFile, TFolder, addIcon, htmlToMarkdown, EditorSelection, EditorChange, normalizePath, MarkdownFileInfo, debounce, Debouncer, getLanguage} from 'obsidian';
 import {Options, RuleType, ruleTypeToRules, rules, sortRules} from './rules';
 import DiffMatchPatch from 'diff-match-patch';
 import dedent from 'ts-dedent';
@@ -81,7 +81,7 @@ export default class LinterPlugin extends Plugin {
   async onload() {
     sortRules();
 
-    setLanguage(window.localStorage.getItem('language'));
+    setLanguage(getLanguage());
     logInfo(getTextInLanguage('logs.plugin-load'));
 
     this.isEnabled = true;
@@ -1111,7 +1111,7 @@ export default class LinterPlugin extends Plugin {
     this.settings.settingsConvertedToConfigKeyValues = true;
     await this.saveSettings();
 
-    setLanguage(window.localStorage.getItem('language'));
+    setLanguage(getLanguage());
 
     return updateMade;
   }


### PR DESCRIPTION
Fixes #1331 

`window.localStorage.getItem('language')` used to include the current language for Obsidian. However it no longer does. So to fix this we will use the `getLanguage` function that was added for Obsidian 1.8.7. It should no longer getting the warning anymore.

Changes Made:
- Swap from using local storage value to the exposed `getLanguage` API function