### PR TITLE
Fix: Paste Not Working as Intended in Obsidian `12.x`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -960,7 +960,10 @@ export default class LinterPlugin extends Plugin {
     // use Turndown via Obsidian API to emulate "Auto Convert HTML" setting
     const convertHtmlEnabled = this.app.vault.getConfig('autoConvertHtml');
     const htmlClipText = clipboardEv.clipboardData.getData('text/html');
-    let clipboardText = htmlClipText && convertHtmlEnabled ? htmlToMarkdown(htmlClipText) : plainClipboard;
+    // make sure that we skip handling Obsidian editor based html copied text as the plaintext is the way it will be pasted as as opposed
+    // to what is created by converting the provided HTML to markdown
+    // see https://github.com/platers/obsidian-linter/issues/1471
+    let clipboardText = htmlClipText && convertHtmlEnabled && !htmlClipText.startsWith('<!-- obsidian -->') ? htmlToMarkdown(htmlClipText) : plainClipboard;
 
     // if everything went well, run clipboard modifications (passing in current line and text to paste)
     const cursorSelections = editor.listSelections();


### PR DESCRIPTION
Fixes #1462 
Fixes #1471 
Fixes #1472 

Several users reported an issue where pasting was not working as expected. Initially I could not reproduce the issue, but a user (@Moyf ) pointed out that the issue should only happen when copying from Obsidian to Obsidian. When I looked into that scenario, I found I could reproduce the issue. The gist of the issue is that Obsidian added HTML content to support pasting into other places more easily. The problem with that is the Linter will prefer converting HTML to markdown when you have the auto convert HTML to markdown setting enabled for pasting. Well, that meant the Linter would now always convert the provided HTML to markdown. But the internal function provided, did not get updated as well to handle its own provided HTML. So the result was different output from the expected markdown. To fix this, the Linter will ignore any HTML that purports to come from Obsidian specifically even when auto convert HTML is enabled.

Changes Made:
- Added logic to check if the HTML content to paste started with `<!-- obsidian -->` and if it does, it just uses the plaintext as that is what was copied from Obsidian