### PR TITLE
Fix: Paste Occasionally Would Post HTML Since Content Did NOT Start with Obsidian Comment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -963,7 +963,7 @@ export default class LinterPlugin extends Plugin {
     // make sure that we skip handling Obsidian editor based html copied text as the plaintext is the way it will be pasted as as opposed
     // to what is created by converting the provided HTML to markdown
     // see https://github.com/platers/obsidian-linter/issues/1471
-    let clipboardText = htmlClipText && convertHtmlEnabled && !htmlClipText.startsWith('<!-- obsidian -->') ? htmlToMarkdown(htmlClipText) : plainClipboard;
+    let clipboardText = htmlClipText && convertHtmlEnabled && htmlClipText.indexOf('<!-- obsidian -->') === -1 ? htmlToMarkdown(htmlClipText) : plainClipboard;
 
     // if everything went well, run clipboard modifications (passing in current line and text to paste)
     const cursorSelections = editor.listSelections();


### PR DESCRIPTION
Fixes #1480 
Fixes #1472 
Fixes #1479 

There was still an issue in some cases where the pasted html clipboard value did not start with the Obsidian comment. To handle this, we needed to go ahead and check for if it was present at all.

Changes Made:
- Swap to index of check instead of starts with check