### PR TITLE
feat: Priority Sort order for unspecified keys (<others> functionality)

### DIFF
--- a/docs/docs/settings/yaml-rules.md
+++ b/docs/docs/settings/yaml-rules.md
@@ -945,7 +945,7 @@ Sorts the YAML keys based on the order and priority specified. <b>Note: may remo
 
 | Name | Description | List Items | Default Value |
 | ---- | ----------- | ---------- | ------------- |
-| `YAML Key Priority Sort Order` | The order in which to sort keys with one on each line where it sorts in the order found in the list | N/A |  |
+| `YAML Key Priority Sort Order` | The order in which to sort keys, with one key per line. Use `<others>` to place unspecified keys at that position in the order. | N/A |  |
 | `Priority Keys at Start of YAML` | YAML Key Priority Sort Order is placed at the start of the YAML frontmatter | N/A | `true` |
 | `YAML Sort Order for Other Keys` | The way in which to sort the keys that are not found in the YAML Key Priority Sort Order text area | `None`: No sorting other than what is in the YAML Key Priority Sort Order text area<br/><br/>`Ascending Alphabetical`: Sorts the keys based on key value from a to z<br/><br/>`Descending Alphabetical`: Sorts the keys based on key value from z to a | `None` |
 
@@ -1067,6 +1067,34 @@ type: programming
 language: Typescript
 ---
 Any blank line is attached to the line that follows it
