### PR TITLE
Fix Pasting Link Twice in a Row Allowing Paste Rules to Run on Links

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -941,6 +941,12 @@ export default class LinterPlugin extends Plugin {
     // Note: it looks like those two plugins look for an exact match for a URL,
     // so we will too.
     const text = plainClipboard.trim();
+    // fixes https://github.com/platers/obsidian-linter/issues/1446
+    // for some reason when you run a global regex on a string it keeps track
+    // of how far it got in that string the last time it ran on it. Hence
+    // pasting the same string 2 times results in 1 match and 1 non-match.
+    // Resetting last index handles this issue.
+    urlRegex.lastIndex = 0;
     if (urlRegex.test(text)) {
       logWarn(getTextInLanguage('logs.paste-link-warning'));
       return;


### PR DESCRIPTION
Fixes #1446 

There was an issue where pasting two times in a row would cause the regex test for the URL to fail. It seems that regex with a `g` keeps track of its last run state in JS. This causes the second attempt on the same string to fail. To fix this, we have to set `lastIndex` to 0. There are probably other ways to skin the cat here as well, but this seems simplest.