### PR TITLE
Fix: Callouts Broken By Two Spaces Around Lines of Content

### DIFF
--- a/__tests__/two-spaces-between-lines-with-content.test.ts
+++ b/__tests__/two-spaces-between-lines-with-content.test.ts
@@ -167,5 +167,39 @@ ruleTest({
         lineBreakIndicator: LineBreakIndicators.TwoSpaces,
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1243
+      testName: 'Make sure that a callout does not erroneously get its callout indicator line updated.',
+      before: dedent`
+        > [!NOTE]
+        > Callout!
+        > Callout2!
+      `,
+      after: dedent`
+        > [!NOTE]
+        > Callout!\\
+        > Callout2!
+      `,
+      options: {
+        lineBreakIndicator: LineBreakIndicators.Backslash,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1243
+      testName: 'Make sure that a nested callout does not erroneously get its callout indicator line updated.',
+      before: dedent`
+        > Something
+        > > [!NOTE]
+        > > Callout!
+        > > Callout2!
+      `,
+      after: dedent`
+        > Something
+        > > [!NOTE]
+        > > Callout!\\
+        > > Callout2!
+      `,
+      options: {
+        lineBreakIndicator: LineBreakIndicators.Backslash,
+      },
+    },
   ],
 });

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -2,7 +2,7 @@ import {visit} from 'unist-util-visit';
 import type {Position} from 'unist';
 import type {Root} from 'mdast';
 import {hashString53Bit, makeSureContentHasEmptyLinesAddedBeforeAndAfter, replaceTextBetweenStartAndEndWithNewValue, getStartOfLineIndex, replaceAt, getStartOfLineWhitespaceOrBlockquoteLevel} from './strings';
-import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator, checklistBoxStartsTextRegex, footnoteDefinitionIndicatorAtStartOfLine, emptyLineMathBlockquoteRegex, startsWithBlockquote, startsWithListMarkerRegex} from './regex';
+import {genericLinkRegex, tableRow, tableSeparator, tableStartingPipe, customIgnoreAllStartIndicator, customIgnoreAllEndIndicator, checklistBoxStartsTextRegex, footnoteDefinitionIndicatorAtStartOfLine, emptyLineMathBlockquoteRegex, startsWithBlockquote, startsWithListMarkerRegex, calloutTypeRegex} from './regex';
 import {gfmFootnote} from 'micromark-extension-gfm-footnote';
 import {gfmTaskListItem} from 'micromark-extension-gfm-task-list-item';
 import {frontmatter} from 'micromark-extension-frontmatter';
@@ -446,12 +446,23 @@ export function addTwoSpacesAtEndOfLinesFollowedByAnotherLineOfTextContent(text:
       continue;
     }
 
-    for (let i = 0; i < lastLineIndex; i++) {
+    let startIndex = 0;
+    // if we are dealing with a blockquote and the first line is a callout indicator, skip the callout
+    if (calloutTypeRegex.test(paragraphLines[0]) && paragraphLines[1].startsWith('>')) {
+      startIndex = 1;
+
+      if (lastLineIndex < 2) {
+        continue;
+      }
+    }
+
+    for (let i = startIndex; i < lastLineIndex; i++) {
       const paragraphLine = paragraphLines[i];
 
       if (lineEndsInLineBreak(paragraphLine, indicator)) {
         continue;
       }
+
       paragraphLines[i] = addOrReplaceLineEnding(paragraphLine, indicator);
     }
 

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -50,6 +50,7 @@ export const nonBlockquoteChecklistRegex = new RegExp(`^\\s*- ${checklistBoxIndi
 export const startsWithListMarkerRegex = new RegExp(`^\\s*(- |\\* |\\+ |\\d+[.)] |- (${checklistBoxIndicator}) )`, 'm');
 
 export const footnoteDefinitionIndicatorAtStartOfLine = /^(\[\^[^\]]*\]) ?([,.;!:?])/gm;
+export const calloutTypeRegex = /^ ?\[![^\s]*\]/m;
 export const calloutRegex = /^(>\s*)+\[![^\s]*\]/m;
 export const codeBlockBlockquoteRegex = /^\n?(>\s*)+((```)|(~~~))/m;
 


### PR DESCRIPTION
Fixes #1243 

Changes Made:
- Updated logic to check if the start of the paragraph is a callout indicator and it it is check that the next line starts with a `>` and if so skip that first line
- Added tests for the scenario in question