### PR TITLE
Fix Issue with Converting to YAML Single Line and Single String Comma Delimited Not Handling Comma Values Properly

### DIFF
--- a/__tests__/format-yaml-arrays.test.ts
+++ b/__tests__/format-yaml-arrays.test.ts
@@ -1074,5 +1074,39 @@ ruleTest({
         aliasArrayStyle: SpecialArrayFormats.SingleStringCommaDelimited,
       },
     },
+    { // relates to https://github.com/platers/obsidian-linter/issues/1434
+      testName: 'Converting from a multi-line array to a single comma delimited string should result in strings with commas in them being escaped',
+      before: dedent`
+        ---
+        aliases:
+          - Denver, Co
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: "Denver, Co"
+        ---
+      `,
+      options: {
+        aliasArrayStyle: SpecialArrayFormats.SingleStringCommaDelimited,
+      },
+    },
+    { // fixes https://github.com/platers/obsidian-linter/issues/1434
+      testName: 'Converting from a multi-line array to a single line array should result in strings with commas in them being escaped',
+      before: dedent`
+        ---
+        aliases:
+          - Denver, Co
+        ---
+      `,
+      after: dedent`
+        ---
+        aliases: ["Denver, Co"]
+        ---
+      `,
+      options: {
+        aliasArrayStyle: NormalArrayFormats.SingleLine,
+      },
+    },
   ],
 });

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -211,6 +211,13 @@ export function formatYamlArrayValue(value: string | string[], format: NormalArr
         return ' ' + value[0];
       }
     case NormalArrayFormats.SingleLine:
+      // make sure that any values with a comma get properly escaped first
+      for (let i = 0; i < value.length; i++) {
+        if (value[i].includes(',') && !isValueEscapedAlready(value[i])) {
+          value[i] = escapeStringIfNecessaryAndPossible(value[i], defaultEscapeCharacter, true);
+        }
+      }
+
       return ' ' + convertStringArrayToSingleLineArray(value);
     case SpecialArrayFormats.SingleStringToMultiLine:
       if (value.length === 1) {
@@ -225,6 +232,13 @@ export function formatYamlArrayValue(value: string | string[], format: NormalArr
 
       return ' ' + value.join(' ');
     case SpecialArrayFormats.SingleStringCommaDelimited:
+      // make sure that any values with a comma get properly escaped first
+      for (let i = 0; i < value.length; i++) {
+        if (value[i].includes(',') && !isValueEscapedAlready(value[i])) {
+          value[i] = escapeStringIfNecessaryAndPossible(value[i], defaultEscapeCharacter, true);
+        }
+      }
+
       if (value.length === 1) {
         return ' ' + value[0];
       }


### PR DESCRIPTION
Fixes #1434 

There was an issue where a user could convert a YAML array to singe line or a comma delimited string and it would not properly convert any values with a comma to an escaped string. To handle this, the logic now checks for whether any given value has a comma and is not escaped and forces it to be an escaped value if it is found to be that way.

Changes Made:
- Added 2 UTs for the scenarios I noticed
- Added logic to check for unescaped strings with a comma in them when they are being converted into lists that have a different meaning for commas and forces the line to be escaped