### PR TITLE
Fix Replacement Order for Escape Characters for Custom Replacement Replace Regex

### DIFF
--- a/__tests__/rules-runner.test.ts
+++ b/__tests__/rules-runner.test.ts
@@ -271,6 +271,20 @@ const customReplaceTestCases: CustomReplaceTestCase[] = [
       Did it stay the same?
     `,
   },
+  { // accounts for https://github.com/platers/obsidian-linter/issues/1508
+    testName: 'An escaped slash should be handled first before other escapes',
+    listOfRegexReplacements: [
+      {
+        label: undefined, find: '\\|([\\w\\d])>', replace: '$|$1 \\rangle$', flags: 'gm', enabled: true,
+      },
+    ],
+    before: dedent`
+      |x>
+    `,
+    after: dedent`
+      $|x \rangle$
+    `,
+  },
 ];
 
 describe('Rules Runner', () => {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -365,6 +365,8 @@ export function hashString53Bit(str: string, seed: number = 0): number {
  * @return {string} The string with the escape characters converted to their escape character form.
  */
 export function convertStringVersionOfEscapeCharactersToEscapeCharacters(val: string): string {
+  // replace string version of escaped \ with the single instance of \
+  val = val.replaceAll('\\\\', '\\');
   // replace string version of form feed character with the actual form feed character
   val = val.replaceAll('\\f', '\f');
   // replace string version of new line character with the actual new line character
@@ -375,8 +377,6 @@ export function convertStringVersionOfEscapeCharactersToEscapeCharacters(val: st
   val = val.replaceAll('\\t', '\t');
   // replace string version of vertical tab character with the actual vertical tab character
   val = val.replaceAll('\\v', '\v');
-  // replace string version of escaped \ with the single instance of \
-  val = val.replaceAll('\\\\', '\\');
 
   return val;
 }


### PR DESCRIPTION
Fixes #1508 

There was a problem reported where trying to have an escaped slash before an r was not working. When I looked into it, it was because I handled escaped slashes last instead of first. So I swapped the order.

Changes Made:
- Handle escaped slashes first
- Added a unit test for the scenario in question