### PR TITLE
Fix: Removing Multiple Blank Lines on Paste Not Considering Whitespace Lines Blank Lines

### DIFF
--- a/src/rules/consecutive-blank-lines.ts
+++ b/src/rules/consecutive-blank-lines.ts
@@ -2,6 +2,7 @@ import {IgnoreTypes} from '../utils/ignore-types';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
+import {multipleBlankLinesRegex} from '../utils/regex';
 
 class ConsecutiveBlankLinesOptions implements Options {}
 
@@ -20,9 +21,7 @@ export default class ConsecutiveBlankLines extends RuleBuilder<ConsecutiveBlankL
     return ConsecutiveBlankLinesOptions;
   }
   apply(text: string, options: ConsecutiveBlankLinesOptions): string {
-    // make sure to account for lines that are purely whitespace as well https://stackoverflow.com/a/3873354/8353749
-    // make sure that the match ends in a newline
-    return text.replace(/(\n([\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?){2,}\n/g, '\n\n');
+    return text.replace(multipleBlankLinesRegex, '\n\n');
   }
   get exampleBuilders(): ExampleBuilder<ConsecutiveBlankLinesOptions>[] {
     return [

--- a/src/rules/remove-multiple-blank-lines-on-paste.ts
+++ b/src/rules/remove-multiple-blank-lines-on-paste.ts
@@ -1,4 +1,5 @@
 // based on https://github.com/chrisgrieser/obsidian-smarter-paste/blob/master/clipboardModification.ts#L14
+import {multipleBlankLinesRegex} from '../utils/regex';
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
@@ -18,7 +19,7 @@ export default class RemoveMultipleBlankLinesOnPaste extends RuleBuilder<RemoveM
     return RemoveMultipleBlankLinesOnPasteOptions;
   }
   apply(text: string, options: RemoveMultipleBlankLinesOnPasteOptions): string {
-    return text.replace(/\n{3,}/g, '\n\n');
+    return text.replace(multipleBlankLinesRegex, '\n\n');
   }
   get exampleBuilders(): ExampleBuilder<RemoveMultipleBlankLinesOnPasteOptions>[] {
     return [
@@ -43,6 +44,22 @@ export default class RemoveMultipleBlankLinesOnPaste extends RuleBuilder<RemoveM
         before: dedent`
           First line.
           ${''}
+          Last line.
+        `,
+        after: dedent`
+          First line.
+          ${''}
+          Last line.
+        `,
+      }),
+      new ExampleBuilder({ // accounts for https://github.com/platers/obsidian-linter/issues/1381
+        description: 'Text with blank lines present that also have tabs or other whitespace will also be considered blank lines',
+        before: dedent`
+          First line.
+          ${'\t'}
+          ${' '}
+          ${' \t'}
+          ${'\t '}
           Last line.
         `,
         after: dedent`

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -55,6 +55,9 @@ export const calloutRegex = /^(>\s*)+\[![^\s]*\]/m;
 export const codeBlockBlockquoteRegex = /^\n?(>\s*)+((```)|(~~~))/m;
 
 export const unicodeLetterRegex = RegExp(/\p{L}/, 'u');
+// make sure to account for lines that are purely whitespace as well https://stackoverflow.com/a/3873354/8353749
+// make sure that the match ends in a newline
+export const multipleBlankLinesRegex = /(\n([\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+)?){2,}\n/g;
 
 // https://stackoverflow.com/questions/38866071/javascript-replace-method-dollar-signs
 // Important to use this for any regex replacements where the replacement string


### PR DESCRIPTION
Fixes #1381 

There was a user reported issue around pasting which resulted in blank lines that had whitespace characters in them not getting removed. The fix was simple since this had previous been addressed with consecutive blank lines.

Changes Made:
- Refactored the multiple blank lines regex to be resuable
- Used multiple blank lines regex that handles whitespace on blank lines in the logic for removing multiple blank lines on paste
- Added an example/UT for the scenario in question