### PR TITLE
Fix Whitespace Only List Lines Not Affected by `trailing-spaces`

### DIFF
--- a/__tests__/trailing-spaces.test.ts
+++ b/__tests__/trailing-spaces.test.ts
@@ -169,7 +169,7 @@ ruleTest({
         ${''}
       `,
     },
-    {
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1505
       testName: 'Make sure that whitespace only lines inside of lists are properly trimmed',
       before: dedent`
         Some text

--- a/__tests__/trailing-spaces.test.ts
+++ b/__tests__/trailing-spaces.test.ts
@@ -169,5 +169,28 @@ ruleTest({
         ${''}
       `,
     },
+    {
+      testName: 'Make sure that whitespace only lines inside of lists are properly trimmed',
+      before: dedent`
+        Some text
+         ${''}
+        - List item 1
+         ${''}
+        1. List item 2
+         ${''}
+        > Blockquote
+         ${''}
+      `,
+      after: dedent`
+        Some text
+        ${''}
+        - List item 1
+        ${''}
+        1. List item 2
+        ${''}
+        > Blockquote
+        ${''}
+      `,
+    },
   ],
 });

--- a/src/rules/trailing-spaces.ts
+++ b/src/rules/trailing-spaces.ts
@@ -34,7 +34,7 @@ export default class TrailingSpaces extends RuleBuilder<TrailingSpacesOptions> {
       }
     });
 
-    return updateListItemText(text, (text: string): string => {
+    text = updateListItemText(text, (text: string): string => {
       if (!options.twoSpaceLineBreak) {
         return text.replace(/[ \t]+$/gm, '');
       } else {
@@ -44,6 +44,17 @@ export default class TrailingSpaces extends RuleBuilder<TrailingSpacesOptions> {
         return text;
       }
     }, true);
+
+    // lastly check for any empty lines that may have slipped through the cracks
+    if (!options.twoSpaceLineBreak) {
+      text = text.replace(/^[ \t]+$/gm, '');
+    } else {
+      text = text.replace(/^[ \t]$/gm, '$1'); // one whitespace
+      text = text.replace(/^[ \t]{3,}$/gm, '$1'); // three or more whitespaces
+      text = text.replace(/^( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
+    }
+
+    return text;
   }
   get exampleBuilders(): ExampleBuilder<TrailingSpacesOptions>[] {
     return [


### PR DESCRIPTION
Fixes #1505 

There was an issue where whitespace only lines were not being affected by `trailing-spaces`. To catch this scenario, once all other logic runs, we need to check for whitespace only lines that match the option selected for leaving or not leaving two trailing spaces alone.

Changes Made:
- Update whitespace only lines once other scenarios are handled
- Added a UT for the scenario in question