### PR TITLE
Clarify nested folder ignoring in documentation

### DIFF
--- a/docs/docs/usage/disabling-rules.md
+++ b/docs/docs/usage/disabling-rules.md
@@ -11,7 +11,7 @@ The values in the text box are expected to be folder paths from the base of the 
 
 ![Setting for ignoring specific folders](../assets/folders-to-ignore.jpg)
 
-For example, in the above image, the `templates` folder will be ignored when the Linter attempts to run its rules. Nested folders are also allowed as well.
+For example, in the above image, the `templates` folder will be ignored when the Linter attempts to run its rules. Nested folders are ignored as well.
 
 ## Ignoring Files via Regex
 


### PR DESCRIPTION
The way the text is currently phrased, it makes it sound like the "templates" folder will be ignored, but nested folders will be allowed (to be updated by Linter).

It could just be me, but I think that maybe using the phrase "ignored as well" makes it clear that subfolders of the folder will all be ignored. Unless I'm misunderstanding the behavior, and they're actually _not_ ignored?