### PR TITLE
fix(trailing-spaces): stop inserting a literal "$1" on whitespace-only lines

### DIFF
--- a/__tests__/trailing-spaces.test.ts
+++ b/__tests__/trailing-spaces.test.ts
@@ -192,5 +192,45 @@ ruleTest({
         ${''}
       `,
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1542
+      testName: 'Whitespace only lines are emptied instead of being replaced with a literal "$1" when two space line break is enabled',
+      before: dedent`
+        Some text
+        ${' '}
+        More text
+        ${'   '}
+        Even more text
+        ${'\t'}
+        The end
+      `,
+      after: dedent`
+        Some text
+        ${''}
+        More text
+        ${''}
+        Even more text
+        ${''}
+        The end
+      `,
+      options: {
+        twoSpaceLineBreak: true,
+      },
+    },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1542
+      testName: 'A whitespace only line of exactly two spaces is still preserved when two space line break is enabled',
+      before: dedent`
+        Some text
+        ${'  '}
+        More text
+      `,
+      after: dedent`
+        Some text
+        ${'  '}
+        More text
+      `,
+      options: {
+        twoSpaceLineBreak: true,
+      },
+    },
   ],
 });

--- a/src/rules/trailing-spaces.ts
+++ b/src/rules/trailing-spaces.ts
@@ -49,8 +49,8 @@ export default class TrailingSpaces extends RuleBuilder<TrailingSpacesOptions> {
     if (!options.twoSpaceLineBreak) {
       text = text.replace(/^[ \t]+$/gm, '');
     } else {
-      text = text.replace(/^[ \t]$/gm, '$1'); // one whitespace
-      text = text.replace(/^[ \t]{3,}$/gm, '$1'); // three or more whitespaces
+      text = text.replace(/^[ \t]$/gm, ''); // one whitespace
+      text = text.replace(/^[ \t]{3,}$/gm, ''); // three or more whitespaces
       text = text.replace(/^( ?\t\t? ?)$/gm, '$1'); // two whitespaces with at least one tab
     }
 


### PR DESCRIPTION
## Summary

Fixes #1542. With `twoSpaceLineBreak` enabled, `TrailingSpaces` used `text.replace(/^[ \t]$/gm, '$1')` and `text.replace(/^[ \t]{3,}$/gm, '$1')` to clear whitespace-only lines of 1 or 3+ characters. Neither regex has a capture group, so `'$1'` is treated as a literal replacement string rather than a backreference — a whitespace-only line gets replaced with the literal text `$1` instead of being emptied.

Changed the replacement string from `'$1'` to `''` in those two calls only. Left the third call on the next line (`text.replace(/^( ?\t\t? ?)$/gm, '$1')`, which handles exactly-two-whitespace lines) untouched — it has a real capture group and is working as intended, out of scope for this issue.

## Test plan

- Reproduced the bug before fixing: `"text\n \nmore text\n    \nend"` → `"text\n$1\nmore text\n$1\nend"` on current `master`
- Added two regression tests to `__tests__/trailing-spaces.test.ts` covering 1-space and 3+ space whitespace-only lines with `twoSpaceLineBreak` enabled, plus confirmed the existing "two spaces preserved" case still passes
- Confirmed the new tests fail without the fix (stashed the source change and reran) and pass with it
- `npx jest __tests__/trailing-spaces.test.ts` — 15/15 pass
- Full suite (`npm test`), `npm run build`, `npm run docs`, and `eslint . --ext .ts` all clean; `npm run docs` regenerates with zero diff