+``````
+</details>
+<details><summary>Sorts YAML keys with `<others>` inserted between priority groups</summary>
+
+Before:
+
+`````` markdown
+---
+tags: computer
+keywords: []
+status: WIP
+type: programming
+date: 02/15/2022
+language: Typescript
+---
+``````
+
+After:
+
+`````` markdown
+---
+date: 02/15/2022
+type: programming
+keywords: []
+language: Typescript
+status: WIP
+tags: computer
+---
 ``````
 </details>
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -831,7 +831,7 @@ export default {
       'description': 'Sorts the YAML keys based on the order and priority specified. <b>Note: may remove blank lines as well. Only works on non-nested keys.</b>',
       'yaml-key-priority-sort-order': {
         'name': 'YAML Key Priority Sort Order',
-        'description': 'The order in which to sort keys with one on each line where it sorts in the order found in the list',
+        'description': 'The order in which to sort keys, with one key per line. Use `<others>` to place unspecified keys at that position in the order.',
       },
       'priority-keys-at-start-of-yaml': {
         'name': 'Priority Keys at Start of YAML',

--- a/src/rules/yaml-key-sort.ts
+++ b/src/rules/yaml-key-sort.ts
@@ -8,6 +8,22 @@ import {FlowCollection} from 'yaml/dist/parse/cst';
 
 type YamlSortOrderForOtherKeys = 'None' | 'Ascending Alphabetical' | 'Descending Alphabetical';
 
+const OTHERS_TOKEN = '<others>';
+
+function normalizeYamlSortToken(token: string): string {
+  token = token.trim();
+
+  if (token === OTHERS_TOKEN) {
+    return token;
+  }
+
+  if (token.endsWith(':')) {
+    return token.substring(0, token.length - 1).trimEnd();
+  }
+
+  return token;
+}
+
 class YamlKeySortOptions implements Options {
   priorityKeysAtStartOfYaml?: boolean = true;
 
@@ -46,18 +62,9 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
     const yamlText = oldYaml;
     const priorityAtStartOfYaml: boolean = options.priorityKeysAtStartOfYaml;
 
-    const yamlKeys: string[] = options.yamlKeyPrioritySortOrder;
-    let index = 0;
-    for (let key of yamlKeys) {
-      key = key.trimEnd();
-      if (key.endsWith(':')) {
-        yamlKeys[index] = key.substring(0, key.length - 1);
-      } else if (key != yamlKeys[index]) {
-        yamlKeys[index] = key;
-      }
-
-      index++;
-    }
+    const yamlKeys: string[] = (options.yamlKeyPrioritySortOrder ?? [])
+        .map(normalizeYamlSortToken)
+        .filter((token) => token.length > 0);
 
     const yamlObject = loadYAML(yamlText);
     const doc = parseYAML(yamlText);
@@ -67,27 +74,69 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
       return text;
     }
 
-    let remainingKeys = this.getYAMLKeysSorted(yamlKeys, doc, startingPriorityKeys);
-
     const sortOrder = options.yamlSortOrderForOtherKeys;
     if (yamlObject == null) {
-      return this.getTextWithNewYamlFrontmatter(text, oldYaml, astToString(startingPriorityKeys), astToString(doc), priorityAtStartOfYaml, options.dateModifiedKey, options.currentTimeFormatted, options.yamlTimestampDateModifiedEnabled);
+      return this.getTextWithNewYamlFrontmatter(
+          text,
+          oldYaml,
+          astToString(startingPriorityKeys),
+          astToString(doc),
+          priorityAtStartOfYaml,
+          options.dateModifiedKey,
+          options.currentTimeFormatted,
+          options.yamlTimestampDateModifiedEnabled,
+      );
     }
 
-    let sortMethod: (previousKey: string, currentKey: string) => number;
-    if (sortOrder === 'Ascending Alphabetical') {
-      sortMethod = this.sortAlphabeticallyAsc;
-    } else if (sortOrder === 'Descending Alphabetical') {
-      sortMethod = this.sortAlphabeticallyDesc;
-    } else {
-      return this.getTextWithNewYamlFrontmatter(text, oldYaml, astToString(startingPriorityKeys), astToString(doc), priorityAtStartOfYaml, options.dateModifiedKey, options.currentTimeFormatted, options.yamlTimestampDateModifiedEnabled);
+    const usedOthersToken = this.getYAMLKeysSortedWithOthers(
+        yamlKeys,
+        doc,
+        startingPriorityKeys,
+        sortOrder,
+    );
+
+    if (usedOthersToken) {
+      return this.getTextWithNewYamlFrontmatter(
+          text,
+          oldYaml,
+          astToString(startingPriorityKeys),
+          '',
+          true,
+          options.dateModifiedKey,
+          options.currentTimeFormatted,
+          options.yamlTimestampDateModifiedEnabled,
+      );
+    }
+
+    let remainingKeys = this.getYAMLKeysSorted(yamlKeys, doc, startingPriorityKeys);
+
+    if (sortOrder === 'None') {
+      return this.getTextWithNewYamlFrontmatter(
+          text,
+          oldYaml,
+          astToString(startingPriorityKeys),
+          astToString(doc),
+          priorityAtStartOfYaml,
+          options.dateModifiedKey,
+          options.currentTimeFormatted,
+          options.yamlTimestampDateModifiedEnabled,
+      );
     }
 
     const remainingDocKeys = getEmptyDocument(doc);
-    remainingKeys = remainingKeys.sort(sortMethod);
+    remainingKeys = this.sortRemainingKeys(remainingKeys, sortOrder);
     this.getYAMLKeysSorted(remainingKeys, doc, remainingDocKeys);
 
-    return this.getTextWithNewYamlFrontmatter(text, oldYaml, astToString(startingPriorityKeys), astToString(remainingDocKeys), priorityAtStartOfYaml, options.dateModifiedKey, options.currentTimeFormatted, options.yamlTimestampDateModifiedEnabled);
+    return this.getTextWithNewYamlFrontmatter(
+        text,
+        oldYaml,
+        astToString(startingPriorityKeys),
+        astToString(remainingDocKeys),
+        priorityAtStartOfYaml,
+        options.dateModifiedKey,
+        options.currentTimeFormatted,
+        options.yamlTimestampDateModifiedEnabled,
+    );
   }
   getYAMLKeysSorted(keys: string[], yamlObject: Document, newDocument: Document): string[] {
     const initialKeys: YamlNode[] = (yamlObject.contents as YamlNode).items as YamlNode[];
@@ -112,6 +161,75 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
     }
 
     return remainingKeys;
+  }
+  getYAMLKeysSortedWithOthers(tokens: string[], yamlObject: Document, newDocument: Document, sortOrder: YamlSortOrderForOtherKeys): boolean {
+    const firstOthersIndex = tokens.indexOf(OTHERS_TOKEN);
+
+    if (firstOthersIndex === -1) {
+      return false;
+    }
+
+    const initialKeys: YamlNode[] = (yamlObject.contents as YamlNode).items as YamlNode[];
+    const srcTokens = (yamlObject.contents.srcToken as FlowCollection).items;
+    let othersInserted = false;
+
+    const addNodeAtIndex = (index: number) => {
+      const node = initialKeys[index];
+      newDocument.add(node);
+      (newDocument.contents.srcToken as YamlCSTTokens).items.push(srcTokens[index]);
+      initialKeys.splice(index, 1);
+      srcTokens.splice(index, 1);
+    };
+
+    const addMatchingKey = (key: string) => {
+      for (let i = 0; i < initialKeys.length; i++) {
+        const node = initialKeys[i];
+        if (node.key.value === key) {
+          addNodeAtIndex(i);
+          break;
+        }
+      }
+    };
+
+    const addRemainingKeys = () => {
+      const explicitlyListedKeys = new Set(
+          tokens.filter((token) => token !== OTHERS_TOKEN),
+      );
+
+      const remainingKeys = initialKeys
+          .map((node) => node.key.value)
+          .filter((key) => !explicitlyListedKeys.has(key));
+
+      const sortedRemainingKeys = this.sortRemainingKeys(remainingKeys, sortOrder);
+
+      for (const key of sortedRemainingKeys) {
+        addMatchingKey(key);
+      }
+    };
+
+    for (const token of tokens) {
+      if (token === OTHERS_TOKEN) {
+        if (!othersInserted) {
+          addRemainingKeys();
+          othersInserted = true;
+        }
+      } else {
+        addMatchingKey(token);
+      }
+    }
+
+    return true;
+  }
+  sortRemainingKeys(keys: string[], sortOrder: YamlSortOrderForOtherKeys): string[] {
+    if (sortOrder === 'Ascending Alphabetical') {
+      return [...keys].sort(this.sortAlphabeticallyAsc);
+    }
+
+    if (sortOrder === 'Descending Alphabetical') {
+      return [...keys].sort(this.sortAlphabeticallyDesc);
+    }
+
+    return [...keys];
   }
   updateDateModifiedIfYamlChanged(oldYaml: string, newYaml: string, dateModifiedKey: string, currentTimeFormatted: string): string {
     if (oldYaml == newYaml) {
@@ -275,6 +393,39 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
           ],
           yamlSortOrderForOtherKeys: 'Descending Alphabetical',
           priorityKeysAtStartOfYaml: false,
+        },
+      }),
+      new ExampleBuilder({
+        description: 'Sorts YAML keys with `<others>` inserted between priority groups',
+        before: dedent`
+          ---
+          tags: computer
+          keywords: []
+          status: WIP
+          type: programming
+          date: 02/15/2022
+          language: Typescript
+          ---
+        `,
+        after: dedent`
+          ---
+          date: 02/15/2022
+          type: programming
+          keywords: []
+          language: Typescript
+          status: WIP
+          tags: computer
+          ---
+        `,
+        options: {
+          yamlKeyPrioritySortOrder: [
+            'date',
+            'type',
+            '<others>',
+            'status',
+            'tags',
+          ],
+          yamlSortOrderForOtherKeys: 'Ascending Alphabetical',
         },
       }),
     ];


### PR DESCRIPTION
## Summary
Addressing #1105 

Allows assigning a "YAML Key Priority Sort Order" for all unspecified keys by including `<others>` as a placeholder in the sort order. This feature enables "sandwiching" undefined keys between a "front" and "back" end of explicitly defined key orderings. 

## PR Known Functionality
- within `<others>` class, "ascending, descending, and none" sorts still function as expected. 
- "Priority Keys at Start of YAML" is functionally redundant — false is achieved through placing `<others>` at top of sort order, true is achieved by placing `<others>` at bottom of sort order. 
- "Priority Keys at Start of YAML" option is overridden iff `<others>` is provided. 
- English translation settings updated to communicate the change.

## Example

Before:
<img width="611" height="486" alt="Screenshot 2026-03-31 at 12 56 54 AM" src="https://github.com/user-attachments/assets/31943669-38d2-4fc6-9c82-ba4c4a30bfc4" />

After:
<img width="607" height="483" alt="Screenshot 2026-03-31 at 12 57 19 AM" src="https://github.com/user-attachments/assets/79f3a307-39fb-4180-8b00-b63ed2a18009" />

*i.e. `misc1` and `misc2`, not defined in the sort order, can have intelligent placement among the specified fields after linted*
