### PR TITLE
Fix List Marker Regex to Include Space After Markers

### DIFF
--- a/__tests__/paragraph-blank-lines.test.ts
+++ b/__tests__/paragraph-blank-lines.test.ts
@@ -565,5 +565,23 @@ ruleTest({
         \t\tbb
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1395
+      testName: 'A paragraph starting with an asterisk for either italics or bold should have a blank line added',
+      before: dedent`
+        # Header
+        **emphasis** blah blah...
+        *italics* more content here...
+        abcabc
+      `,
+      after: dedent`
+        # Header
+        ${''}
+        **emphasis** blah blah...
+        ${''}
+        *italics* more content here...
+        ${''}
+        abcabc
+      `,
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -47,7 +47,7 @@ export const checklistBoxStartsTextRegex = new RegExp(`^${checklistBoxIndicator}
 export const indentedOrBlockquoteNestedChecklistIndicatorRegex = new RegExp(`^${lineStartingWithWhitespaceOrBlockquoteTemplate}- ${checklistBoxIndicator} `);
 export const nonBlockquoteChecklistRegex = new RegExp(`^\\s*- ${checklistBoxIndicator} `);
 
-export const startsWithListMarkerRegex = new RegExp(`^\\s*(-|\\*|\\+|\\d+[.)]|- (${checklistBoxIndicator}))`, 'm');
+export const startsWithListMarkerRegex = new RegExp(`^\\s*(- |\\* |\\+ |\\d+[.)] |- (${checklistBoxIndicator}) )`, 'm');
 
 export const footnoteDefinitionIndicatorAtStartOfLine = /^(\[\^[^\]]*\]) ?([,.;!:?])/gm;
 export const calloutRegex = /^(>\s*)+\[![^\s]*\]/m;


### PR DESCRIPTION
Fixes #1395 

There was an issue reported where paragraphs that started with an asterisk and no space after it were getting ignored by `Paragraph Blank Lines`. The problem is that the regex used to determine if the paragraph started with a list indicator was not making sure the list marker/indicator was followed by a space. Updating the underlying regex seems to fix the issue.