### PR TITLE
Fix Empty Lines Between List Markers and Checklists Not Including Lines Made Up of Just Whitespace

### DIFF
--- a/__tests__/remove-empty-lines-between-list-markers-and-checklists.test.ts
+++ b/__tests__/remove-empty-lines-between-list-markers-and-checklists.test.ts
@@ -79,12 +79,12 @@ ruleTest({
         ${'\t'}
         - \`Map<K, V>\` represents a collection of **key-value pairs** (e.g., a phonebook: name → number).
         ${' \t'}
-        - \`List<E>\` ...
+        ${'  '}- \`List<E>\` ...
       `,
       after: dedent`
         - \`Collection<E>\` represents a group of **individual elements** (E, like a list of names).
         - \`Map<K, V>\` represents a collection of **key-value pairs** (e.g., a phonebook: name → number).
-        - \`List<E>\` ...
+        ${'  '}- \`List<E>\` ...
       `,
     },
   ],

--- a/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
+++ b/src/rules/remove-empty-lines-between-list-markers-and-checklists.ts
@@ -41,7 +41,7 @@ export default class RemoveEmptyLinesBetweenListMarkersAndChecklists extends Rul
     return this.replaceEmptyLinesBetweenList(text, splatMarkerRegexText);
   }
   replaceEmptyLinesBetweenList = function(text: string, listIndicatorRegexText: string): string {
-    const listRegex = new RegExp(`^${listIndicatorRegexText}(?:\n(?:[\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?){2,}${listIndicatorRegexText}$`, 'gm');
+    const listRegex = new RegExp(`^${listIndicatorRegexText}\n(?:(?:[\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?\n){1,}${listIndicatorRegexText}$`, 'gm');
     let match;
     let newText = text;
 


### PR DESCRIPTION
Fixes #1354 

There was a reported issue where empty lines was not including lines with just whitespace. In order to handle this, we need to make sure that to include that in the regex logic.

Changes Made:
- Updated the regex to include whitespace only lines
- Added a test case for the scenario in question