### PR TITLE
Fix: `Move Footnotes to Bottom` Adding Blank Line in Files with No Footnotes

### DIFF
--- a/__tests__/move-footnotes-to-the-bottom.test.ts
+++ b/__tests__/move-footnotes-to-the-bottom.test.ts
@@ -325,5 +325,19 @@ ruleTest({
         includeBlankLineBetweenFootnotes: true,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1481
+      testName: 'Moving footnotes to the bottom of the file when the file is empty should not add a blank line',
+      before: dedent``,
+      after: dedent``,
+    },
+    { // relates to https://github.com/platers/obsidian-linter/issues/1481
+      testName: 'Moving footnotes to the bottom of the file when the file has no footnotes should not add a blank line',
+      before: dedent`
+        Here is some content
+      `,
+      after: dedent`
+        Here is some content
+      `,
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -279,7 +279,7 @@ export function moveFootnotesToEnd(text: string, includeBlankLinesBetweenFootnot
   let whitespaceBetweenFootnotes = '\n';
   if (includeBlankLinesBetweenFootnotes) {
     whitespaceBetweenFootnotes = '\n\n';
-  } else {
+  } else if (footnotes.length > 0) {
     text += '\n';
   }
 


### PR DESCRIPTION
Fixes #1481 

There was an issue where moving footnotes to the bottom always would update the text to add a single new line character at the end of the file. It should instead only do so when it is about to add footnotes.

Changes Made:
- Added two tests to handle the scenario where there are no footnotes, but there is content and the scenario where the file is empty
- Updated the logic to only add the new line at the end of the text if it is about to add at least 1 footnote