### PR TITLE
Update Wording for `Re-Index Footnotes` Description and Fix a Couple of Old Bold and Italic Word Formatting

### DIFF
--- a/src/lang/locale/de.ts
+++ b/src/lang/locale/de.ts
@@ -526,7 +526,7 @@ export default {
     // re-index-footnotes.ts
     're-index-footnotes': {
       'name': 'Fußnoten neu indizieren',
-      'description': 'Indiziert Fußnotenschlüssel und Fußnoten basierend auf der Reihenfolge des Auftretens neu (HINWEIS: Diese Regel funktioniert *nicht*, wenn es mehr als eine Fußnote für einen Schlüssel gibt.)',
+      'description': 'Indiziert Fußnotenschlüssel und Fußnoten neu, basierend auf der Reihenfolge der Fußnotenverweise in der Datei. <b>HINWEIS: Diese Regel funktioniert <i>nicht</i>, wenn es mehr als eine Fußnote für einen Schlüssel gibt.</b>',
     },
     // remove-consecutive-list-markers.ts
     'remove-consecutive-list-markers': {
@@ -675,7 +675,7 @@ export default {
     // yaml-key-sort.ts
     'yaml-key-sort': {
       'name': 'Sortierung von YAML-Schlüsseln',
-      'description': 'Sortiert die YAML-Schlüssel basierend auf der angegebenen Reihenfolge und Priorität. Hinweis: Kann auch Leerzeilen entfernen.',
+      'description': 'Sortiert die YAML-Schlüssel basierend auf der angegebenen Reihenfolge und Priorität. <b>Hinweis: Kann auch Leerzeilen entfernen.</b>',
       'yaml-key-priority-sort-order': {
         'name': 'Prioritätssortierreihenfolge der YAML-Schlüssel',
         'description': 'Die Reihenfolge, in der die Schlüssel sortiert werden sollen, wobei in jeder Zeile ein Schlüssel in der Reihenfolge der Liste sortiert wird',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -637,7 +637,7 @@ export default {
     // re-index-footnotes.ts
     're-index-footnotes': {
       'name': 'Re-Index Footnotes',
-      'description': 'Re-indexes footnote keys and footnote, based on the order of occurrence. <b>Note: This rule does <i>not</i> work if there is more than one footnote for a key.</b>',
+      'description': 'Re-indexes footnote keys and footnote, based on the order of footnote references in the file. <b>Note: This rule does <i>not</i> work if there is more than one footnote for a key.</b>',
     },
     // remove-consecutive-list-markers.ts
     'remove-consecutive-list-markers': {

--- a/src/lang/locale/es.ts
+++ b/src/lang/locale/es.ts
@@ -460,7 +460,7 @@ export default {
     },
     're-index-footnotes': {
       'name': 'Volver a indexar notas al pie',
-      'description': 'Vuelve a indexar las notas al pie de página y las notas al pie, según el orden de aparición (NOTA: esta regla *no* funciona si hay más de una nota al pie para una clave).',
+      'description': 'Vuelve a indexar las notas al pie de página y las notas al pie, según el orden de las referencias de notas al pie en el archivo. <b>NOTA: esta regla *no* funciona si hay más de una nota al pie para una clave.</b>',
     },
     'remove-consecutive-list-markers': {
       'name': 'Eliminar marcadores de lista consecutiva',
@@ -527,11 +527,11 @@ export default {
       'description': 'Elimina el espacio antes de los caracteres especificados y después de los caracteres especificados. Tenga en cuenta que esto puede causar problemas con el formato de descuento en algunos casos.',
       'characters-to-remove-space-before': {
         'name': 'Eliminar espacio antes de los caracteres',
-        'description': 'Elimina el espacio antes de los caracteres especificados. **Nota: el uso de `{` o `}` en la lista de caracteres afectará inesperadamente a los archivos, ya que se usa en la sintaxis de ignorar en segundo plano.**',
+        'description': 'Elimina el espacio antes de los caracteres especificados. <b>Nota: el uso de `{` o `}` en la lista de caracteres afectará inesperadamente a los archivos, ya que se usa en la sintaxis de ignorar en segundo plano.</b>',
       },
       'characters-to-remove-space-after': {
         'name': 'Eliminar espacio después de los caracteres',
-        'description': 'Elimina el espacio después de los caracteres especificados. **Nota: el uso de `{` o `}` en la lista de caracteres afectará inesperadamente a los archivos, ya que se usa en la sintaxis de ignorar en segundo plano.**',
+        'description': 'Elimina el espacio después de los caracteres especificados. <b>Nota: el uso de `{` o `}` en la lista de caracteres afectará inesperadamente a los archivos, ya que se usa en la sintaxis de ignorar en segundo plano.</b>',
       },
     },
     'remove-trailing-punctuation-in-heading': {
@@ -592,7 +592,7 @@ export default {
     },
     'yaml-key-sort': {
       'name': 'Clasificación de clave de YAML',
-      'description': 'Ordena las claves de YAML según el orden y la prioridad especificados. Nota: también puede eliminar las líneas en blanco.',
+      'description': 'Ordena las claves de YAML según el orden y la prioridad especificados. <b>Nota: también puede eliminar las líneas en blanco.</b>',
       'yaml-key-priority-sort-order': {
         'name': 'Orden de clasificación de prioridad de clave de YAML',
         'description': 'El orden en el que se ordenan las claves con una en cada línea donde se ordena en el orden que se encuentra en la lista',


### PR DESCRIPTION
Relates to #1464 

Changes Made:
- Tried to make the description clearer for re indexing footnotes by clarifying that the order is based on the footnote reference order and not the definition order (only updated in English, Spanish, and German)
- Fixed some old formatting of bold and italic text in the localization text when it should now be HTML