### PR TITLE
Performance: Improve Performance for Saving Settings and Allowing Users to Quickly Enable and Disable Rules

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,9 @@ export default class LinterPlugin extends Plugin {
   private activeFileChangeDebouncer: Map<string, FileChangeUpdateInfo> = new Map();
   private defaultAutoCorrectMisspellings: Map<string, string> = new Map();
   private hasLoadedMisspellingFiles = false;
+  private saveSettingsDebounce = debounce(async (settings: LinterSettings) => {
+    await this.saveData(settings);
+  }, 5000);
 
   async onload() {
     sortRules();
@@ -142,7 +145,8 @@ export default class LinterPlugin extends Plugin {
       await this.loadAutoCorrectFiles(false);
     }
 
-    await this.saveData(this.settings);
+    void this.saveSettingsDebounce(this.settings);
+
     this.updatePasteOverrideStatus();
     this.updateHasCustomCommandStatus();
   }


### PR DESCRIPTION
There was something I noticed when tinkering with the settings for the Linter. And that is if I was trying to enable a lot of settings back to back and then scroll, the UI of the Linter settings would freeze. This was caused by not debouncing writing the settings changes to disk. So if the user went on a spree updating settings. Each setting change would cause the Linter to try to write the settings to disk. The change made was to debounce writing settings changes to disk by 5 seconds. So if the user makes say 20 settings changes each within 5 seconds of each other, there is only 1 disk update instead of 20.

Changes Made:
- Updated save settings to debounce the logic for saving settings to disk