### PR TITLE
Fix Changing Enabled Status for Custom Settings Not Saving Settings

### DIFF
--- a/src/ui/linter-components/custom-command-option.ts
+++ b/src/ui/linter-components/custom-command-option.ts
@@ -86,6 +86,7 @@ export class CustomCommandOption extends AddCustomRow {
           cb.setValue(command.enabled)
               .onChange((status: boolean) => {
                 command.enabled = status;
+                this.saveSettings();
               });
         });
   }

--- a/src/ui/linter-components/custom-replace-option.ts
+++ b/src/ui/linter-components/custom-replace-option.ts
@@ -112,6 +112,7 @@ export class CustomReplaceOption extends AddCustomRow {
       cb.setValue(regex.enabled)
           .onChange((status: boolean) => {
             regex.enabled = status;
+            this.saveSettings();
           });
     });
 


### PR DESCRIPTION
Fixes #1497 

There was a bug reported around a custom replacement not being able to be disabled. The bug is actually that just changing that one setting of whether or not the custom option is enabled or disabled does not trigger saving the settings. Thus restarting or closing obsidian afterwards does not retain the change. This PR should fix that.

Changes Made:
- Add the logic for saving settings to both custom commands and custom replacements for when the custom option is enabled or disabled