### PR TITLE
Feat: Reenable zh-tw Now that It Has a Translation

### DIFF
--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -24,7 +24,7 @@ import sq from './locale/sq';
 import tr from './locale/tr';
 import uk from './locale/uk';
 import zhCN from './locale/zh-cn';
-// import zhTW from './locale/zh-tw'; for now we will use Simplified Chinese instead of Traditional for both
+import zhTW from './locale/zh-tw';
 
 type LanguageStrings = typeof en;
 
@@ -53,7 +53,7 @@ export const localeMap: { [k: string]: LanguageLocale } = {
   sq,
   tr,
   uk,
-  'zh-TW': zhCN,
+  'zh-TW': zhTW,
   'zh': zhCN,
 };
 


### PR DESCRIPTION
Fixes #1463 

There was a question about why zh-tw was not showing when it was selected. When I looked into it, it was because at one point we did not have a translation so simplified Chinese was used instead. Now we have both translations, so it should be fine to just go ahead and reenable it for users, so they can start using the added translation.