### PR TITLE
Fix Non-Latin Characters Not Working for `remove-consecutive-list-markers`

### DIFF
--- a/__tests__/remove-consecutive-list-markers.test.ts
+++ b/__tests__/remove-consecutive-list-markers.test.ts
@@ -1,0 +1,22 @@
+import RemoveConsecutiveListMarkers from '../src/rules/remove-consecutive-list-markers';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: RemoveConsecutiveListMarkers,
+  testCases: [
+    {
+      testName: 'Make sure consecutive list markers are removed when dealing with non-latin characters',
+      before: dedent`
+        - - test content
+        - - тест content
+        - - 测试 content
+      `,
+      after: dedent`
+        - test content
+        - тест content
+        - 测试 content
+      `,
+    },
+  ],
+});

--- a/__tests__/remove-consecutive-list-markers.test.ts
+++ b/__tests__/remove-consecutive-list-markers.test.ts
@@ -5,7 +5,7 @@ import {ruleTest} from './common';
 ruleTest({
   RuleBuilderClass: RemoveConsecutiveListMarkers,
   testCases: [
-    {
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1278
       testName: 'Make sure consecutive list markers are removed when dealing with non-latin characters',
       before: dedent`
         - - test content

--- a/src/rules/remove-consecutive-list-markers.ts
+++ b/src/rules/remove-consecutive-list-markers.ts
@@ -19,7 +19,7 @@ export default class RemoveConsecutiveListMarkers extends RuleBuilder<RemoveCons
     return RemoveConsecutiveListMarkersOptions;
   }
   apply(text: string, options: RemoveConsecutiveListMarkersOptions): string {
-    return text.replace(/^([ |\t]*)- - \b/gm, '$1- ');
+    return text.replace(/^([ |\t]*)- - (\p{L})/gmu, '$1- $2');
   }
   get exampleBuilders(): ExampleBuilder<RemoveConsecutiveListMarkersOptions>[] {
     return [


### PR DESCRIPTION
Fixes #1278

There was an issue where I was matching on word boundaries for regex for `remove-consecutive-list-markers`. However it seems that non-Latin languages do not have their characters included as a part of word boundaries. So instead I am going to a unicode letter. Hopefully that fixes the issue moving forward.

Changes Made:
- Added a UT for the scenario in question
- Swap from matching on word boundary for matching on unicode letter