### PR TITLE
Fix `YAML Timestamp` Not Getting Updated in Reading Mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ type FileChangeUpdateInfo = {
   debounceFn: Debouncer<[TFile, Editor], Promise<void>>,
   isRunning: boolean
   originalText: string
+  markdownInfo: MarkdownView | MarkdownFileInfo
 }
 
 export default class LinterPlugin extends Plugin {
@@ -297,6 +298,7 @@ export default class LinterPlugin extends Plugin {
           // to check if the same file we already intend to add is in the map before we set
           // the value in the map
           originalText: '',
+          fileView: info,
         };
         this.activeFileChangeDebouncer.set(info.file.path, activeFileDebounceInfo);
         // do not use editor because it already has the change, so if the user removes all changes
@@ -798,7 +800,27 @@ export default class LinterPlugin extends Plugin {
                 return;
               }
 
+              let markdownInfo: MarkdownView;
+              let modeNeedsResetting = false;
+              let originalState;
+              if (activeFileChangeInfo.markdownInfo instanceof MarkdownView) {
+                markdownInfo = activeFileChangeInfo.markdownInfo;
+                originalState = markdownInfo.getState();
+                modeNeedsResetting = originalState.mode !== 'source';
+                // if we are in reading mode, we need to change to source mode in order to make changes
+                if (modeNeedsResetting) {
+                  const newState = markdownInfo.getState();
+                  newState.mode = 'source';
+                  await markdownInfo.setState(newState, {history: false});
+                }
+              }
+
               this.updateEditor(oldText, newText, editor);
+
+              if (modeNeedsResetting) {
+                await markdownInfo.setState(originalState, {history: false});
+                await markdownInfo.leaf.rebuildView();
+              }
             } else {
               logInfo(getTextInLanguage('logs.file-change-yaml-lint-skipped'));
             }

--- a/src/typings/obsidian-ex.d.ts
+++ b/src/typings/obsidian-ex.d.ts
@@ -75,6 +75,10 @@ declare module 'obsidian' {
      */
     cm?: EditorView;
   }
+
+  interface WorkspaceLeaf{
+    rebuildView(): Promise<void>;
+  }
 }
 
 


### PR DESCRIPTION
Fixes #1361 

There was a reported bug where if a user had setting enabled to get the timestamp to update x seconds after they make a change in the editor and then they changed to reading view before those x seconds were up, the changes would not be shown. To get around this, we have to change the view out of reading mode and then back to reading mode after the changes are made. But this requires the file to be reloaded in order to work. This causes a little bit of a screen flicker.

Changes Made:
- Updated typings accordingly for the new unofficial API that is used
- Passed in the markdown info to use as needed for changing the view to and from reading mode