### PR TITLE
Fix Placeholder Logic Using Identical Placeholders and Occasionally Causing Errors Restoring Content

### DIFF
--- a/__tests__/ignore-list-of-types.test.ts
+++ b/__tests__/ignore-list-of-types.test.ts
@@ -103,7 +103,9 @@ describe('Ignore List of Types', () => {
   for (const testCase of ignoreListOfTypesTestCases) {
     it(testCase.name, () => {
       const text = ignoreListOfTypes(testCase.ignoreTypes, testCase.text, (text: string) => {
-        expect(text).toEqual(testCase.expectedTextAfterIgnore);
+        // to make sure that the custom ignore matches the expected, we will go ahead and replace the "UUID" from the end of the indicator
+        const cleanedText = text.replaceAll(/{CUSTOM_IGNORE_PLACEHOLDER.+}/g, '{CUSTOM_IGNORE_PLACEHOLDER}');
+        expect(cleanedText).toEqual(testCase.expectedTextAfterIgnore);
 
         return text;
       } );

--- a/__tests__/move-footnotes-to-the-bottom.test.ts
+++ b/__tests__/move-footnotes-to-the-bottom.test.ts
@@ -339,5 +339,86 @@ ruleTest({
         Here is some content
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom preserves inline code values in the body when footnotes are interspersed',
+      before: dedent`
+        Here is \`first code\` in the body.[^1]
+        ${''}
+        [^1]: Footnote one.
+        ${''}
+        Here is \`second code\` in the body.[^2]
+        ${''}
+        [^2]: Footnote two.
+      `,
+      after: dedent`
+        Here is \`first code\` in the body.[^1]
+        ${''}
+        Here is \`second code\` in the body.[^2]
+        ${''}
+        [^1]: Footnote one.
+        [^2]: Footnote two.
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom preserves inline code values inside footnotes',
+      before: dedent`
+        Body text.[^1]
+        ${''}
+        [^1]: Footnote with \`code inside\`.
+        ${''}
+        More body text.
+      `,
+      after: dedent`
+        Body text.[^1]
+        ${''}
+        More body text.
+        ${''}
+        [^1]: Footnote with \`code inside\`.
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom does not mix inline code between body and footnotes with multiple occurrences',
+      before: dedent`
+        Body has \`alpha\` and \`beta\`.[^1]
+        ${''}
+        [^1]: Footnote has \`gamma\`.
+        ${''}
+        More body has \`delta\`.[^2]
+        ${''}
+        [^2]: Another footnote has \`epsilon\`.
+      `,
+      after: dedent`
+        Body has \`alpha\` and \`beta\`.[^1]
+        ${''}
+        More body has \`delta\`.[^2]
+        ${''}
+        [^1]: Footnote has \`gamma\`.
+        [^2]: Another footnote has \`epsilon\`.
+      `,
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1439
+      testName: 'Moving footnotes to the bottom does not mix inline code between body and footnotes when includeBlankLineBetweenFootnotes is true',
+      before: dedent`
+        Body has \`body-code\`.[^1]
+        ${''}
+        [^1]: Footnote has \`footnote-code-1\`.
+        ${''}
+        More body.[^2]
+        ${''}
+        [^2]: Another footnote has \`footnote-code-2\`.
+      `,
+      after: dedent`
+        Body has \`body-code\`.[^1]
+        ${''}
+        More body.[^2]
+        ${''}
+        [^1]: Footnote has \`footnote-code-1\`.
+        ${''}
+        [^2]: Another footnote has \`footnote-code-2\`.
+      `,
+      options: {
+        includeBlankLineBetweenFootnotes: true,
+      },
+    },
   ],
 });

--- a/src/rules/blockquote-style.ts
+++ b/src/rules/blockquote-style.ts
@@ -63,6 +63,9 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
     let startOfIndex = 0;
     let newBlockquote = blockquote;
     let breakOutOfLoop = false;
+    const mathPlaceHolderRegex = new RegExp(IgnoreTypes.math.placeholder.replace('}', '.+}'), '');
+    const codePlaceHolderRegex = new RegExp(IgnoreTypes.code.placeholder.replace('}', '.+}'), '');
+
     do {
       nextNewLine = newBlockquote.indexOf('\n', currentIndex);
       if (nextNewLine === -1) {
@@ -80,7 +83,7 @@ export default class BlockquoteStyle extends RuleBuilder<BlockquoteStyleOptions>
 
       const restOfLine = newBlockquote.substring(startOfRestOfLine, endOfRestOfLine);
       // we need to ignore code and math blocks to prevent changing values in the display
-      if (restOfLine.includes(IgnoreTypes.math.placeholder) || restOfLine.includes(IgnoreTypes.code.placeholder)) {
+      if (restOfLine.match(mathPlaceHolderRegex) || restOfLine.match(codePlaceHolderRegex)) {
         currentIndex++;
         continue;
       }

--- a/src/rules/proper-ellipsis.ts
+++ b/src/rules/proper-ellipsis.ts
@@ -13,15 +13,14 @@ export default class ProperEllipsis extends RuleBuilder<ProperEllipsisOptions> {
       nameKey: 'rules.proper-ellipsis.name',
       descriptionKey: 'rules.proper-ellipsis.description',
       type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.image],
     });
   }
   get OptionsClass(): new () => ProperEllipsisOptions {
     return ProperEllipsisOptions;
   }
   apply(text: string, options: ProperEllipsisOptions): string {
-    return ignoreListOfTypes([IgnoreTypes.code, IgnoreTypes.math, IgnoreTypes.yaml, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.tag, IgnoreTypes.image], text, (text) => {
-      return text.replaceAll(ellipsisRegex, '…');
-    });
+    return text.replaceAll(ellipsisRegex, '…');
   }
   get exampleBuilders(): ExampleBuilder<ProperEllipsisOptions>[] {
     return [

--- a/src/rules/proper-ellipsis.ts
+++ b/src/rules/proper-ellipsis.ts
@@ -1,7 +1,7 @@
 import {Options, RuleType} from '../rules';
 import RuleBuilder, {ExampleBuilder, OptionBuilderBase} from './rule-builder';
 import dedent from 'ts-dedent';
-import {ignoreListOfTypes, IgnoreTypes} from '../utils/ignore-types';
+import {IgnoreTypes} from '../utils/ignore-types';
 import {ellipsisRegex} from '../utils/regex';
 
 class ProperEllipsisOptions implements Options {}

--- a/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
+++ b/src/rules/space-between-chinese-japanese-or-korean-and-english-or-numbers.ts
@@ -30,7 +30,7 @@ export default class SpaceBetweenChineseJapaneseOrKoreanAndEnglishOrNumbers exte
     const head = this.buildHeadRegex(options.englishNonLetterCharactersAfterCJKCharacters);
     const tail = this.buildTailRegex(options.englishNonLetterCharactersBeforeCJKCharacters);
     // inline math, inline code, markdown links, and wiki links are an exception in that even though they are to be ignored we want to keep a space around these types when surrounded by CJK characters
-    const regexEscapedIgnoreExceptionPlaceHolders = `${IgnoreTypes.link.placeholder}|${IgnoreTypes.inlineMath.placeholder}|${IgnoreTypes.inlineCode.placeholder}|${IgnoreTypes.wikiLink.placeholder}`.replaceAll('{', '\\{').replaceAll('}', '\\}');
+    const regexEscapedIgnoreExceptionPlaceHolders = `${IgnoreTypes.link.placeholder}|${IgnoreTypes.inlineMath.placeholder}|${IgnoreTypes.inlineCode.placeholder}|${IgnoreTypes.wikiLink.placeholder}`.replaceAll('{', '\\{').replaceAll('}', '.+\\}');
     const ignoreExceptionsHead = new RegExp(`(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})( *)(${regexEscapedIgnoreExceptionPlaceHolders})`, 'gmu');
     const ignoreExceptionsTail = new RegExp(`(${regexEscapedIgnoreExceptionPlaceHolders})( *)(\\p{sc=Han}|\\p{sc=Katakana}|\\p{sc=Hiragana}|\\p{sc=Hangul})`, 'gmu');
     const addSpaceAroundChineseJapaneseKoreanAndEnglish = function(text: string): string {

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -248,6 +248,7 @@ function getNewPlaceHolder(placeholder: string): string {
 
   // This is not a true uuid, but it gets the job done, so I will use this and avoid trying to figure out
   // how to use crypto with this logic here
+  // from https://gist.github.com/prashant1k99/e11b01a01dead835a1382a596d50e31d
   const uuid = Date.now().toString(36) + Math.random().toString(36).substring(2, 10);
   if (placeholder.endsWith('}')) {
     return placeholder.replace('}', uuid + '}');

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -3,7 +3,7 @@ import {getAllCustomIgnoreSectionsInText, getAllTablesInText, getPositions, MDAs
 import type {Position} from 'unist';
 import {replaceTextBetweenStartAndEndWithNewValue} from './strings';
 
-export type IgnoreFunction = ((text: string, placeholder: string) => [string[], string]);
+export type IgnoreFunction = ((text: string, placeholder: string) => [placeholderInfo[], string]);
 export type IgnoreType = {replaceAction: MDAstTypes | RegExp | IgnoreFunction, placeholder: string};
 
 export const IgnoreTypes: Record<string, IgnoreType> = {
@@ -36,22 +36,24 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
   customIgnore: {replaceAction: replaceCustomIgnore, placeholder: '{CUSTOM_IGNORE_PLACEHOLDER}'},
 } as const;
 
+type placeholderInfo = {placeholder: string, replacedValue: string}
+
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
-  let setOfPlaceholders: {placeholder: string, replacedValues: string[]}[] = [];
+  let setOfPlaceholders: placeholderInfo[] = [];
 
   // replace ignore blocks with their placeholders
-  let replaceValues: string[] = [];
+  let placeholders: placeholderInfo[] = [];
   for (const ignoreType of ignoreTypes) {
     if (typeof ignoreType.replaceAction === 'string') { // mdast
-      [replaceValues, text] = replaceMdastType(text, ignoreType.placeholder, ignoreType.replaceAction);
+      [placeholders, text] = replaceMdastType(text, ignoreType.placeholder, ignoreType.replaceAction);
     } else if (ignoreType.replaceAction instanceof RegExp) {
-      [replaceValues, text] = replaceRegex(text, ignoreType.placeholder, ignoreType.replaceAction);
+      [placeholders, text] = replaceRegex(text, ignoreType.placeholder, ignoreType.replaceAction);
     } else if (typeof ignoreType.replaceAction === 'function') {
       const ignoreFunc: IgnoreFunction = ignoreType.replaceAction;
-      [replaceValues, text] = ignoreFunc(text, ignoreType.placeholder);
+      [placeholders, text] = ignoreFunc(text, ignoreType.placeholder);
     }
 
-    setOfPlaceholders.push({replacedValues: replaceValues, placeholder: ignoreType.placeholder});
+    setOfPlaceholders.push(...placeholders);
   }
 
   text = func(text);
@@ -59,12 +61,10 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
   setOfPlaceholders = setOfPlaceholders.reverse();
   // add back values that were replaced with their placeholders
   if (setOfPlaceholders != null && setOfPlaceholders.length > 0) {
-    setOfPlaceholders.forEach((replacedInfo: {placeholder: string, replacedValues: string[], replaceDollarSigns: boolean}) => {
-      replacedInfo.replacedValues.forEach((replacedValue: string) => {
-        // Regex was added to fix capitalization issue  where another rule made the text not match the original place holder's case
-        // see https://github.com/platers/obsidian-linter/issues/201
-        text = text.replace(new RegExp(replacedInfo.placeholder, 'i'), escapeDollarSigns(replacedValue));
-      });
+    setOfPlaceholders.forEach((replacedInfo: placeholderInfo) => {
+      // Regex was added to fix capitalization issue  where another rule made the text not match the original place holder's case
+      // see https://github.com/platers/obsidian-linter/issues/201
+      text = text.replace(new RegExp(replacedInfo.placeholder, 'i'), escapeDollarSigns(replacedInfo.replacedValue));
     });
   }
 
@@ -77,11 +77,11 @@ export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func:
  * @param {string} placeholder The placeholder to use
  * @param {MDAstTypes} type The type of node to ignore by replacing with the specified placeholder
  * @return {string} The text with mdast nodes types specified replaced
- * @return {string[]} The mdast nodes values replaced
+ * @return {placeholderInfo[]} The mdast nodes values replaced and generated placeholder
  */
-function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): [string[], string] {
+function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): [placeholderInfo[], string] {
   let positions: Position[] = getPositions(type, text);
-  const replacedValues: string[] = [];
+  const replacedValues: placeholderInfo[] = [];
 
   if (type === MDAstTypes.List) {
     positions = removeOverlappingPositions(positions);
@@ -89,11 +89,12 @@ function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): 
 
   for (const position of positions) {
     const valueToReplace = text.substring(position.start.offset, position.end.offset);
-    replacedValues.push(valueToReplace);
+    replacedValues.push({placeholder: getNewPlaceHolder(placeholder), replacedValue: valueToReplace});
   }
 
+  let i = 0;
   for (const position of positions) {
-    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, placeholder);
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, replacedValues[i++].placeholder);
   }
 
   // Reverse the replaced values so that they are in the same order as the original text
@@ -108,25 +109,25 @@ function replaceMdastType(text: string, placeholder: string, type: MDAstTypes): 
  * @param {string} placeholder The placeholder to use
  * @param {RegExp} regex The regex to use to find what to replace with the placeholder
  * @return {string} The text with regex matches replaced
- * @return {string[]} The regex matches replaced
+ * @return {placeholderInfo[]} The regex matches replaced and generated placeholder
  */
-function replaceRegex(text: string, placeholder: string, regex: RegExp): [string[], string] {
-  const regexMatches = text.match(regex);
-  const textMatches: string[] = [];
+function replaceRegex(text: string, placeholder: string, regex: RegExp): [placeholderInfo[], string] {
+  const textMatches: placeholderInfo[] = [];
+
   if (regex.flags.includes('g')) {
-    text = text.replaceAll(regex, placeholder);
+    text = text.replaceAll(regex, (match: string) => {
+      const id = getNewPlaceHolder(placeholder);
+      textMatches.push({placeholder: id, replacedValue: match});
 
-    if (regexMatches) {
-      for (const matchText of regexMatches) {
-        textMatches.push(matchText);
-      }
-    }
+      return id;
+    });
   } else {
-    text = text.replace(regex, placeholder);
+    text = text.replace(regex, (match: string) => {
+      const id = getNewPlaceHolder(placeholder);
+      textMatches.push({placeholder: id, replacedValue: match});
 
-    if (regexMatches) {
-      textMatches.push(regexMatches[0]);
-    }
+      return id;
+    });
   }
 
   return [textMatches, text];
@@ -137,11 +138,11 @@ function replaceRegex(text: string, placeholder: string, regex: RegExp): [string
  * @param {string} text The text to replace links in
  * @param {string} regularLinkPlaceholder The placeholder to use for regular markdown links
  * @return {string} The text with links replaced
- * @return {string[]} The regular markdown links replaced
+ * @return {placeholderInfo[]} The regular markdown links replaced and generated placeholder
  */
-function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): [string[], string] {
+function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): [placeholderInfo[], string] {
   const positions: Position[] = getPositions(MDAstTypes.Link, text);
-  const replacedRegularLinks: string[] = [];
+  const replacedRegularLinks: placeholderInfo[] = [];
 
 
   const positionsToReplace: Position [] = [];
@@ -157,11 +158,12 @@ function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): [st
     }
 
     positionsToReplace.push(position);
-    replacedRegularLinks.push(regularLink);
+    replacedRegularLinks.push({placeholder: getNewPlaceHolder(regularLinkPlaceholder), replacedValue: regularLink});
   }
 
+  let i = 0;
   for (const position of positionsToReplace) {
-    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, regularLinkPlaceholder);
+    text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, replacedRegularLinks[i++].placeholder);
   }
 
   // Reverse the regular links so that they are in the same order as the original text
@@ -170,47 +172,51 @@ function replaceMarkdownLinks(text: string, regularLinkPlaceholder: string): [st
   return [replacedRegularLinks, text];
 }
 
-function replaceTags(text: string, placeholder: string): [string[], string] {
-  const replacedValues: string[] = [];
+function replaceTags(text: string, placeholder: string): [placeholderInfo[], string] {
+  const replacedValues: placeholderInfo[] = [];
 
   text = text.replace(tagWithLeadingWhitespaceRegex, (_, whitespace, tag) => {
-    replacedValues.push(tag);
-    return whitespace + placeholder;
+    const id = getNewPlaceHolder(placeholder);
+
+    replacedValues.push({placeholder: id, replacedValue: tag});
+    return whitespace + id;
   });
 
   return [replacedValues, text];
 }
 
-function replaceTables(text: string, tablePlaceholder: string): [string[], string] {
+function replaceTables(text: string, tablePlaceholder: string): [placeholderInfo[], string] {
   const tablePositions = getAllTablesInText(text);
 
-  const replacedTables: string[] = new Array(tablePositions.length);
+  const replacedTables: placeholderInfo[] = new Array(tablePositions.length);
   let index = 0;
   const length = replacedTables.length;
   for (const tablePosition of tablePositions) {
-    replacedTables[length - 1 - index++] = text.substring(tablePosition.startIndex, tablePosition.endIndex);
+    replacedTables[length - 1 - index++] = {placeholder: getNewPlaceHolder(tablePlaceholder), replacedValue: text.substring(tablePosition.startIndex, tablePosition.endIndex)};
   }
 
+  let i = length -1;
   for (const tablePosition of tablePositions) {
-    text = replaceTextBetweenStartAndEndWithNewValue(text, tablePosition.startIndex, tablePosition.endIndex, tablePlaceholder);
+    text = replaceTextBetweenStartAndEndWithNewValue(text, tablePosition.startIndex, tablePosition.endIndex, replacedTables[i--].placeholder);
   }
 
   return [replacedTables, text];
 }
 
 
-function replaceCustomIgnore(text: string, customIgnorePlaceholder: string): [string[], string] {
+function replaceCustomIgnore(text: string, customIgnorePlaceholder: string): [placeholderInfo[], string] {
   const customIgnorePositions = getAllCustomIgnoreSectionsInText(text);
 
-  const replacedSections: string[] = new Array(customIgnorePositions.length);
+  const replacedSections: placeholderInfo[] = new Array(customIgnorePositions.length);
   let index = 0;
   const length = replacedSections.length;
   for (const customIgnorePosition of customIgnorePositions) {
-    replacedSections[length - 1 - index++] = text.substring(customIgnorePosition.startIndex, customIgnorePosition.endIndex);
+    replacedSections[length - 1 - index++] = {placeholder: getNewPlaceHolder(customIgnorePlaceholder), replacedValue: text.substring(customIgnorePosition.startIndex, customIgnorePosition.endIndex)};
   }
 
+  let i = length - 1;
   for (const customIgnorePosition of customIgnorePositions) {
-    text = replaceTextBetweenStartAndEndWithNewValue(text, customIgnorePosition.startIndex, customIgnorePosition.endIndex, customIgnorePlaceholder);
+    text = replaceTextBetweenStartAndEndWithNewValue(text, customIgnorePosition.startIndex, customIgnorePosition.endIndex, replacedSections[i--].placeholder);
   }
 
   return [replacedSections, text];
@@ -233,4 +239,19 @@ function removeOverlappingPositions(positions: Position[]): Position[] {
   }
 
   return result;
+}
+
+function getNewPlaceHolder(placeholder: string): string {
+  if (placeholder.includes('---')) {
+    return placeholder;
+  }
+
+  // This is not a true uuid, but it gets the job done, so I will use this and avoid trying to figure out
+  // how to use crypto with this logic here
+  const uuid = Date.now().toString(36) + Math.random().toString(36).substring(2, 10);
+  if (placeholder.endsWith('}')) {
+    return placeholder.replace('}', uuid + '}');
+  }
+
+  return placeholder + uuid;
 }

--- a/src/utils/ignore-types.ts
+++ b/src/utils/ignore-types.ts
@@ -39,29 +39,29 @@ export const IgnoreTypes: Record<string, IgnoreType> = {
 type placeholderInfo = {placeholder: string, replacedValue: string}
 
 export function ignoreListOfTypes(ignoreTypes: IgnoreType[], text: string, func: ((text: string) => string)): string {
-  let setOfPlaceholders: placeholderInfo[] = [];
+  let placeholders: placeholderInfo[] = [];
 
   // replace ignore blocks with their placeholders
-  let placeholders: placeholderInfo[] = [];
+  let tempPlaceholders: placeholderInfo[] = [];
   for (const ignoreType of ignoreTypes) {
     if (typeof ignoreType.replaceAction === 'string') { // mdast
-      [placeholders, text] = replaceMdastType(text, ignoreType.placeholder, ignoreType.replaceAction);
+      [tempPlaceholders, text] = replaceMdastType(text, ignoreType.placeholder, ignoreType.replaceAction);
     } else if (ignoreType.replaceAction instanceof RegExp) {
-      [placeholders, text] = replaceRegex(text, ignoreType.placeholder, ignoreType.replaceAction);
+      [tempPlaceholders, text] = replaceRegex(text, ignoreType.placeholder, ignoreType.replaceAction);
     } else if (typeof ignoreType.replaceAction === 'function') {
       const ignoreFunc: IgnoreFunction = ignoreType.replaceAction;
-      [placeholders, text] = ignoreFunc(text, ignoreType.placeholder);
+      [tempPlaceholders, text] = ignoreFunc(text, ignoreType.placeholder);
     }
 
-    setOfPlaceholders.push(...placeholders);
+    placeholders.push(...tempPlaceholders);
   }
 
   text = func(text);
 
-  setOfPlaceholders = setOfPlaceholders.reverse();
+  placeholders = placeholders.reverse();
   // add back values that were replaced with their placeholders
-  if (setOfPlaceholders != null && setOfPlaceholders.length > 0) {
-    setOfPlaceholders.forEach((replacedInfo: placeholderInfo) => {
+  if (placeholders != null && placeholders.length > 0) {
+    placeholders.forEach((replacedInfo: placeholderInfo) => {
       // Regex was added to fix capitalization issue  where another rule made the text not match the original place holder's case
       // see https://github.com/platers/obsidian-linter/issues/201
       text = text.replace(new RegExp(replacedInfo.placeholder, 'i'), escapeDollarSigns(replacedInfo.replacedValue));


### PR DESCRIPTION
Relates to #1501 
Fixes #1439 

I decided to go ahead and tackle this logic and make it a bit simpler since it looked like it would be a hassle to do this in most other ways. This is passing UTs and seems to do the job.

Changes Made:
- Swapped from a static placeholder except for YAML and added a "UUID" which is a psuedo uuid
- Changed ignore types return type to match the 1 to 1 mapping instead of the 1 to many mapping we had before
- Added tests from #1501 here to make sure things worked
- Updated use of placeholders in rules for ignore purposes to make sure they properly were setup for regex matching
- Moved ignore types up in proper ellipses since it was an extra/redundant call to the ignore types logic
- Updated UTs to actually pass based on new format