### PR TITLE
Fix Capitalize Headings incorrectly capitalizing words following a word starting with an ignored character.

### DIFF
--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -224,5 +224,17 @@ ruleTest({
         style: 'First letter',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1544
+      testName: 'Make sure that words in parentheses are correctly capitalized',
+      before: dedent`
+        # Long Way (Known good)
+      `,
+      after: dedent`
+        # Long Way (Known Good)
+      `,
+      options: {
+        style: 'Title Case',
+      },
+    },
   ],
 });

--- a/__tests__/capitalize-headings.test.ts
+++ b/__tests__/capitalize-headings.test.ts
@@ -225,12 +225,16 @@ ruleTest({
       },
     },
     { // accounts for https://github.com/platers/obsidian-linter/issues/1544
-      testName: 'Make sure that words in parentheses are correctly capitalized',
+      testName: 'Make sure words following a word with a starting character from startingWordIgnoreCharacters are not incorrectly capitalized on the second character',
       before: dedent`
         # Long Way (Known good)
+        # 'twas the night before christmas
+        # (Here's a heading with nested "ignored characters")
       `,
       after: dedent`
         # Long Way (Known Good)
+        # 'Twas the Night before Christmas
+        # (Here's a Heading with Nested "Ignored Characters")
       `,
       options: {
         style: 'Title Case',

--- a/src/rules/capitalize-headings.ts
+++ b/src/rules/capitalize-headings.ts
@@ -346,7 +346,6 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
       const wordRegex = new RegExp(`^${startingCustomRegexGroup}[\\p{L}’'-]{1,}${endingCustomRegexGroup}$`, 'u');
       const keepCasing = options.ignoreWords;
       const ignoreShortWords = options.lowercaseWords;
-      let indexToCapitalize = 0;
       let firstWord = true;
       for (let j = 1; j < headerWords.length; j++) {
         // based on https://stackoverflow.com/a/62032796 "/\p{L}/u" accounts for all unicode letters across languages
@@ -355,8 +354,9 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
           continue;
         }
 
+        let indexToCapitalize = 0;
         if (options.startingWordIgnoreCharacters?.includes(headerWords[j][0])) {
-          indexToCapitalize =1;
+          indexToCapitalize = 1;
         }
 
         const ignoreCasedWord = options.ignoreCasedWords && headerWords[j] !== headerWords[j].toLowerCase();
@@ -366,9 +366,9 @@ export default class CapitalizeHeadings extends RuleBuilder<CapitalizeHeadingsOp
           const ignoreWord = ignoreShortWords.includes(headerWords[j]);
           if ((!ignoreWord && !capitalizeJustFirstLetter) || firstWord === true) {
             if (indexToCapitalize === 0) {
-              headerWords[j] = headerWords[j][indexToCapitalize].toUpperCase() + headerWords[j].slice(indexToCapitalize+1);
+              headerWords[j] = headerWords[j][indexToCapitalize].toUpperCase() + headerWords[j].slice(indexToCapitalize + 1);
             } else {
-              headerWords[j] = headerWords[j][0] + headerWords[j][indexToCapitalize].toUpperCase() + headerWords[j].slice(indexToCapitalize+1);
+              headerWords[j] = headerWords[j][0] + headerWords[j][indexToCapitalize].toUpperCase() + headerWords[j].slice(indexToCapitalize + 1);
             }
           }
         }


### PR DESCRIPTION
Fixes #1544

When Capitalize headings encountered a word that starts with an ignored character (`'"(‘“-`), all subsequent words would invariably have their second character capitalized, regardless of whether they start with an ignored character as well.

The cause of this was the index to capitalize persisting across words. Ideally, it should be reset to 0 before checking for ignored characters again on the next word.

**Changes Made:**
- Reset the index to capitalize on a word-by-word basis
- Added test cases for the issue