### PR TITLE
FR #1359: add "Sentence per line" content rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Each rule is its own set of logic and is designed to be run independently. This 
 - [remove-empty-list-markers](https://platers.github.io/obsidian-linter/settings/content-rules/#remove-empty-list-markers)
 - [remove-hyphenated-line-breaks](https://platers.github.io/obsidian-linter/settings/content-rules/#remove-hyphenated-line-breaks)
 - [remove-multiple-spaces](https://platers.github.io/obsidian-linter/settings/content-rules/#remove-multiple-spaces)
+- [sentence-per-line](https://platers.github.io/obsidian-linter/settings/content-rules/#sentence-per-line)
 - [strong-style](https://platers.github.io/obsidian-linter/settings/content-rules/#strong-style)
 - [two-spaces-between-lines-with-content](https://platers.github.io/obsidian-linter/settings/content-rules/#line-break-between-lines-with-content)
 - [unordered-list-style](https://platers.github.io/obsidian-linter/settings/content-rules/#unordered-list-style)

--- a/__tests__/sentence-per-line.test.ts
+++ b/__tests__/sentence-per-line.test.ts
@@ -81,6 +81,28 @@ ruleTest({
       `,
     },
     {
+      testName: 'A URL autolink is opaque and a sentence can start with one',
+      before: dedent`
+        See this here. <https://example.com> is the source link.
+      `,
+      after: dedent`
+        See this here.
+        <https://example.com> is the source link.
+      `,
+    },
+    {
+      testName: 'A lone URL autolink line is a divider and is not merged into prose',
+      before: dedent`
+        <https://example.com>
+        Some text here. More text here.
+      `,
+      after: dedent`
+        <https://example.com>
+        Some text here.
+        More text here.
+      `,
+    },
+    {
       testName: 'M2: a "." inside an inline HTML attribute is opaque',
       before: dedent`
         Text <abbr title="e.g. foo. Bar">x</abbr>. Next sentence here.

--- a/__tests__/sentence-per-line.test.ts
+++ b/__tests__/sentence-per-line.test.ts
@@ -1,0 +1,302 @@
+import SentencePerLine from '../src/rules/sentence-per-line';
+import dedent from 'ts-dedent';
+import {ruleTest} from './common';
+
+ruleTest({
+  RuleBuilderClass: SentencePerLine,
+  testCases: [
+    {
+      testName: 'A basic multi-sentence paragraph is split one sentence per line',
+      before: dedent`
+        This is a sentence. This is another sentence. And a third one here.
+      `,
+      after: dedent`
+        This is a sentence.
+        This is another sentence.
+        And a third one here.
+      `,
+    },
+    {
+      testName: 'A soft-wrapped single sentence is reflowed onto one line',
+      before: dedent`
+        This sentence was
+        soft wrapped across
+        three source lines.
+      `,
+      after: dedent`
+        This sentence was soft wrapped across three source lines.
+      `,
+    },
+    {
+      testName: 'A sentence that starts with a link is split correctly',
+      before: dedent`
+        See the start. [The docs](https://example.com) explain it well.
+      `,
+      after: dedent`
+        See the start.
+        [The docs](https://example.com) explain it well.
+      `,
+    },
+    {
+      testName: 'B2: an initial before a link atom (default options) is not split',
+      before: dedent`
+        Edited by J. [the source](https://ex.com) and reviewed here.
+      `,
+      after: dedent`
+        Edited by J. [the source](https://ex.com) and reviewed here.
+      `,
+    },
+    {
+      testName: 'B3: a regex-metachar terminator inside a masked link never splits it',
+      before: dedent`
+        Go to [a](https://x.io/p?q=1.2) now. Stop here please.
+      `,
+      after: dedent`
+        Go to [a](https://x.io/p?q=1.2) now.
+        Stop here please.
+      `,
+      options: {
+        sentenceTerminators: '.?',
+        abbreviationList: [],
+      },
+    },
+    {
+      testName: 'Abbreviations, decimals, and versions are not split',
+      before: dedent`
+        The value is 3.14 per Dr. Smith using v1.2.3 here. It is e.g. quite useful.
+      `,
+      after: dedent`
+        The value is 3.14 per Dr. Smith using v1.2.3 here.
+        It is e.g. quite useful.
+      `,
+    },
+    {
+      testName: 'Links, wiki links, inline code, and bare URLs are never split inside',
+      before: dedent`
+        Use [[My Note]] and \`some.code.here\` and https://a.b/c.d often. Done now please.
+      `,
+      after: dedent`
+        Use [[My Note]] and \`some.code.here\` and https://a.b/c.d often.
+        Done now please.
+      `,
+    },
+    {
+      testName: 'M2: a "." inside an inline HTML attribute is opaque',
+      before: dedent`
+        Text <abbr title="e.g. foo. Bar">x</abbr>. Next sentence here.
+      `,
+      after: dedent`
+        Text <abbr title="e.g. foo. Bar">x</abbr>.
+        Next sentence here.
+      `,
+    },
+    {
+      testName: 'B4: CJK text splits with the CJK terminator set and no spaces',
+      before: dedent`
+        这是一句。这是另一句。
+      `,
+      after: dedent`
+        这是一句。
+        这是另一句。
+      `,
+      options: {
+        sentenceTerminators: '。！？',
+      },
+    },
+    {
+      testName: 'B1: a masked table directly adjacent to prose keeps the table and adjacency intact',
+      before: dedent`
+        | a | b |
+        | --- | --- |
+        | 1 | 2 |
+        Some text here. More text here.
+      `,
+      after: dedent`
+        | a | b |
+        | --- | --- |
+        | 1 | 2 |
+        Some text here.
+        More text here.
+      `,
+    },
+    {
+      testName: 'B1: an Obsidian comment block directly adjacent to prose is preserved',
+      before: dedent`
+        %%
+        a hidden comment
+        %%
+        Text one here. Text two here.
+      `,
+      after: dedent`
+        %%
+        a hidden comment
+        %%
+        Text one here.
+        Text two here.
+      `,
+    },
+    {
+      testName: 'B1: a custom-ignore block directly adjacent to prose is preserved',
+      before: dedent`
+        <!-- linter-disable -->
+        Do not touch this. Really do not.
+        <!-- linter-enable -->
+        Now reflow this. Yes please do.
+      `,
+      after: dedent`
+        <!-- linter-disable -->
+        Do not touch this. Really do not.
+        <!-- linter-enable -->
+        Now reflow this.
+        Yes please do.
+      `,
+    },
+    {
+      testName: 'Fenced code, lists, blockquotes, and setext headings are left untouched',
+      before: dedent`
+        First here. Second here.
+        ${''}
+        ${'```'}js
+        const a = 1. const b = 2.
+        ${'```'}
+        ${''}
+        - item one. still one.
+        - item two. still two.
+        ${''}
+        > Quote one. Quote two.
+        ${''}
+        Heading
+        =======
+        Body one here. Body two here.
+      `,
+      after: dedent`
+        First here.
+        Second here.
+        ${''}
+        ${'```'}js
+        const a = 1. const b = 2.
+        ${'```'}
+        ${''}
+        - item one. still one.
+        - item two. still two.
+        ${''}
+        > Quote one. Quote two.
+        ${''}
+        Heading
+        =======
+        Body one here.
+        Body two here.
+      `,
+    },
+    {
+      testName: 'A two-space hard break is preserved and not merged across',
+      before: 'Line one here.  \nLine two here. Line three here.',
+      after: 'Line one here.  \nLine two here.\nLine three here.',
+    },
+    {
+      testName: 'A <br> hard break is preserved and not merged across',
+      before: dedent`
+        Keep this here.<br>
+        Then split this. And this too.
+      `,
+      after: dedent`
+        Keep this here.<br>
+        Then split this.
+        And this too.
+      `,
+    },
+    {
+      testName: 'A backslash hard break is preserved and not merged across',
+      before: 'Hold this line.\\\nThen split here. And there too.',
+      after: 'Hold this line.\\\nThen split here.\nAnd there too.',
+    },
+    {
+      testName: 'Intra-sentence double spaces and NBSP round-trip (minimal join)',
+      before: 'Hello world here. Next  one  here is fine.',
+      after: 'Hello world here.\nNext  one  here is fine.',
+    },
+    {
+      testName: 'A trailing newline is preserved',
+      before: 'A first one. A second one.\n',
+      after: 'A first one.\nA second one.\n',
+    },
+    {
+      testName: 'No trailing newline stays without one',
+      before: 'A first one. A second one.',
+      after: 'A first one.\nA second one.',
+    },
+    {
+      testName: 'Empty sentence terminators make the rule a no-op',
+      before: dedent`
+        One sentence here. Two sentences here.
+        A soft wrapped
+        continuation line.
+      `,
+      after: dedent`
+        One sentence here. Two sentences here.
+        A soft wrapped
+        continuation line.
+      `,
+      options: {
+        sentenceTerminators: '',
+      },
+    },
+    {
+      testName: 'P1: a custom abbreviation list passed as an array suppresses a split',
+      before: dedent`
+        We are Acme Corp. We always win. The end here.
+      `,
+      after: dedent`
+        We are Acme Corp. We always win.
+        The end here.
+      `,
+      options: {
+        abbreviationList: ['corp.'],
+      },
+    },
+    {
+      testName: 'P1: without the custom abbreviation the same text does split',
+      before: dedent`
+        We are Acme Corp. We always win. The end here.
+      `,
+      after: dedent`
+        We are Acme Corp.
+        We always win.
+        The end here.
+      `,
+      options: {
+        abbreviationList: [],
+      },
+    },
+  ],
+});
+
+describe('Sentence per line idempotency', () => {
+  const rule = SentencePerLine.getRule();
+  const cases: {name: string, text: string, options?: {[k: string]: unknown}}[] = [
+    {name: 'basic paragraph', text: 'One here. Two here. Three here.'},
+    {
+      name: 'soft-wrapped multi line',
+      text: 'A sentence that\nwas soft wrapped. Another sentence here.',
+    },
+    {name: 'two-space hard break', text: 'Keep this.  \nSplit this. And this.'},
+    {name: '<br> hard break', text: 'Keep this.<br>\nSplit this. And this.'},
+    {
+      name: 'table adjacent to prose',
+      text: '| a | b |\n| --- | --- |\n| 1 | 2 |\nSome text. More text.',
+    },
+    {
+      name: 'starts with a link',
+      text: 'See the start. [docs](https://example.com) explain it well.',
+    },
+    {name: 'trailing newline', text: 'A first one. A second one.\n'},
+  ];
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const once = rule.apply(c.text, c.options);
+      const twice = rule.apply(once, c.options);
+      expect(twice).toBe(once);
+    });
+  }
+});

--- a/__tests__/sentence-splitting.test.ts
+++ b/__tests__/sentence-splitting.test.ts
@@ -1,0 +1,264 @@
+import {
+  splitIntoSentences,
+  DEFAULT_SENTENCE_TERMINATORS,
+  DEFAULT_ABBREVIATIONS,
+  UNAMBIGUOUS_TERMINATORS,
+} from '../src/utils/sentence-splitting';
+
+const T = DEFAULT_SENTENCE_TERMINATORS;
+const A = DEFAULT_ABBREVIATIONS;
+
+// A realistic regular-link placeholder (matches getNewPlaceHolder output shape).
+const LINK = '{REGULAR_LINK_PLACEHOLDER' + 'lk3n9q1z' + '}';
+const CODE = '{INLINE_CODE_BLOCK_PLACEHOLDER' + 'c0d3z9a1' + '}';
+const TAG = '#tag-placeholder' + 'tg7h2k1p';
+
+describe('splitIntoSentences', () => {
+  describe('basic behavior', () => {
+    it('splits a simple multi-sentence string', () => {
+      expect(splitIntoSentences('Hello world. Goodbye now.', T, A)).toEqual([
+        'Hello world.',
+        'Goodbye now.',
+      ]);
+    });
+
+    it('leaves a single sentence untouched', () => {
+      expect(splitIntoSentences('Just one sentence.', T, A)).toEqual([
+        'Just one sentence.',
+      ]);
+    });
+
+    it('splits on ? and !', () => {
+      expect(splitIntoSentences('Really? Yes! Done.', T, A)).toEqual([
+        'Really?',
+        'Yes!',
+        'Done.',
+      ]);
+    });
+
+    it('idempotent shape: re-splitting joined output is stable', () => {
+      const once = splitIntoSentences('A first one. A second one.', T, A);
+      const logical = once.join(' ');
+      expect(splitIntoSentences(logical, T, A)).toEqual(once);
+    });
+  });
+
+  describe('atom opacity (invariant 1 / B2 / B3 / M2)', () => {
+    it('treats a sentence that starts with a link atom as a valid start', () => {
+      expect(
+          splitIntoSentences(`This ends. ${LINK} starts it.`, T, A),
+      ).toEqual(['This ends.', `${LINK} starts it.`]);
+    });
+
+    it('B2: initial before a link atom (default options) does not split', () => {
+      expect(
+          splitIntoSentences(`Edited by J. ${LINK} here.`, T, A),
+      ).toEqual([`Edited by J. ${LINK} here.`]);
+    });
+
+    it('B3: custom terminators that occur inside a placeholder never split it', () => {
+      expect(
+          splitIntoSentences(`See ${CODE} now. Done.`, '.0_', []),
+      ).toEqual([`See ${CODE} now.`, 'Done.']);
+    });
+
+    it('B3: a custom "-" terminator does not split inside a tag placeholder', () => {
+      expect(splitIntoSentences(`A ${TAG} Z`, '-', [])).toEqual([
+        `A ${TAG} Z`,
+      ]);
+    });
+
+    it('B3: regex-metachar terminators are literal and do not crash', () => {
+      expect(splitIntoSentences('a [x] b', ']', [])).toEqual(['a [x] b']);
+      expect(splitIntoSentences('a{b}c', '{}', [])).toEqual(['a{b}c']);
+      expect(splitIntoSentences('back\\slash here', '\\', [])).toEqual([
+        'back\\slash here',
+      ]);
+    });
+
+    it('M2: a `.` inside an inline HTML attribute is opaque', () => {
+      expect(
+          splitIntoSentences(
+              'Text <abbr title="e.g. foo. Bar">x</abbr>. Next.',
+              T,
+              A,
+          ),
+      ).toEqual(['Text <abbr title="e.g. foo. Bar">x</abbr>.', 'Next.']);
+    });
+
+    it('M2: a mid-line <br> is an opaque atom, not a forced split', () => {
+      expect(splitIntoSentences('foo <br> bar baz', T, [])).toEqual([
+        'foo <br> bar baz',
+      ]);
+    });
+
+    it('M2: an HTML comment is opaque', () => {
+      expect(
+          splitIntoSentences('Keep <!-- e.g. a. b. --> together. Done.', T, A),
+      ).toEqual(['Keep <!-- e.g. a. b. --> together.', 'Done.']);
+    });
+  });
+
+  describe('whitespace gate by terminator class (B4)', () => {
+    it('B4: CJK terminators split with no following whitespace', () => {
+      expect(splitIntoSentences('这是一句。这是另一句。', '。！？', [])).toEqual([
+        '这是一句。',
+        '这是另一句。',
+      ]);
+    });
+
+    it('B4: half-width "." directly before CJK is not split (accepted)', () => {
+      expect(splitIntoSentences('句子.句子', '.', [])).toEqual(['句子.句子']);
+    });
+
+    it('ambiguous "." with no following whitespace does not split', () => {
+      expect(splitIntoSentences('3.14 is pi', '.', [])).toEqual(['3.14 is pi']);
+    });
+
+    it('UNAMBIGUOUS_TERMINATORS contains the CJK/full-width marks', () => {
+      for (const ch of '。！？') {
+        expect(UNAMBIGUOUS_TERMINATORS.includes(ch)).toBe(true);
+      }
+    });
+  });
+
+  describe('suppression guards', () => {
+    it('abbreviations including multi-dot are not split internally', () => {
+      expect(
+          splitIntoSentences(
+              'We use e.g. apples and i.e. oranges. Done.',
+              T,
+              A,
+          ),
+      ).toEqual(['We use e.g. apples and i.e. oranges.', 'Done.']);
+    });
+
+    it('a.m./p.m. and U.S. abbreviations suppress', () => {
+      expect(
+          splitIntoSentences('Meet at 9 a.m. in the U.S. office today.', T, A),
+      ).toEqual(['Meet at 9 a.m. in the U.S. office today.']);
+    });
+
+    it('single-letter initials are not split', () => {
+      expect(
+          splitIntoSentences('J. R. R. Tolkien wrote books.', T, A),
+      ).toEqual(['J. R. R. Tolkien wrote books.']);
+    });
+
+    it('M5: U.S.A. advances correctly and splits at the true end', () => {
+      expect(
+          splitIntoSentences('I love the U.S.A. It rocks.', T, A),
+      ).toEqual(['I love the U.S.A.', 'It rocks.']);
+    });
+
+    it('decimals and versions are not split', () => {
+      expect(
+          splitIntoSentences('Pi is 3.14 and v1.2.3 is old. Yes.', T, A),
+      ).toEqual(['Pi is 3.14 and v1.2.3 is old.', 'Yes.']);
+    });
+
+    it('M5: a long run of dots does not hang or crash', () => {
+      expect(splitIntoSentences('....', T, [])).toEqual(['....']);
+      expect(splitIntoSentences('Wait.... Done.', T, [])).toEqual([
+        'Wait....',
+        'Done.',
+      ]);
+    });
+  });
+
+  describe('trailing closers (M8)', () => {
+    it('boundary lands after a closing quote', () => {
+      expect(
+          splitIntoSentences('He said "Go." Then left.', T, A),
+      ).toEqual(['He said "Go."', 'Then left.']);
+    });
+
+    it('M8: inline footnote ref is a trailing closer', () => {
+      expect(
+          splitIntoSentences('See the end.[^1] Next part.', T, A),
+      ).toEqual(['See the end.[^1]', 'Next part.']);
+    });
+
+    it('M8: a raw reference link splits after the bracket', () => {
+      expect(
+          splitIntoSentences('See [the doc][d]. Next.', T, A),
+      ).toEqual(['See [the doc][d].', 'Next.']);
+    });
+
+    it('M8: "]" configured as a terminator does not split inside [x]', () => {
+      expect(splitIntoSentences('a [x] b', ']', [])).toEqual(['a [x] b']);
+    });
+  });
+
+  describe('ellipsis', () => {
+    it('the … glyph splits before an uppercase start', () => {
+      expect(splitIntoSentences('Wait… Really?', T, A)).toEqual([
+        'Wait…',
+        'Really?',
+      ]);
+    });
+
+    it('the … glyph does not split before a lowercase word', () => {
+      expect(splitIntoSentences('Hmm… and then more', T, A)).toEqual([
+        'Hmm… and then more',
+      ]);
+    });
+  });
+
+  describe('next-start classification (accepted imprecision)', () => {
+    it('a lowercase-starting next sentence is not split (accepted)', () => {
+      expect(
+          splitIntoSentences('Buy it now. iOS rocks here.', T, A),
+      ).toEqual(['Buy it now. iOS rocks here.']);
+    });
+
+    it('M7: a lone capital genuinely ending a sentence is not split (accepted)', () => {
+      expect(
+          splitIntoSentences('Choose plan B. Then pay now.', T, A),
+      ).toEqual(['Choose plan B. Then pay now.']);
+    });
+
+    it('an abbreviation that genuinely ends a sentence is not split (accepted)', () => {
+      expect(
+          splitIntoSentences('I work at Foo Inc. We are great here.', T, A),
+      ).toEqual(['I work at Foo Inc. We are great here.']);
+    });
+
+    it('next start behind an opening quote is recognized', () => {
+      expect(
+          splitIntoSentences('He left. "Yes," she said.', T, A),
+      ).toEqual(['He left.', '"Yes," she said.']);
+    });
+  });
+
+  describe('option handling', () => {
+    it('empty terminators makes the splitter a no-op', () => {
+      expect(splitIntoSentences('A. B. C.', '', A)).toEqual(['A. B. C.']);
+      expect(splitIntoSentences('A. B. C.', '   ', A)).toEqual(['A. B. C.']);
+    });
+
+    it('custom terminators replace the default set', () => {
+      expect(splitIntoSentences('One; Two; Three', ';', [])).toEqual([
+        'One;',
+        'Two;',
+        'Three',
+      ]);
+    });
+
+    it('a custom abbreviation suppresses a split', () => {
+      expect(
+          splitIntoSentences('Send to addr. Now please.', '.', ['addr.']),
+      ).toEqual(['Send to addr. Now please.']);
+      expect(
+          splitIntoSentences('Send to addr. Now please.', '.', []),
+      ).toEqual(['Send to addr.', 'Now please.']);
+    });
+
+    it('DEFAULT_ABBREVIATIONS is a non-empty string array', () => {
+      expect(Array.isArray(DEFAULT_ABBREVIATIONS)).toBe(true);
+      expect(DEFAULT_ABBREVIATIONS.length).toBeGreaterThan(0);
+      expect(DEFAULT_ABBREVIATIONS).toContain('e.g.');
+      expect(DEFAULT_ABBREVIATIONS).toContain('U.S.');
+    });
+  });
+});

--- a/__tests__/sentence-splitting.test.ts
+++ b/__tests__/sentence-splitting.test.ts
@@ -97,6 +97,25 @@ describe('splitIntoSentences', () => {
           splitIntoSentences('Keep <!-- e.g. a. b. --> together. Done.', T, A),
       ).toEqual(['Keep <!-- e.g. a. b. --> together.', 'Done.']);
     });
+
+    it('an angle-bracket-wrapped URL placeholder is one opaque atom', () => {
+      const AUTOLINK = `<${'{URL_PLACEHOLDER' + 'u9r1l2k3' + '}'}>`;
+      expect(
+          splitIntoSentences(`Before. ${AUTOLINK} starts here.`, T, A),
+      ).toEqual(['Before.', `${AUTOLINK} starts here.`]);
+    });
+
+    it('a raw URL autolink is one opaque atom', () => {
+      expect(
+          splitIntoSentences('See this. <https://example.com> is it.', T, A),
+      ).toEqual(['See this.', '<https://example.com> is it.']);
+    });
+
+    it('an email autolink is one opaque atom', () => {
+      expect(
+          splitIntoSentences('Email me. <foo@bar.com> works fine.', T, A),
+      ).toEqual(['Email me.', '<foo@bar.com> works fine.']);
+    });
   });
 
   describe('whitespace gate by terminator class (B4)', () => {
@@ -252,6 +271,16 @@ describe('splitIntoSentences', () => {
       expect(
           splitIntoSentences('Send to addr. Now please.', '.', []),
       ).toEqual(['Send to addr.', 'Now please.']);
+    });
+
+    it('astral (multi-code-unit) terminators are ignored, not silently broken', () => {
+      // an emoji terminator never matches; the rule degrades to a no-op rather
+      // than accepting-but-never-splitting on it
+      expect(splitIntoSentences('A😀 B😀 C', '😀', [])).toEqual(['A😀 B😀 C']);
+      // a BMP terminator alongside it still works; the emoji is plain text
+      expect(
+          splitIntoSentences('End😀 here. More here😀 done.', '.😀', []),
+      ).toEqual(['End😀 here.', 'More here😀 done.']);
     });
 
     it('DEFAULT_ABBREVIATIONS is a non-empty string array', () => {

--- a/docs/additional-info/rules/sentence-per-line.md
+++ b/docs/additional-info/rules/sentence-per-line.md
@@ -49,6 +49,10 @@ favor precision (not splitting where it would be wrong) over recall:
   is therefore **not** reflowed (a no-op, matching how other content rules
   treat HTML blocks).
 
+- Sentence terminators must be single Basic-Multilingual-Plane code points.
+  An astral character such as an emoji is ignored (it cannot reliably be
+  matched a code unit at a time), so it never acts as a terminator.
+
 The sentence terminators and the abbreviation list are both configurable to
 tune this behavior. Leaving the terminators empty makes the rule a no-op.
 

--- a/docs/additional-info/rules/sentence-per-line.md
+++ b/docs/additional-info/rules/sentence-per-line.md
@@ -1,0 +1,74 @@
+#### Rendering: Obsidian "Strict line breaks"
+
+This rule writes one sentence per source line. Under standard Markdown (and
+under Obsidian with **Settings → Editor → Strict line breaks** turned **on**) a
+single newline is treated as a space, so the rendered output is **unchanged** —
+only the diff-friendliness of the source improves.
+
+**Obsidian's "Strict line breaks" setting is off by default.** With it off,
+Obsidian renders a single newline as a visible line break, so this rule **will**
+change reading-view rendering (each sentence appears on its own visual line).
+Enable this rule only if you use "Strict line breaks", or a standard-Markdown
+renderer (GitHub/GitLab, Pandoc, Hugo, etc.). This is the single most important
+thing to know before turning the rule on.
+
+#### Scope
+
+Only top-level paragraphs are reflowed. Headings, lists, blockquotes, tables,
+fenced/indented code, math blocks, HTML blocks, footnote definitions, and YAML
+frontmatter are left untouched. Reflowing prose nested inside list items and
+blockquotes is intentionally out of scope for now.
+
+A line whose content is exactly one masked construct (a table, an Obsidian
+`%%…%%` comment, a custom-ignore block, or a lone link/embed) acts as a
+structural divider: it is emitted verbatim and the blank-or-not spacing on
+either side of it is preserved exactly. Adding blank lines around blocks is the
+job of *Paragraph blank lines*, not this rule; this rule only avoids corrupting
+that adjacency.
+
+#### Accepted heuristic limitations
+
+Sentence detection is a heuristic. The following are deliberate trade-offs that
+favor precision (not splitting where it would be wrong) over recall:
+
+- A sentence that genuinely starts with a lowercase word or a digit
+  (`iOS is great.`) is **not** split — the following word looks like a
+  continuation.
+- A single capital letter that genuinely ends a sentence before another capital
+  (`Choose plan B. Then pay.`) is **not** split — it is indistinguishable from
+  an initial such as `J. R. R. Tolkien`.
+- An abbreviation that genuinely ends a sentence (`… at Foo Inc. We won.`) is
+  **not** split.
+- A half-width `.` placed directly before CJK text with no space
+  (`句子.句子`) is **not** split — CJK authors should use the full-width `。`
+  (which splits without requiring a space).
+- A mid-line `<br>`/`<br/>` is treated as opaque inline content and does not
+  force a split (only a *line-final* hard break is honored).
+- Prose glued to the line immediately after a closing HTML block tag (no blank
+  line after `</div>`) is absorbed into the HTML block by Markdown itself and
+  is therefore **not** reflowed (a no-op, matching how other content rules
+  treat HTML blocks).
+
+The sentence terminators and the abbreviation list are both configurable to
+tune this behavior. Leaving the terminators empty makes the rule a no-op.
+
+#### Interaction with other rules
+
+- **Line break between lines with content** (`two-spaces-between-lines-with-content`):
+  using both is contradictory — it would add a hard-break indicator to every
+  per-sentence line, turning each sentence into a *rendered* line break and
+  defeating the purpose of this rule. Enabling one while the other is on prompts
+  you to disable the conflicting rule, and if both are enabled via
+  `data.json`/sync, *Line break between lines with content* is automatically
+  disabled on the next settings load (with a notice).
+- **Trailing spaces**: this rule preserves an author hard break by re-emitting
+  its exact indicator. Whether that indicator survives a *full* lint run depends
+  on *Trailing spaces*, which runs afterward:
+  - `<br>`, `<br/>`, and `\` always survive.
+  - Exactly two trailing spaces survive **only** if *Trailing spaces* has its
+    "Two space linebreak" option enabled.
+  - A one-space, three-or-more-space, or any tab-containing trailing run is
+    **not** preserved (it is stripped by *Trailing spaces*).
+
+  For a hard break that survives a full lint run, author it as `<br>`, `<br/>`,
+  `\`, or as exactly two trailing spaces with "Two space linebreak" enabled.

--- a/docs/docs/settings/content-rules.md
+++ b/docs/docs/settings/content-rules.md
@@ -1214,6 +1214,164 @@ Lorem ipsum dolor sit amet.
 ``````
 </details>
 
+## Sentence per line
+
+Alias: `sentence-per-line`
+
+Splits paragraph text so each sentence is on its own line, making line-based diffs localized to the edited sentence. With standard Markdown or Obsidian's <i>Strict line breaks</i> setting <b>on</b>, rendered output is unchanged; with Strict line breaks <b>off</b> (Obsidian's default) each sentence renders on its own line. Headings, lists, blockquotes, tables, code, math, and HTML blocks are left untouched. This is a heuristic; known limitations are listed in the <a href="https://platers.github.io/obsidian-linter/settings/content-rules/#sentence-per-line">rule docs</a>.
+
+### Options
+
+| Name | Description | List Items | Default Value |
+| ---- | ----------- | ---------- | ------------- |
+| `Sentence terminators` | The characters that end a sentence. Non-ASCII marks (such as the CJK/full-width <code>。！？</code>) split even without a following space; ASCII <code>.?!</code> require a following space or end of line. Leave empty to make this rule a no-op. | N/A | `.?!…。！？` |
+| `Abbreviations` | A newline-separated list of abbreviations (including their trailing period, e.g. <code>e.g.</code>, <code>U.S.</code>) that should not be treated as the end of a sentence. | N/A | `e.g.
+i.e.
+etc.
+vs.
+cf.
+al.
+Mr.
+Mrs.
+Ms.
+Dr.
+Prof.
+Sr.
+Jr.
+Inc.
+Ltd.
+Co.
+U.S.
+a.m.
+p.m.` |
+
+### Additional Info
+
+
+#### Rendering: Obsidian "Strict line breaks"
+
+This rule writes one sentence per source line. Under standard Markdown (and
+under Obsidian with **Settings → Editor → Strict line breaks** turned **on**) a
+single newline is treated as a space, so the rendered output is **unchanged** —
+only the diff-friendliness of the source improves.
+
+**Obsidian's "Strict line breaks" setting is off by default.** With it off,
+Obsidian renders a single newline as a visible line break, so this rule **will**
+change reading-view rendering (each sentence appears on its own visual line).
+Enable this rule only if you use "Strict line breaks", or a standard-Markdown
+renderer (GitHub/GitLab, Pandoc, Hugo, etc.). This is the single most important
+thing to know before turning the rule on.
+
+#### Scope
+
+Only top-level paragraphs are reflowed. Headings, lists, blockquotes, tables,
+fenced/indented code, math blocks, HTML blocks, footnote definitions, and YAML
+frontmatter are left untouched. Reflowing prose nested inside list items and
+blockquotes is intentionally out of scope for now.
+
+A line whose content is exactly one masked construct (a table, an Obsidian
+`%%…%%` comment, a custom-ignore block, or a lone link/embed) acts as a
+structural divider: it is emitted verbatim and the blank-or-not spacing on
+either side of it is preserved exactly. Adding blank lines around blocks is the
+job of *Paragraph blank lines*, not this rule; this rule only avoids corrupting
+that adjacency.
+
+#### Accepted heuristic limitations
+
+Sentence detection is a heuristic. The following are deliberate trade-offs that
+favor precision (not splitting where it would be wrong) over recall:
+
+- A sentence that genuinely starts with a lowercase word or a digit
+  (`iOS is great.`) is **not** split — the following word looks like a
+  continuation.
+- A single capital letter that genuinely ends a sentence before another capital
+  (`Choose plan B. Then pay.`) is **not** split — it is indistinguishable from
+  an initial such as `J. R. R. Tolkien`.
+- An abbreviation that genuinely ends a sentence (`… at Foo Inc. We won.`) is
+  **not** split.
+- A half-width `.` placed directly before CJK text with no space
+  (`句子.句子`) is **not** split — CJK authors should use the full-width `。`
+  (which splits without requiring a space).
+- A mid-line `<br>`/`<br/>` is treated as opaque inline content and does not
+  force a split (only a *line-final* hard break is honored).
+- Prose glued to the line immediately after a closing HTML block tag (no blank
+  line after `</div>`) is absorbed into the HTML block by Markdown itself and
+  is therefore **not** reflowed (a no-op, matching how other content rules
+  treat HTML blocks).
+
+The sentence terminators and the abbreviation list are both configurable to
+tune this behavior. Leaving the terminators empty makes the rule a no-op.
+
+#### Interaction with other rules
+
+- **Line break between lines with content** (`two-spaces-between-lines-with-content`):
+  using both is contradictory — it would add a hard-break indicator to every
+  per-sentence line, turning each sentence into a *rendered* line break and
+  defeating the purpose of this rule. Enabling one while the other is on prompts
+  you to disable the conflicting rule, and if both are enabled via
+  `data.json`/sync, *Line break between lines with content* is automatically
+  disabled on the next settings load (with a notice).
+- **Trailing spaces**: this rule preserves an author hard break by re-emitting
+  its exact indicator. Whether that indicator survives a *full* lint run depends
+  on *Trailing spaces*, which runs afterward:
+  - `<br>`, `<br/>`, and `\` always survive.
+  - Exactly two trailing spaces survive **only** if *Trailing spaces* has its
+    "Two space linebreak" option enabled.
+  - A one-space, three-or-more-space, or any tab-containing trailing run is
+    **not** preserved (it is stripped by *Trailing spaces*).
+
+  For a hard break that survives a full lint run, author it as `<br>`, `<br/>`,
+  `\`, or as exactly two trailing spaces with "Two space linebreak" enabled.
+
+
+### Examples
+
+<details><summary>Each sentence in a paragraph is put on its own line</summary>
+
+Before:
+
+`````` markdown
+This is a sentence. This is another sentence.
+``````
+
+After:
+
+`````` markdown
+This is a sentence.
+This is another sentence.
+``````
+</details>
+<details><summary>Abbreviations, decimals, and initials are not treated as the end of a sentence</summary>
+
+Before:
+
+`````` markdown
+The value is 3.14 according to Dr. Smith. It is e.g. quite useful.
+``````
+
+After:
+
+`````` markdown
+The value is 3.14 according to Dr. Smith.
+It is e.g. quite useful.
+``````
+</details>
+<details><summary>A sentence that starts with a link is still split correctly</summary>
+
+Before:
+
+`````` markdown
+See the start. [The docs](https://example.com) explain it.
+``````
+
+After:
+
+`````` markdown
+See the start.
+[The docs](https://example.com) explain it.
+``````
+</details>
+
 ## Strong style
 
 Alias: `strong-style`

--- a/docs/docs/settings/content-rules.md
+++ b/docs/docs/settings/content-rules.md
@@ -1299,6 +1299,10 @@ favor precision (not splitting where it would be wrong) over recall:
   is therefore **not** reflowed (a no-op, matching how other content rules
   treat HTML blocks).
 
+- Sentence terminators must be single Basic-Multilingual-Plane code points.
+  An astral character such as an emoji is ignored (it cannot reliably be
+  matched a code unit at a time), so it never acts as a terminator.
+
 The sentence terminators and the abbreviation list are both configurable to
 tune this behavior. Leaving the terminators empty makes the rule a no-op.
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -755,6 +755,19 @@ export default {
         'description': 'The YAML keys to remove from the YAML frontmatter with or without colons',
       },
     },
+    // sentence-per-line.ts
+    'sentence-per-line': {
+      'name': 'Sentence per line',
+      'description': 'Splits paragraph text so each sentence is on its own line, making line-based diffs localized to the edited sentence. With standard Markdown or Obsidian\'s <i>Strict line breaks</i> setting <b>on</b>, rendered output is unchanged; with Strict line breaks <b>off</b> (Obsidian\'s default) each sentence renders on its own line. Headings, lists, blockquotes, tables, code, math, and HTML blocks are left untouched. This is a heuristic; known limitations are listed in the <a href="https://platers.github.io/obsidian-linter/settings/content-rules/#sentence-per-line">rule docs</a>.',
+      'sentence-terminators': {
+        'name': 'Sentence terminators',
+        'description': 'The characters that end a sentence. Non-ASCII marks (such as the CJK/full-width <code>。！？</code>) split even without a following space; ASCII <code>.?!</code> require a following space or end of line. Leave empty to make this rule a no-op.',
+      },
+      'abbreviations': {
+        'name': 'Abbreviations',
+        'description': 'A newline-separated list of abbreviations (including their trailing period, e.g. <code>e.g.</code>, <code>U.S.</code>) that should not be treated as the end of a sentence.',
+      },
+    },
     // sort-yaml-array-values.ts
     'sort-yaml-array-values': {
       'name': 'Sort YAML array values',

--- a/src/main.ts
+++ b/src/main.ts
@@ -703,6 +703,20 @@ export default class LinterPlugin extends Plugin {
       noticeText += '\n' + getTextInLanguage('disabled-conflicting-rule-notice').replace('{NAME_1}', getTextInLanguage('rules.paragraph-blank-lines.name')).replace('{NAME_2}', getTextInLanguage('rules.two-spaces-between-lines-with-content.name'));
     }
 
+    if (this.settings.ruleConfigs['sentence-per-line'] && this.settings.ruleConfigs['sentence-per-line'].enabled &&
+      this.settings.ruleConfigs['two-spaces-between-lines-with-content'] && this.settings.ruleConfigs['two-spaces-between-lines-with-content'].enabled
+    ) {
+      this.settings.ruleConfigs['two-spaces-between-lines-with-content'].enabled = false;
+      updateMade = true;
+
+      if (conflictingRulePresent) {
+        noticeText += '\n';
+      }
+      conflictingRulePresent = true;
+
+      noticeText += '\n' + getTextInLanguage('disabled-conflicting-rule-notice').replace('{NAME_1}', getTextInLanguage('rules.two-spaces-between-lines-with-content.name')).replace('{NAME_2}', getTextInLanguage('rules.sentence-per-line.name'));
+    }
+
     if (conflictingRulePresent) {
       new Notice(noticeText, userClickTimeout);
     }

--- a/src/rules/sentence-per-line.ts
+++ b/src/rules/sentence-per-line.ts
@@ -1,0 +1,100 @@
+import {Options, rulesDict, RuleType} from '../rules';
+import RuleBuilder, {ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder, TextOptionBuilder} from './rule-builder';
+import dedent from 'ts-dedent';
+import {IgnoreTypes} from '../utils/ignore-types';
+import {reflowParagraphsOneSentencePerLine} from '../utils/mdast';
+import {DEFAULT_ABBREVIATIONS, DEFAULT_SENTENCE_TERMINATORS} from '../utils/sentence-splitting';
+import {BooleanOption} from '../option';
+import {ConfirmRuleDisableModal} from '../ui/modals/confirm-rule-disable-modal';
+import {App} from 'obsidian';
+
+class SentencePerLineOptions implements Options {
+  sentenceTerminators?: string = DEFAULT_SENTENCE_TERMINATORS;
+  abbreviationList?: string[] = [...DEFAULT_ABBREVIATIONS];
+}
+
+@RuleBuilder.register
+export default class SentencePerLine extends RuleBuilder<SentencePerLineOptions> {
+  constructor() {
+    super({
+      nameKey: 'rules.sentence-per-line.name',
+      descriptionKey: 'rules.sentence-per-line.description',
+      type: RuleType.CONTENT,
+      ruleIgnoreTypes: [IgnoreTypes.inlineCode, IgnoreTypes.inlineMath, IgnoreTypes.link, IgnoreTypes.wikiLink, IgnoreTypes.image, IgnoreTypes.url, IgnoreTypes.anchorTag, IgnoreTypes.tag, IgnoreTypes.yaml, IgnoreTypes.table, IgnoreTypes.obsidianMultiLineComments],
+      disableConflictingOptions(value: boolean, app: App): void {
+        const twoSpacesEnableOption = rulesDict['two-spaces-between-lines-with-content'].options[0] as BooleanOption;
+        if (value && twoSpacesEnableOption.getValue()) {
+          new ConfirmRuleDisableModal(app, 'rules.two-spaces-between-lines-with-content.name', 'rules.sentence-per-line.name', () => {
+            twoSpacesEnableOption.setValue(false);
+          },
+          () => {
+            (rulesDict['sentence-per-line'].options[0] as BooleanOption).setValue(false);
+          }).open();
+        }
+      },
+    });
+  }
+  get OptionsClass(): new () => SentencePerLineOptions {
+    return SentencePerLineOptions;
+  }
+  apply(text: string, options: SentencePerLineOptions): string {
+    const terminators = options.sentenceTerminators ?? '';
+    // an empty/blank terminator set makes the rule a no-op (never collapse soft
+    // wraps, never throw, never match-everything)
+    if (terminators.trim() === '') {
+      return text;
+    }
+
+    return reflowParagraphsOneSentencePerLine(text, terminators, options.abbreviationList ?? []);
+  }
+  get exampleBuilders(): ExampleBuilder<SentencePerLineOptions>[] {
+    return [
+      new ExampleBuilder({
+        description: 'Each sentence in a paragraph is put on its own line',
+        before: dedent`
+          This is a sentence. This is another sentence.
+        `,
+        after: dedent`
+          This is a sentence.
+          This is another sentence.
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'Abbreviations, decimals, and initials are not treated as the end of a sentence',
+        before: dedent`
+          The value is 3.14 according to Dr. Smith. It is e.g. quite useful.
+        `,
+        after: dedent`
+          The value is 3.14 according to Dr. Smith.
+          It is e.g. quite useful.
+        `,
+      }),
+      new ExampleBuilder({
+        description: 'A sentence that starts with a link is still split correctly',
+        before: dedent`
+          See the start. [The docs](https://example.com) explain it.
+        `,
+        after: dedent`
+          See the start.
+          [The docs](https://example.com) explain it.
+        `,
+      }),
+    ];
+  }
+  get optionBuilders(): OptionBuilderBase<SentencePerLineOptions>[] {
+    return [
+      new TextOptionBuilder({
+        OptionsClass: SentencePerLineOptions,
+        nameKey: 'rules.sentence-per-line.sentence-terminators.name',
+        descriptionKey: 'rules.sentence-per-line.sentence-terminators.description',
+        optionsKey: 'sentenceTerminators',
+      }),
+      new TextAreaOptionBuilder({
+        OptionsClass: SentencePerLineOptions,
+        nameKey: 'rules.sentence-per-line.abbreviations.name',
+        descriptionKey: 'rules.sentence-per-line.abbreviations.description',
+        optionsKey: 'abbreviationList',
+      }),
+    ];
+  }
+}

--- a/src/rules/two-spaces-between-lines-with-content.ts
+++ b/src/rules/two-spaces-between-lines-with-content.ts
@@ -21,9 +21,17 @@ export default class TwoSpacesBetweenLinesWithContent extends RuleBuilder<TwoSpa
       ruleIgnoreTypes: [IgnoreTypes.obsidianMultiLineComments, IgnoreTypes.yaml, IgnoreTypes.table],
       disableConflictingOptions(value: boolean, app: App): void {
         const paragraphBlankLinesEnableOption = rulesDict['paragraph-blank-lines'].options[0] as BooleanOption;
+        const sentencePerLineEnableOption = rulesDict['sentence-per-line'].options[0] as BooleanOption;
         if (value && paragraphBlankLinesEnableOption.getValue()) {
           new ConfirmRuleDisableModal(app, 'rules.paragraph-blank-lines.name', 'rules.two-spaces-between-lines-with-content.name', () => {
             paragraphBlankLinesEnableOption.setValue(false);
+          },
+          () => {
+            (rulesDict['two-spaces-between-lines-with-content'].options[0] as BooleanOption).setValue(false);
+          }).open();
+        } else if (value && sentencePerLineEnableOption.getValue()) {
+          new ConfirmRuleDisableModal(app, 'rules.sentence-per-line.name', 'rules.two-spaces-between-lines-with-content.name', () => {
+            sentencePerLineEnableOption.setValue(false);
           },
           () => {
             (rulesDict['two-spaces-between-lines-with-content'].options[0] as BooleanOption).setValue(false);

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -1253,7 +1253,7 @@ export function updateHeaderText(text: string, func:(text: string) => string): s
 // placeholder, a lone inline atom such as an autolink, an HTML comment, or an
 // inline HTML tag) is a structural divider: emitted verbatim, never merged with
 // an adjacent prose line, and the newline on each side of it is never collapsed.
-const singleAtomLineRegex = /^(?:\{[A-Z_]+[a-z0-9]+\}|#tag-placeholder[a-z0-9]+|<!--[\s\S]*?-->|<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>)$/;
+const singleAtomLineRegex = /^(?:\{[A-Z_]+[a-z0-9]+\}|#tag-placeholder[a-z0-9]+|<!--[\s\S]*?-->|<(?:\{[A-Z_]+[a-z0-9]+\}|[A-Za-z][A-Za-z0-9+.-]*:[^<>\s]*|[^<>\s@]+@[^<>\s]+)>|<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>)$/;
 
 /**
  * Detects whether a single source line ends in an author hard-break indicator,

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -16,6 +16,7 @@ import {gfmTaskListItemFromMarkdown} from 'mdast-util-gfm-task-list-item';
 import QuickLRU from 'quick-lru';
 import {countInstances} from './strings';
 import {getTextInLanguage} from '../lang/helpers';
+import {splitIntoSentences} from './sentence-splitting';
 
 const LRU = new QuickLRU({maxSize: 200});
 
@@ -1243,6 +1244,146 @@ export function updateHeaderText(text: string, func:(text: string) => string): s
 
   for (const headerUpdate of updateLocations) {
     text = replaceTextBetweenStartAndEndWithNewValue(text, headerUpdate.startIndex, headerUpdate.endIndex, headerUpdate.newText);
+  }
+
+  return text;
+}
+
+// A line whose trimmed content is exactly one opaque atom (a masked block
+// placeholder, a lone inline atom such as an autolink, an HTML comment, or an
+// inline HTML tag) is a structural divider: emitted verbatim, never merged with
+// an adjacent prose line, and the newline on each side of it is never collapsed.
+const singleAtomLineRegex = /^(?:\{[A-Z_]+[a-z0-9]+\}|#tag-placeholder[a-z0-9]+|<!--[\s\S]*?-->|<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>)$/;
+
+/**
+ * Detects whether a single source line ends in an author hard-break indicator,
+ * replicating the exact conditions and precedence of `lineEndsInLineBreak` plus
+ * `addOrReplaceLineEnding`'s character counts. Unlike those helpers it is an
+ * all-indicator detector and reports the exact raw indicator string so it can
+ * be stripped and re-emitted byte-for-byte (CommonMark hard breaks are
+ * spaces-only, so a trailing tab run is not an indicator).
+ * @param {string} line The source line to inspect (without its trailing newline)
+ * @return {{indicator: LineBreakIndicators, raw: string} | null} The detected
+ * indicator and its exact raw text, or null when the line has no hard break.
+ */
+export function detectTrailingLineBreakIndicator(line: string): {indicator: LineBreakIndicators, raw: string} | null {
+  if (line.endsWith('<br/>')) {
+    return {indicator: LineBreakIndicators.LineBreakHtml, raw: '<br/>'};
+  }
+
+  if (line.endsWith('<br>')) {
+    return {indicator: LineBreakIndicators.LineBreakHtmlNotXml, raw: '<br>'};
+  }
+
+  if (!line.endsWith('\\\\') && line.endsWith('\\')) {
+    return {indicator: LineBreakIndicators.Backslash, raw: '\\'};
+  }
+
+  let k = line.length;
+  while (k > 0 && line[k - 1] === ' ') {
+    k--;
+  }
+  if (line.length - k >= 2) {
+    return {indicator: LineBreakIndicators.TwoSpaces, raw: line.slice(k)};
+  }
+
+  return null;
+}
+
+function buildLogicalString(lines: string[]): string {
+  const lastIndex = lines.length - 1;
+  const stripped = lines.map((line, index) => {
+    let s = line;
+    if (index > 0) {
+      s = s.replace(/^[ \t]+/, '');
+    }
+    if (index < lastIndex) {
+      s = s.replace(/[ \t]+$/, '');
+    }
+    return s;
+  });
+  return stripped.join(' ');
+}
+
+function reflowProseRun(lines: string[], terminators: string, abbreviations: string[]): string {
+  type Segment = {lines: string[], indicator: string};
+  const segments: Segment[] = [];
+  let current: string[] = [];
+  for (const line of lines) {
+    const breakInfo = detectTrailingLineBreakIndicator(line);
+    if (breakInfo) {
+      current.push(line.slice(0, line.length - breakInfo.raw.length));
+      segments.push({lines: current, indicator: breakInfo.raw});
+      current = [];
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0 || segments.length === 0) {
+    segments.push({lines: current, indicator: ''});
+  }
+
+  return segments
+      .map((segment) => {
+        const logical = buildLogicalString(segment.lines);
+        const sentences = splitIntoSentences(logical, terminators, abbreviations);
+        return sentences.join('\n') + segment.indicator;
+      })
+      .join('\n');
+}
+
+function reflowParagraph(raw: string, terminators: string, abbreviations: string[]): string {
+  const lines = raw.split('\n');
+  const groups: string[] = [];
+  let proseRun: string[] = [];
+
+  const flushProseRun = () => {
+    if (proseRun.length > 0) {
+      groups.push(reflowProseRun(proseRun, terminators, abbreviations));
+      proseRun = [];
+    }
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '' || singleAtomLineRegex.test(trimmed)) {
+      flushProseRun();
+      groups.push(line);
+    } else {
+      proseRun.push(line);
+    }
+  }
+  flushProseRun();
+
+  return groups.join('\n');
+}
+
+/**
+ * Reflows every root-level paragraph so that each sentence is on its own source
+ * line. Only the raw `[start, end)` span of each root-child `paragraph` node is
+ * rewritten (in reverse document order so earlier offsets stay valid), so
+ * blank lines, the trailing newline, and every non-paragraph construct (code,
+ * math, HTML blocks, headings, lists, blockquotes, footnote definitions, yaml)
+ * are left untouched by construction. Structural dividers inside a merged
+ * paragraph are preserved verbatim with their adjacent newlines intact.
+ * @param {string} text The placeholder-masked markdown text.
+ * @param {string} terminators The user-configured sentence terminators.
+ * @param {string[]} abbreviations The abbreviation suppression list.
+ * @return {string} The text with root-level paragraphs reflowed.
+ */
+export function reflowParagraphsOneSentencePerLine(text: string, terminators: string, abbreviations: string[]): string {
+  const ast = parseTextToAST(text);
+  const positions: Position[] = ast.children
+      .filter((node) => node.type === (MDAstTypes.Paragraph as string) && node.position != null)
+      .map((node) => node.position as Position)
+      .sort((a, b) => b.start.offset - a.start.offset);
+
+  for (const position of positions) {
+    const raw = text.substring(position.start.offset, position.end.offset);
+    const reflowed = reflowParagraph(raw, terminators, abbreviations);
+    if (reflowed !== raw) {
+      text = replaceTextBetweenStartAndEndWithNewValue(text, position.start.offset, position.end.offset, reflowed);
+    }
   }
 
   return text;

--- a/src/utils/sentence-splitting.ts
+++ b/src/utils/sentence-splitting.ts
@@ -19,8 +19,10 @@ export const DEFAULT_ABBREVIATIONS: string[] = [
   'Inc.', 'Ltd.', 'Co.', 'U.S.', 'a.m.', 'p.m.',
 ];
 
-// Priority order: placeholder, HTML comment, inline HTML tag.
-const ATOM_RE = /\{[A-Z_]+[a-z0-9]+\}|#tag-placeholder[a-z0-9]+|---\n---|<!--[\s\S]*?-->|<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>/g;
+// Priority order: placeholder, HTML comment, CommonMark autolink (incl. an
+// angle-wrapped URL placeholder, since `url` masking leaves the `<>` behind),
+// inline HTML tag.
+const ATOM_RE = /\{[A-Z_]+[a-z0-9]+\}|#tag-placeholder[a-z0-9]+|---\n---|<!--[\s\S]*?-->|<(?:\{[A-Z_]+[a-z0-9]+\}|[A-Za-z][A-Za-z0-9+.-]*:[^<>\s]*|[^<>\s@]+@[^<>\s]+)>|<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>/g;
 
 const CLOSING_CHARS = '"\'”’)]}»›';
 const OPENING_CHARS = '"\'“‘([{«‹';
@@ -63,6 +65,12 @@ function sanitizeTerminators(terminators: string): Set<string> {
     const cp = ch.codePointAt(0) ?? 0;
     // drop control characters and ASCII whitespace
     if (cp < 0x20 || cp === 0x7f || ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      continue;
+    }
+    // the scan compares single UTF-16 code units, so an astral terminator
+    // (e.g. an emoji) could never match; ignore it rather than accept it and
+    // silently never split on it
+    if (ch.length > 1) {
       continue;
     }
     set.add(ch);

--- a/src/utils/sentence-splitting.ts
+++ b/src/utils/sentence-splitting.ts
@@ -1,0 +1,312 @@
+// A standalone, mdast-free, dependency-free, deterministic, O(n) sentence
+// splitter. It operates on placeholder-masked logical text and must never look
+// inside an atom (a placeholder, an HTML comment, or an inline HTML tag). See
+// the "Sentence per line" rule docs for the heuristic's accepted limitations.
+
+export const DEFAULT_SENTENCE_TERMINATORS = '.?!…。！？';
+
+// The CJK / full-width sentence-final marks plus the ellipsis glyph. These are
+// never intra-word or decimal, so they split without requiring trailing
+// whitespace. Exported for documentation/testing; the runtime class test is
+// purely "code point > 0x7F" (every non-ASCII terminator is unambiguous).
+export const UNAMBIGUOUS_TERMINATORS = '。！？．！？…';
+
+// Precision-first: entries that would suppress common real sentence ends
+// (No., St., Fig., pp.) are intentionally omitted; users can add their own.
+export const DEFAULT_ABBREVIATIONS: string[] = [
+  'e.g.', 'i.e.', 'etc.', 'vs.', 'cf.', 'al.',
+  'Mr.', 'Mrs.', 'Ms.', 'Dr.', 'Prof.', 'Sr.', 'Jr.',
+  'Inc.', 'Ltd.', 'Co.', 'U.S.', 'a.m.', 'p.m.',
+];
+
+// Priority order: placeholder, HTML comment, inline HTML tag.
+const ATOM_RE = /\{[A-Z_]+[a-z0-9]+\}|#tag-placeholder[a-z0-9]+|---\n---|<!--[\s\S]*?-->|<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?>/g;
+
+const CLOSING_CHARS = '"\'”’)]}»›';
+const OPENING_CHARS = '"\'“‘([{«‹';
+const BRACKET_LABEL_RE = /^\[[^\]\n]*\]/;
+
+const UPPER_OR_OTHER_LETTER = /\p{Lu}|\p{Lo}/u;
+const ANY_LETTER = /\p{L}/u;
+
+type AtomRanges = {
+  // start offset -> end offset (exclusive) for fast skip
+  startToEnd: Map<number, number>,
+  // set of exclusive end offsets (a position immediately after an atom)
+  ends: Set<number>,
+};
+
+function tokenizeAtoms(text: string): AtomRanges {
+  const startToEnd = new Map<number, number>();
+  const ends = new Set<number>();
+  ATOM_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ATOM_RE.exec(text)) !== null) {
+    const start = m.index;
+    const end = start + m[0].length;
+    startToEnd.set(start, end);
+    ends.add(end);
+    if (m[0].length === 0) {
+      ATOM_RE.lastIndex++;
+    }
+  }
+  return {startToEnd, ends};
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || /\s/.test(ch);
+}
+
+function sanitizeTerminators(terminators: string): Set<string> {
+  const set = new Set<string>();
+  for (const ch of terminators) {
+    const cp = ch.codePointAt(0) ?? 0;
+    // drop control characters and ASCII whitespace
+    if (cp < 0x20 || cp === 0x7f || ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      continue;
+    }
+    set.add(ch);
+  }
+  return set;
+}
+
+function normalizeAbbreviations(abbreviations: string[]): {list: string[], maxLen: number} {
+  const list: string[] = [];
+  let maxLen = 0;
+  for (const raw of abbreviations) {
+    const a = raw.trim().toLowerCase();
+    if (a === '') {
+      continue;
+    }
+    list.push(a);
+    if (a.length > maxLen) {
+      maxLen = a.length;
+    }
+  }
+  // longest first so the longest match wins
+  list.sort((x, y) => y.length - x.length);
+  return {list, maxLen};
+}
+
+/**
+ * Splits a single logical string (one hard-break segment, soft wraps already
+ * collapsed to single spaces) into sentences. Pure, deterministic, O(n) and
+ * opaque to atoms. Joining the result with '\n' is the exact inverse of the
+ * split for any text this splitter produced (structural idempotency).
+ * @param {string} text The logical string to split.
+ * @param {string} terminators The user-configured sentence terminators.
+ * @param {string[]} abbreviations The abbreviation suppression list.
+ * @return {string[]} The sentences; one element means "no boundary found".
+ */
+export function splitIntoSentences(text: string, terminators: string, abbreviations: string[]): string[] {
+  const termSet = sanitizeTerminators(terminators);
+  if (termSet.size === 0 || text === '') {
+    return [text];
+  }
+
+  const {startToEnd: atomStart, ends: atomEnds} = tokenizeAtoms(text);
+  const {list: abbrevs, maxLen: maxAbbrevLen} = normalizeAbbreviations(abbreviations);
+  const S = text;
+  const n = S.length;
+
+  const isUnambiguous = (ch: string): boolean => (ch.codePointAt(0) ?? 0) > 0x7f;
+
+  const boundaryBefore = (pos: number): boolean => {
+    if (pos <= 0) {
+      return true;
+    }
+    if (atomEnds.has(pos)) {
+      return true;
+    }
+    const prev = S[pos - 1];
+    return isWhitespace(prev) || OPENING_CHARS.includes(prev);
+  };
+
+  const nextNonWs = (start: number): number => {
+    let j = start;
+    while (j < n && !atomStart.has(j) && isWhitespace(S[j])) {
+      j++;
+    }
+    return j;
+  };
+
+  const consumeClosers = (start: number): number => {
+    let j = start;
+    while (j < n) {
+      if (atomStart.has(j)) {
+        break;
+      }
+      const c = S[j];
+      if (CLOSING_CHARS.includes(c) || termSet.has(c) || c === '…') {
+        j++;
+        continue;
+      }
+      const label = BRACKET_LABEL_RE.exec(S.slice(j));
+      if (label) {
+        j += label[0].length;
+        continue;
+      }
+      break;
+    }
+    return j;
+  };
+
+  const startsNewSentence = (pos: number): boolean => {
+    if (pos >= n) {
+      return false;
+    }
+    if (atomStart.has(pos)) {
+      return true;
+    }
+    let q = pos;
+    if (OPENING_CHARS.includes(S[q])) {
+      q++;
+    }
+    if (q >= n || atomStart.has(q)) {
+      return atomStart.has(q);
+    }
+    const cp = S.codePointAt(q);
+    if (cp === undefined) {
+      return false;
+    }
+    return UPPER_OR_OTHER_LETTER.test(String.fromCodePoint(cp));
+  };
+
+  const nextIsInitialOrLetterStart = (pos: number): boolean => {
+    if (pos >= n) {
+      return false;
+    }
+    if (atomStart.has(pos)) {
+      return true;
+    }
+    let q = pos;
+    if (OPENING_CHARS.includes(S[q])) {
+      q++;
+    }
+    if (q >= n) {
+      return false;
+    }
+    if (atomStart.has(q)) {
+      return true;
+    }
+    const cp = S.codePointAt(q);
+    if (cp === undefined) {
+      return false;
+    }
+    const ch = String.fromCodePoint(cp);
+    if (UPPER_OR_OTHER_LETTER.test(ch)) {
+      return true;
+    }
+    // another single-letter initial: a lone letter immediately followed by a
+    // terminator (e.g. the "m" in "a.m.", the "g" in "e.g.")
+    return ANY_LETTER.test(ch) && q + 1 < n && termSet.has(S[q + 1]);
+  };
+
+  const abbreviationSuppressed = (termIdx: number): boolean => {
+    if (abbrevs.length === 0) {
+      return false;
+    }
+    let lbStart = Math.max(0, termIdx - maxAbbrevLen);
+    // never look back across an atom boundary
+    for (let k = termIdx; k > lbStart; k--) {
+      if (atomEnds.has(k)) {
+        lbStart = k;
+        break;
+      }
+    }
+    const suffix = S.slice(lbStart, termIdx + 1).toLowerCase();
+    for (const abbr of abbrevs) {
+      if (suffix.endsWith(abbr)) {
+        const matchStart = termIdx + 1 - abbr.length;
+        if (boundaryBefore(matchStart)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  const initialSuppressed = (termIdx: number, closerEnd: number): boolean => {
+    const p = termIdx - 1;
+    if (p < 0 || !ANY_LETTER.test(S[p])) {
+      return false;
+    }
+    if (!boundaryBefore(p)) {
+      return false;
+    }
+    const ns = nextNonWs(closerEnd);
+    return nextIsInitialOrLetterStart(ns);
+  };
+
+  const numberSuppressed = (termIdx: number): boolean => {
+    const prev = S[termIdx - 1];
+    const next = S[termIdx + 1];
+    return prev !== undefined && next !== undefined && /\d/.test(prev) && /\d/.test(next);
+  };
+
+  const sentences: string[] = [];
+  let sentenceStart = 0;
+  let i = 0;
+  while (i < n) {
+    const atomEnd = atomStart.get(i);
+    if (atomEnd !== undefined) {
+      i = atomEnd;
+      continue;
+    }
+    const ch = S[i];
+    if (!termSet.has(ch)) {
+      i++;
+      continue;
+    }
+
+    const cEnd = consumeClosers(i + 1);
+
+    if (
+      abbreviationSuppressed(i) ||
+      initialSuppressed(i, cEnd) ||
+      numberSuppressed(i)
+    ) {
+      i++;
+      continue;
+    }
+
+    const atEnd = cEnd >= n;
+    if (!isUnambiguous(ch) && !atEnd && !isWhitespace(S[cEnd])) {
+      // ambiguous class requires whitespace or end-of-segment after closers
+      i++;
+      continue;
+    }
+
+    if (atEnd) {
+      sentences.push(S.slice(sentenceStart, cEnd));
+      sentenceStart = cEnd;
+      i = cEnd;
+      continue;
+    }
+
+    const ns = nextNonWs(cEnd);
+    if (ns >= n) {
+      sentences.push(S.slice(sentenceStart, cEnd));
+      sentenceStart = n;
+      i = n;
+      break;
+    }
+
+    if (startsNewSentence(ns)) {
+      sentences.push(S.slice(sentenceStart, cEnd));
+      sentenceStart = ns;
+      i = ns;
+      continue;
+    }
+
+    i++;
+  }
+
+  if (sentenceStart < n) {
+    sentences.push(S.slice(sentenceStart));
+  }
+  if (sentences.length === 0) {
+    return [S];
+  }
+  return sentences;
+}


### PR DESCRIPTION
## Why

When Markdown is tracked in git (or any line-based VCS), keeping each sentence on its own source line makes diffs *localized*: editing one sentence produces a one-line patch instead of re-flowing an entire paragraph. This "semantic line breaks" / "ventilated prose" convention is requested in **#1359** ("FR: Put each sentence on its own line"). The single comment on that issue asks for the sentence-terminating characters to be configurable — this PR exposes that (plus an abbreviation list) as options.

**Rendering caveat (the first thing a reviewer/user will rightly ask).** Under standard Markdown a single newline is a space, so rendered output is unchanged — but **Obsidian's "Strict line breaks" setting is off by default**, and with it off Obsidian renders a single newline as a visible line break. So for default-configured Obsidian users this rule *does* change reading-view rendering. This is stated plainly in the rule description, the settings docs, and the rule's additional-info page rather than buried — it's the key "is this safe for me" decision.

`Fixes #1359`

## What it does

Reflows **only root-level paragraphs** so each sentence is on its own line. Headings, lists, blockquotes, tables, fenced/indented code, math blocks, HTML blocks, footnote definitions, and YAML are left untouched (by AST construction, not string-sniffing). Reflowing prose nested in lists/blockquotes is intentionally out of scope for v1.

Sentence detection is a deterministic, dependency-free, O(n) scanner with a token layer so masked placeholders, inline HTML, and autolinks are fully opaque (never split inside, valid sentence starts). It is precision-first: configurable terminators (ASCII `.?!` require trailing whitespace; CJK/full-width `。！？` and `…` do not), an abbreviation list (`e.g.`, `U.S.`, `a.m.`, …), and suppression of single-letter initials, decimals/versions, and ellipses. Deliberate, documented heuristic limitations (lowercase/digit sentence starts, lone-capital endings, half-width `.`+CJK, mid-line `<br>`) are listed in the rule docs.

Safety properties:
- **Masking-aware**: operates on the framework's placeholder-masked text; terminator membership is never tested on atom characters, so a user terminator like `_`/`}`/`.` can't corrupt a placeholder on restoration.
- **Idempotent** by construction (join is the exact inverse of split); covered by tests that apply the rule twice.
- **Structural dividers**: a masked block (table, `%%comment%%`, custom-ignore, lone link/autolink) adjacent to prose with no blank line is preserved verbatim with its adjacency intact (it is *not* this rule's job to add blank lines — that's `paragraph-blank-lines`).
- **Hard breaks** (`  `, `<br>`, `<br/>`, `\`) are preserved and never merged across.
- **Conflict handling** mirrors the existing `paragraph-blank-lines` ↔ `two-spaces-between-lines-with-content` precedent *symmetrically*: a confirm-modal on either UI toggle, plus a settings-load guard in `main.ts` for the `data.json`/sync path.

## Files

New: `src/utils/sentence-splitting.ts`, `src/rules/sentence-per-line.ts`, two test suites, `docs/additional-info/rules/sentence-per-line.md`. Touched: `src/utils/mdast.ts` (two helpers), `src/main.ts` (conflict block), `src/rules/two-spaces-between-lines-with-content.ts` (symmetric wiring), `src/lang/locale/en.ts`, generated `content-rules.md`, README rule list.

## Notes for the reviewer

- Followed `docs/contributing/adding-a-rule.md`: FR exists (#1359), rule copied from the template, options/examples/locale wired the standard way.
- The abbreviation option uses the `format-yaml-array` precedent (`optionsKey` ≠ config key) so a `TextAreaOptionBuilder` default/override doesn't hit the `.split` path.
- `npm run docs` regenerated README + `content-rules.md`; I scoped this PR to only the new rule and intentionally **did not** sweep in unrelated pre-existing doc-regeneration drift (`heading-rules.md` and some README anchors) from an earlier source-only change — happy to send that separately if you'd prefer.
- One known cosmetic: the generator renders a non-empty `TextArea` default (the abbreviation list) with raw newlines in the options-table cell. This rule is the first with a non-empty `TextArea` default, so there's no prior art for how you'd like it formatted — glad to adjust the generator or the default presentation per your preference.

## Test plan

- [ ] `npm run test` — full suite green (this branch: 1274 passing, incl. 65 new cases)
- [ ] `npm run lint` — clean
- [ ] `npm run build` — clean
- [ ] Manual in a vault: rendering unchanged with "Strict line breaks" on; re-running is a no-op; a table/code/`%%comment%%`/custom-ignore block adjacent to prose is not corrupted; the conflict modal fires for both toggle directions; enabling both rules via `data.json` disables `two-spaces…` on next load with a notice.

🤖 This change was developed with AI assistance (noted via `Co-Authored-By` trailers on the commits); a human reviewed and is submitting it. Happy to walk through any part of the design.