### PR TITLE
fix: preserve dollar signs in YAML values when sorting keys

### DIFF
--- a/__tests__/yaml-key-sort.test.ts
+++ b/__tests__/yaml-key-sort.test.ts
@@ -359,5 +359,23 @@ ruleTest({
         yamlSortOrderForOtherKeys: 'Ascending Alphabetical',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1532
+      testName: 'Dollar signs in YAML values are preserved when sorting keys',
+      before: dedent`
+        ---
+        zeta: last
+        alpha: $$$$
+        ---
+      `,
+      after: dedent`
+        ---
+        alpha: $$$$
+        zeta: last
+        ---
+      `,
+      options: {
+        yamlSortOrderForOtherKeys: 'Ascending Alphabetical',
+      },
+    },
   ],
 });

--- a/src/rules/yaml-key-sort.ts
+++ b/src/rules/yaml-key-sort.ts
@@ -2,6 +2,7 @@ import {Options, RuleType} from '../rules';
 import RuleBuilder, {BooleanOptionBuilder, DropdownOptionBuilder, ExampleBuilder, OptionBuilderBase, TextAreaOptionBuilder} from './rule-builder';
 import dedent from 'ts-dedent';
 import {parseYAML, getYAMLText, loadYAML, setYamlSection, astToString, getEmptyDocument} from '../utils/yaml';
+import {escapeDollarSigns} from '../utils/regex';
 import {Document} from 'yaml';
 import {YamlCSTTokens, YamlNode} from '../typings/yaml';
 import {FlowCollection} from 'yaml/dist/parse/cst';
@@ -130,7 +131,10 @@ export default class YamlKeySort extends RuleBuilder<YamlKeySortOptions> {
       newYaml = this.updateDateModifiedIfYamlChanged(oldYaml, newYaml, dateModifiedKey, currentTimeFormatted);
     }
 
-    return text.replace(oldYaml, newYaml);
+    // `newYaml` is used as the replacement string, so any `$` in a YAML value
+    // (e.g. `$$$$`) would be interpreted as a replacement pattern and collapsed.
+    // Escape it the same way formatYAML() already does. See #1532.
+    return text.replace(oldYaml, escapeDollarSigns(newYaml));
   }
   sortAlphabeticallyAsc(previousKey: string, currentKey: string): number {
     previousKey = previousKey.toLowerCase();


### PR DESCRIPTION
## What

Fixes #1532 — the YAML Key Sort rule silently halves runs of `$` in property values on every lint (`$$$$` → `$$` → `$`), losing data.

## Root cause

Not the `setYamlSection` regex suspected in the issue thread — that path uses a *function* replacement, which is `$`-safe. The actual culprit is in `YamlKeySort.getTextWithNewYamlFrontmatter`:

```ts
return text.replace(oldYaml, newYaml);
```

Here `newYaml` is used as a **replacement string**, so `String.prototype.replace` interprets `$$` as an escaped `$` — collapsing every `$$` to `$`. That's the halving.

## Fix

The codebase already solved this exact problem: `formatYAML()` in `src/utils/yaml.ts` wraps its replacement in `escapeDollarSigns()`. This applies the same existing helper in `yaml-key-sort.ts`:

```ts
return text.replace(oldYaml, escapeDollarSigns(newYaml));
```

One import + one call — no new utility, matching the established pattern.

## Test

Added a regression case to `__tests__/yaml-key-sort.test.ts`: a value `$$$$` must survive a key sort. Verified it **fails on the current code** (`$$$$` → `$$`) and **passes with the fix**.

## Verification

- New test fails before the change, passes after.
- Full suite green: **59 suites / 1196 tests**.
- eslint clean on both changed files.

## Note (not fixed here, to keep scope tight)

`src/rules/yaml-title-alias.ts:121` has the same `text.replace(oldYaml, newYamlValue)` pattern and would corrupt `$`-runs in aliases the same way. I left it out of this PR to keep the fix focused on #1532 — happy to send a follow-up (or fold it in here if you'd prefer).
