### PR TITLE
fix(regex): purely-numeric #tags no longer match, per Obsidian's tag spec

### DIFF
--- a/__tests__/move-tags-to-yaml.test.ts
+++ b/__tests__/move-tags-to-yaml.test.ts
@@ -384,5 +384,23 @@ ruleTest({
         howToHandleExistingTags: 'Remove whole tag',
       },
     },
+    { // accounts for https://github.com/platers/obsidian-linter/issues/1535
+      testName: 'Purely numeric hashes are not treated as tags since Obsidian requires at least one non-numerical character',
+      before: dedent`
+        Numeric only: #123
+        Year like: #1984
+        Valid tag with digits: #y1984
+        Valid tag ending in digits: #1984book
+      `,
+      after: dedent`
+        ---
+        tags: [y1984, 1984book]
+        ---
+        Numeric only: #123
+        Year like: #1984
+        Valid tag with digits: #y1984
+        Valid tag ending in digits: #1984book
+      `,
+    },
   ],
 });

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -14,7 +14,8 @@ export const wikiLinkRegex = /(!?)\[{2}([^\][\n|]+)(\|([^\][\n|]+))?(\|([^\][\n|
 // based on https://davidwells.io/snippets/regex-match-markdown-links
 export const genericLinkRegex = /(!?)\[([^[]*)\](\(.*\))/g;
 // based on https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format
-export const tagWithLeadingWhitespaceRegex = /(\s|^)(#[\p{L}\-_\d/\p{Emoji_Presentation}]+)/gu;
+// the lookahead enforces "tags must contain at least one non-numerical character", so `#1984` is not a tag while `#y1984` is
+export const tagWithLeadingWhitespaceRegex = /(\s|^)(#(?=\d*[\p{L}\-_/\p{Emoji_Presentation}])[\p{L}\-_\d/\p{Emoji_Presentation}]+)/gu;
 export const obsidianMultilineCommentRegex = /^%%\n[^%]*\n%%/gm;
 export const wordSplitterRegex = /[,\s]+/;
 export const whitespaceSplitterRegex = /\S+/g;


### PR DESCRIPTION
## Summary

Fixes #1535. `tagWithLeadingWhitespaceRegex` in `src/utils/regex.ts` matched any `#` followed by one or more characters from `[\p{L}\-_\d/\p{Emoji_Presentation}]` — including tags made up entirely of digits, like `#123`. Per [Obsidian's tag spec](https://help.obsidian.md/Editing+and+formatting/Tags#Tag+format): "Tags must contain at least one non-numerical character. For example, `#1984` isn't a valid tag, but `#y1984` is." So `move-tags-to-yaml` (and, since this regex is shared, `matchTagRegex` and the `tag` `IgnoreTypes` filter in `ignore-types.ts`) were treating purely-numeric hashes as real tags when Obsidian itself doesn't.

Added a lookahead requiring at least one non-digit character in the tag body: `#(?=\d*[\p{L}\-_/\p{Emoji_Presentation}])[\p{L}\-_\d/\p{Emoji_Presentation}]+`. This only changes purely-numeric matches — anything with a letter, emoji, `-`, `_`, or `/` anywhere in it (e.g. `#y1984`, `#1984book`, `#inbox/to-read`) still matches exactly as before.

## Test plan

Validated the new regex against an 18-case table before committing: `#123`, `#1984`, `#0` correctly rejected; `#y1984`, `#1984book`, `#a1`, `#1_2`, `#camelCase`, `#kebab-case`, `#snake_case`, `#inbox/to-read`, `#🎉` etc. still match; `"#123 #456 #ok"` correctly yields only `#ok`.

- Added a regression test to `__tests__/move-tags-to-yaml.test.ts`; confirmed it fails without the fix and passes with it
- `npx jest __tests__/move-tags-to-yaml.test.ts __tests__/format-tags-in-yaml.test.ts` — 21/21 pass (format-tags-in-yaml needed no changes — it operates on YAML tags, not body `#tags`)
- Full suite (`npm test`), `npm run build`, `npm run docs`, and `eslint . --ext .ts` all clean; `npm run docs` regenerates with zero diff

One caveat I can't fully verify: `#12/34` and `#1-2` still match under this fix, since `/` and `-` are non-numerical characters per the literal wording of the spec — I believe that's correct, but couldn't confirm against Obsidian's actual parser for those specific inputs.