### PR TITLE
Update Traditional Chinese to Use Simplified Chinese Translation

### DIFF
--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -24,7 +24,7 @@ import sq from './locale/sq';
 import tr from './locale/tr';
 import uk from './locale/uk';
 import zhCN from './locale/zh-cn';
-import zhTW from './locale/zh-tw';
+// import zhTW from './locale/zh-tw'; for now we will use Simplified Chinese instead of Traditional for both
 
 type LanguageStrings = typeof en;
 
@@ -53,7 +53,7 @@ export const localeMap: { [k: string]: LanguageLocale } = {
   sq,
   tr,
   uk,
-  'zh-TW': zhTW,
+  'zh-TW': zhCN,
   'zh': zhCN,
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,7 +298,7 @@ export default class LinterPlugin extends Plugin {
           // to check if the same file we already intend to add is in the map before we set
           // the value in the map
           originalText: '',
-          fileView: info,
+          markdownInfo: info,
         };
         this.activeFileChangeDebouncer.set(info.file.path, activeFileDebounceInfo);
         // do not use editor because it already has the change, so if the user removes all changes


### PR DESCRIPTION
Fixes #1348 

Changes Made:
- Fixed a failed property rename
- Swapped to using Simplified Chinese instead of Traditional Chinese for that translation since we have one and not the other