### PR TITLE
Fix: Restore Inline Code Correctly When Moving Footnotes to the Bottom

### DIFF
--- a/__tests__/ignore-list-of-types.test.ts
+++ b/__tests__/ignore-list-of-types.test.ts
@@ -4,8 +4,9 @@ import dedent from 'ts-dedent';
 type customIgnoresInTextTestCase = {
   name: string,
   text: string,
-  expectedTextAfterIgnore: string,
+  expectedTextAfterIgnore?: string,
   ignoreTypes: IgnoreType[];
+  afterIgnoreAssert?: (text: string) => void,
 };
 
 const ignoreListOfTypesTestCases: customIgnoresInTextTestCase[] = [
@@ -97,13 +98,30 @@ const ignoreListOfTypesTestCases: customIgnoresInTextTestCase[] = [
     `,
     ignoreTypes: [IgnoreTypes.customIgnore],
   },
+  {
+    name: 'inline code ignore types are promoted to unique tokens',
+    text: dedent`
+      Before \`alpha\` and \`beta\`
+    `,
+    ignoreTypes: [IgnoreTypes.inlineCode],
+    afterIgnoreAssert: (text: string) => {
+      expect(text).toContain('{INLINE_CODE_BLOCK_PLACEHOLDER}_0');
+      expect(text).toContain('{INLINE_CODE_BLOCK_PLACEHOLDER}_1');
+      expect(text).not.toContain('`alpha`');
+      expect(text).not.toContain('`beta`');
+    },
+  },
 ];
 
 describe('Ignore List of Types', () => {
   for (const testCase of ignoreListOfTypesTestCases) {
     it(testCase.name, () => {
       const text = ignoreListOfTypes(testCase.ignoreTypes, testCase.text, (text: string) => {
-        expect(text).toEqual(testCase.expectedTextAfterIgnore);
+        if (testCase.afterIgnoreAssert) {
+          testCase.afterIgnoreAssert(text);
+        } else {
+          expect(text).toEqual(testCase.expectedTextAfterIgnore);
+        }
 
         return text;
       } );

--- a/__tests__/ignore-list-of-types.test.ts
+++ b/__tests__/ignore-list-of-types.test.ts
@@ -4,7 +4,7 @@ import dedent from 'ts-dedent';
 type customIgnoresInTextTestCase = {
   name: string,
   text: string,
-  expectedTextAfterIgnore: string,
+  expectedTextAfterIgnore?: string,
   ignoreTypes: IgnoreType[];
 };
 
@@ -46,17 +46,6 @@ const ignoreListOfTypesTestCases: customIgnoresInTextTestCase[] = [
       ${''}
       content
     `,
-    expectedTextAfterIgnore: dedent`
-      content
-      ${''}
-      {CUSTOM_IGNORE_PLACEHOLDER}
-      ${''}
-      content
-      ${''}
-      {CUSTOM_IGNORE_PLACEHOLDER}
-      ${''}
-      content
-    `,
     ignoreTypes: [IgnoreTypes.customIgnore],
   },
   {
@@ -84,17 +73,6 @@ const ignoreListOfTypesTestCases: customIgnoresInTextTestCase[] = [
       ${''}
       content
     `,
-    expectedTextAfterIgnore: dedent`
-      content
-      ${''}
-      {CUSTOM_IGNORE_PLACEHOLDER}
-      ${''}
-      content
-      ${''}
-      {CUSTOM_IGNORE_PLACEHOLDER}
-      ${''}
-      content
-    `,
     ignoreTypes: [IgnoreTypes.customIgnore],
   },
 ];
@@ -103,7 +81,15 @@ describe('Ignore List of Types', () => {
   for (const testCase of ignoreListOfTypesTestCases) {
     it(testCase.name, () => {
       const text = ignoreListOfTypes(testCase.ignoreTypes, testCase.text, (text: string) => {
-        expect(text).toEqual(testCase.expectedTextAfterIgnore);
+        if (testCase.expectedTextAfterIgnore !== undefined) {
+          expect(text).toEqual(testCase.expectedTextAfterIgnore);
+        } else {
+          expect(text).not.toContain('$$\nabc\n$$');
+
+          const ignoreTokens = text.match(/IGNORE_TOKEN_[a-z0-9]+_\d+/g);
+          expect(ignoreTokens).toHaveLength(2);
+          expect(new Set(ignoreTokens).size).toBe(2);
+        }
 
         return text;
       } );

--- a/__tests__/ignore-list-of-types.test.ts
+++ b/__tests__/ignore-list-of-types.test.ts
@@ -4,7 +4,7 @@ import dedent from 'ts-dedent';
 type customIgnoresInTextTestCase = {
   name: string,
   text: string,
-  expectedTextAfterIgnore?: string,
+  expectedTextAfterIgnore: string,
   ignoreTypes: IgnoreType[];
 };
 
@@ -46,6 +46,17 @@ const ignoreListOfTypesTestCases: customIgnoresInTextTestCase[] = [
       ${''}
       content
     `,
+    expectedTextAfterIgnore: dedent`
+      content
+      ${''}
+      {CUSTOM_IGNORE_PLACEHOLDER}
+      ${''}
+      content
+      ${''}
+      {CUSTOM_IGNORE_PLACEHOLDER}
+      ${''}
+      content
+    `,
     ignoreTypes: [IgnoreTypes.customIgnore],
   },
   {
@@ -73,6 +84,17 @@ const ignoreListOfTypesTestCases: customIgnoresInTextTestCase[] = [
       ${''}
       content
     `,
+    expectedTextAfterIgnore: dedent`
+      content
+      ${''}
+      {CUSTOM_IGNORE_PLACEHOLDER}
+      ${''}
+      content
+      ${''}
+      {CUSTOM_IGNORE_PLACEHOLDER}
+      ${''}
+      content
+    `,
     ignoreTypes: [IgnoreTypes.customIgnore],
   },
 ];
@@ -81,15 +103,7 @@ describe('Ignore List of Types', () => {
   for (const testCase of ignoreListOfTypesTestCases) {
     it(testCase.name, () => {
       const text = ignoreListOfTypes(testCase.ignoreTypes, testCase.text, (text: string) => {
-        if (testCase.expectedTextAfterIgnore !== undefined) {
-          expect(text).toEqual(testCase.expectedTextAfterIgnore);
-        } else {
-          expect(text).not.toContain('$$\nabc\n$$');
-
-          const ignoreTokens = text.match(/IGNORE_TOKEN_[a-z0-9]+_\d+/g);
-          expect(ignoreTokens).toHaveLength(2);
-          expect(new Set(ignoreTokens).size).toBe(2);
-        }
+        expect(text).toEqual(testCase.expectedTextAfterIgnore);
 
         return text;
       } );

--- a/__tests__/move-footnotes-to-the-bottom.test.ts
+++ b/__tests__/move-footnotes-to-the-bottom.test.ts
@@ -339,5 +339,86 @@ ruleTest({
         Here is some content
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom preserves inline code values in the body when footnotes are interspersed',
+      before: dedent`
+        Here is \`first code\` in the body.[^1]
+        ${''}
+        [^1]: Footnote one.
+        ${''}
+        Here is \`second code\` in the body.[^2]
+        ${''}
+        [^2]: Footnote two.
+      `,
+      after: dedent`
+        Here is \`first code\` in the body.[^1]
+        ${''}
+        Here is \`second code\` in the body.[^2]
+        ${''}
+        [^1]: Footnote one.
+        [^2]: Footnote two.
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom preserves inline code values inside footnotes',
+      before: dedent`
+        Body text.[^1]
+        ${''}
+        [^1]: Footnote with \`code inside\`.
+        ${''}
+        More body text.
+      `,
+      after: dedent`
+        Body text.[^1]
+        ${''}
+        More body text.
+        ${''}
+        [^1]: Footnote with \`code inside\`.
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom does not mix inline code between body and footnotes with multiple occurrences',
+      before: dedent`
+        Body has \`alpha\` and \`beta\`.[^1]
+        ${''}
+        [^1]: Footnote has \`gamma\`.
+        ${''}
+        More body has \`delta\`.[^2]
+        ${''}
+        [^2]: Another footnote has \`epsilon\`.
+      `,
+      after: dedent`
+        Body has \`alpha\` and \`beta\`.[^1]
+        ${''}
+        More body has \`delta\`.[^2]
+        ${''}
+        [^1]: Footnote has \`gamma\`.
+        [^2]: Another footnote has \`epsilon\`.
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom does not mix inline code between body and footnotes when includeBlankLineBetweenFootnotes is true',
+      before: dedent`
+        Body has \`body-code\`.[^1]
+        ${''}
+        [^1]: Footnote has \`footnote-code-1\`.
+        ${''}
+        More body.[^2]
+        ${''}
+        [^2]: Another footnote has \`footnote-code-2\`.
+      `,
+      after: dedent`
+        Body has \`body-code\`.[^1]
+        ${''}
+        More body.[^2]
+        ${''}
+        [^1]: Footnote has \`footnote-code-1\`.
+        ${''}
+        [^2]: Another footnote has \`footnote-code-2\`.
+      `,
+      options: {
+        includeBlankLineBetweenFootnotes: true,
+      },
+    },
   ],
 });

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -40,6 +40,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
   let setOfPlaceholders: {replacements: IgnoredReplacement[]}[] = [];
   const ignoreSessionPrefix = createIgnoreSessionPrefix();
+  let tokenIndex = 0;
 
   // replace ignore blocks with their placeholders
   let replaceValues: string[] = [];
@@ -53,11 +54,9 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
       [replaceValues, text] = ignoreFunc(text, ignoreType.placeholder);
     }
 
-    // Promote base placeholders to unique tokens so ignored values can still be restored after rules reorder parts of the document, such as moving footnotes.
-    // see https://github.com/platers/obsidian-linter/issues/1439
-    const replacements = replaceValues.map((value: string, index: number) : IgnoredReplacement => {
+    const replacements = replaceValues.map((value: string) : IgnoredReplacement => {
       return {
-        token: createIgnoreToken(ignoreSessionPrefix, index),
+        token: createUniqueToken(ignoreType.placeholder, ignoreSessionPrefix, tokenIndex++),
         original: value,
       };
     });
@@ -90,8 +89,13 @@ function createIgnoreSessionPrefix(): string {
   return Math.random().toString(36).slice(2, 10);
 }
 
-function createIgnoreToken(ignoreSessionPrefix: string, index: number): string {
-  return `IGNORE_TOKEN_${ignoreSessionPrefix}_${index}`;
+function createUniqueToken(placeholder: string, ignoreSessionPrefix: string, index: number): string {
+  if (placeholder.startsWith('{') && placeholder.endsWith('}')) {
+    // Make brace-format placeholders unique per occurrence so that restoration
+    // is order-independent after rules reorder content. See: #1439
+    return placeholder.slice(0, -1) + `_${ignoreSessionPrefix}_${index}}`;
+  }
+  return placeholder;
 }
 
 /**

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -53,6 +53,8 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
       [replaceValues, text] = ignoreFunc(text, ignoreType.placeholder);
     }
 
+    // Promote base placeholders to unique tokens so ignored values can still be restored after rules reorder parts of the document, such as moving footnotes.
+    // see https://github.com/platers/obsidian-linter/issues/1439
     const replacements = replaceValues.map((value: string, index: number) : IgnoredReplacement => {
       return {
         token: createIgnoreToken(ignoreSessionPrefix, index),

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -4,13 +4,16 @@ import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
 
 export type IgnoreFunction = ((text: string, placeholder: string) => [string[], string]);
-export type IgnoreType = {replaceAction: MDAstTypes | RegExp | IgnoreFunction, placeholder: string};
+export type IgnoreType = {replaceAction: MDAstTypes | RegExp | IgnoreFunction, placeholder: string, useUniqueTokens?: boolean};
 export type IgnoredReplacement = {token: string, original: string};
+type IgnoredReplacementGroup =
+  | {mode: 'token', replacements: IgnoredReplacement[]}
+  | {mode: 'placeholder', placeholder: string, replacedValues: string[]};
 
 export const IgnoreTypes: Record<string, IgnoreType> = {
   // mdast node types
   code: {replaceAction: MDAstTypes.Code, placeholder: '{CODE_BLOCK_PLACEHOLDER}'},
-  inlineCode: {replaceAction: MDAstTypes.InlineCode, placeholder: '{INLINE_CODE_BLOCK_PLACEHOLDER}'},
+  inlineCode: {replaceAction: MDAstTypes.InlineCode, placeholder: '{INLINE_CODE_BLOCK_PLACEHOLDER}', useUniqueTokens: true},
   image: {replaceAction: MDAstTypes.Image, placeholder: '{IMAGE_PLACEHOLDER}'},
   thematicBreak: {replaceAction: MDAstTypes.HorizontalRule, placeholder: '{HORIZONTAL_RULE_PLACEHOLDER}'},
   italics: {replaceAction: MDAstTypes.Italics, placeholder: '{ITALICS_PLACEHOLDER}'},
@@ -38,8 +41,7 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
 } as const;
 
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
-  let setOfPlaceholders: {replacements: IgnoredReplacement[]}[] = [];
-  const ignoreSessionPrefix = createIgnoreSessionPrefix();
+  let ignoredReplacementGroups: IgnoredReplacementGroup[] = [];
   let tokenIndex = 0;
 
   // replace ignore blocks with their placeholders
@@ -54,48 +56,52 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
       [replaceValues, text] = ignoreFunc(text, ignoreType.placeholder);
     }
 
-    const replacements = replaceValues.map((value: string) : IgnoredReplacement => {
-      return {
-        token: createUniqueToken(ignoreType.placeholder, ignoreSessionPrefix, tokenIndex++),
-        original: value,
-      };
-    });
+    // Make brace-format placeholders unique per occurrence so that restoration is order-independent after rules reorder content.
+    // see https://github.com/platers/obsidian-linter/issues/1439
+    if (ignoreType.useUniqueTokens) {
+      const replacements = replaceValues.map((value: string) : IgnoredReplacement => {
+        return {
+          token: `${ignoreType.placeholder}_${tokenIndex++}`,
+          original: value,
+        };
+      });
 
-    for (const replacement of replacements) {
-      text = text.replace(ignoreType.placeholder, replacement.token);
+      const uniqueTokenRegex = new RegExp(`${ignoreType.placeholder}(?!_)`);
+      for (const replacement of replacements) {
+        text = text.replace(uniqueTokenRegex, replacement.token);
+      }
+
+      ignoredReplacementGroups.push({mode: 'token', replacements});
+    } else {
+      ignoredReplacementGroups.push({
+        mode: 'placeholder',
+        placeholder: ignoreType.placeholder,
+        replacedValues: replaceValues,
+      });
     }
-
-    setOfPlaceholders.push({replacements});
   }
 
   text = func(text);
 
-  setOfPlaceholders = setOfPlaceholders.reverse();
+  ignoredReplacementGroups = ignoredReplacementGroups.reverse();
   // Restore ignored values by replacing each generated token with its original text.
-  if (setOfPlaceholders != null && setOfPlaceholders.length > 0) {
-    setOfPlaceholders.forEach((replacementGroup: {replacements: IgnoredReplacement[]}) => {
-      replacementGroup.replacements.forEach((replacement: IgnoredReplacement) => {
-        // Use a case-insensitive regex so ignored values can still be restored if another rule changes a generated token's casing.
-        // see https://github.com/platers/obsidian-linter/issues/201
-        text = text.replace(new RegExp(replacement.token, 'i'), escapeDollarSigns(replacement.original));
-      });
+  if (ignoredReplacementGroups != null && ignoredReplacementGroups.length > 0) {
+    ignoredReplacementGroups.forEach((replacementGroup: IgnoredReplacementGroup) => {
+      if (replacementGroup.mode === 'token') {
+        replacementGroup.replacements.forEach((replacement: IgnoredReplacement) => {
+          // Use a case-insensitive regex so ignored values can still be restored if another rule changes a generated token's casing.
+          // see https://github.com/platers/obsidian-linter/issues/201
+          text = text.replace(new RegExp(replacement.token, 'i'), escapeDollarSigns(replacement.original));
+        });
+      } else {
+        replacementGroup.replacedValues.forEach((replacedValue: string) => {
+          text = text.replace(new RegExp(replacementGroup.placeholder, 'i'), escapeDollarSigns(replacedValue));
+        });
+      }
     });
   }
 
   return text;
-}
-
-function createIgnoreSessionPrefix(): string {
-  return Math.random().toString(36).slice(2, 10);
-}
-
-function createUniqueToken(placeholder: string, ignoreSessionPrefix: string, index: number): string {
-  if (placeholder.startsWith('{') && placeholder.endsWith('}')) {
-    // Make brace-format placeholders unique per occurrence so that restoration
-    // is order-independent after rules reorder content. See: #1439
-    return placeholder.slice(0, -1) + `_${ignoreSessionPrefix}_${index}}`;
-  }
-  return placeholder;
 }
 
 /**

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -58,7 +58,7 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
     const replacements = replaceValues.map((value: string, index: number) : IgnoredReplacement => {
       return {
         token: createIgnoreToken(ignoreSessionPrefix, index),
-        original: value
+        original: value,
       };
     });
 
@@ -74,7 +74,7 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
   setOfPlaceholders = setOfPlaceholders.reverse();
   // Restore ignored values by replacing each generated token with its original text.
   if (setOfPlaceholders != null && setOfPlaceholders.length > 0) {
-    setOfPlaceholders.forEach((replacementGroup: {replacements: IgnoredReplacement[]})  => {
+    setOfPlaceholders.forEach((replacementGroup: {replacements: IgnoredReplacement[]}) => {
       replacementGroup.replacements.forEach((replacement: IgnoredReplacement) => {
         // Use a case-insensitive regex so ignored values can still be restored if another rule changes a generated token's casing.
         // see https://github.com/platers/obsidian-linter/issues/201

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -70,11 +70,11 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
   text = func(text);
 
   setOfPlaceholders = setOfPlaceholders.reverse();
-  // add back values that were replaced with their placeholders
+  // Restore ignored values by replacing each generated token with its original text.
   if (setOfPlaceholders != null && setOfPlaceholders.length > 0) {
     setOfPlaceholders.forEach((replacementGroup: {replacements: IgnoredReplacement[]})  => {
       replacementGroup.replacements.forEach((replacement: IgnoredReplacement) => {
-        // Regex was added to fix capitalization issue  where another rule made the text not match the original place holder's case
+        // Use a case-insensitive regex so ignored values can still be restored if another rule changes a generated token's casing.
         // see https://github.com/platers/obsidian-linter/issues/201
         text = text.replace(new RegExp(replacement.token, 'i'), escapeDollarSigns(replacement.original));
       });

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -5,6 +5,7 @@ import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
 
 export type IgnoreFunction = ((text: string, placeholder: string) => [string[], string]);
 export type IgnoreType = {replaceAction: MDAstTypes | RegExp | IgnoreFunction, placeholder: string};
+export type IgnoredReplacement = {token: string, original: string};
 
 export const IgnoreTypes: Record<string, IgnoreType> = {
   // mdast node types
@@ -37,7 +38,8 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
 } as const;
 
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
-  let setOfPlaceholders: {placeholder: string, replacedValues: string[]}[] = [];
+  let setOfPlaceholders: {replacements: IgnoredReplacement[]}[] = [];
+  const ignoreSessionPrefix = createIgnoreSessionPrefix();
 
   // replace ignore blocks with their placeholders
   let replaceValues: string[] = [];
@@ -51,7 +53,18 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
       [replaceValues, text] = ignoreFunc(text, ignoreType.placeholder);
     }
 
-    setOfPlaceholders.push({replacedValues: replaceValues, placeholder: ignoreType.placeholder});
+    const replacements = replaceValues.map((value: string, index: number) : IgnoredReplacement => {
+      return {
+        token: createIgnoreToken(ignoreSessionPrefix, index),
+        original: value
+      };
+    });
+
+    for (const replacement of replacements) {
+      text = text.replace(ignoreType.placeholder, replacement.token);
+    }
+
+    setOfPlaceholders.push({replacements});
   }
 
   text = func(text);
@@ -59,16 +72,24 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
   setOfPlaceholders = setOfPlaceholders.reverse();
   // add back values that were replaced with their placeholders
   if (setOfPlaceholders != null && setOfPlaceholders.length > 0) {
-    setOfPlaceholders.forEach((replacedInfo: {placeholder: string, replacedValues: string[], replaceDollarSigns: boolean}) => {
-      replacedInfo.replacedValues.forEach((replacedValue: string) => {
+    setOfPlaceholders.forEach((replacementGroup: {replacements: IgnoredReplacement[]})  => {
+      replacementGroup.replacements.forEach((replacement: IgnoredReplacement) => {
         // Regex was added to fix capitalization issue  where another rule made the text not match the original place holder's case
         // see https://github.com/platers/obsidian-linter/issues/201
-        text = text.replace(new RegExp(replacedInfo.placeholder, 'i'), escapeDollarSigns(replacedValue));
+        text = text.replace(new RegExp(replacement.token, 'i'), escapeDollarSigns(replacement.original));
       });
     });
   }
 
   return text;
+}
+
+function createIgnoreSessionPrefix(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function createIgnoreToken(ignoreSessionPrefix: string, index: number): string {
+  return `IGNORE_TOKEN_${ignoreSessionPrefix}_${index}`;
 }
 
 /**


### PR DESCRIPTION
Fixes #1439

When the `Move Footnotes to the Bottom` rule ran, inline code values in the body and footnotes could be restored in the wrong locations. The issue was caused by `ignoreListOfTypes()` using shared placeholders for inline code and then restoring values sequentially after the document had been reordered.

This change promotes ignored inline code placeholders to unique tokens and restores those values using a 1:1 token-to-original mapping. Other ignore types continue to use their existing placeholder-based flow so their intermediate formatting contracts remain unchanged.

Changes Made:
- Updated `ignoreListOfTypes()` to promote ignored inline code placeholders to unique tokens while preserving the existing placeholder flow for other ignore types
- Changed inline code restoration to use token-based replacement instead of sequential shared-placeholder replacement
- Added regression tests covering inline code restoration when moving footnotes to the bottom
- Added ignore list test coverage for unique inline code token promotion