### PR TITLE
fix: ordered list indicators become NaN when terminated with ')'

### DIFF
--- a/__tests__/ordered-list-style.test.ts
+++ b/__tests__/ordered-list-style.test.ts
@@ -1,6 +1,7 @@
 import OrderedListStyle from '../src/rules/ordered-list-style';
 import dedent from 'ts-dedent';
 import {ruleTest} from './common';
+import {OrderListItemStyles} from '../src/utils/mdast';
 
 ruleTest({
   RuleBuilderClass: OrderedListStyle,
@@ -188,6 +189,32 @@ ruleTest({
         - c
           1. d
           2. d
+      `,
+    },
+    {
+      testName: 'Parenthesis-terminated indicators keep their numbers when preserve start is enabled',
+      options: {preserveStart: true},
+      before: dedent`
+        1) Item 1
+        1) Item 2
+        1) Item 3
+      `,
+      after: dedent`
+        1. Item 1
+        2. Item 2
+        3. Item 3
+      `,
+    },
+    {
+      testName: 'Parenthesis-terminated indicators keep their numbers when number style is preserve',
+      options: {numberStyle: OrderListItemStyles.Preserve},
+      before: dedent`
+        3) Item 3
+        4) Item 4
+      `,
+      after: dedent`
+        3. Item 3
+        4. Item 4
       `,
     },
   ],

--- a/src/utils/mdast.ts
+++ b/src/utils/mdast.ts
@@ -787,7 +787,9 @@ export function updateOrderedListItemIndicators(text: string, orderedListStyle: 
 
     let lastItemListIndicatorLevel = -1;
     listText = listText.replace(/^(( |\t|> )*)((\d+(\.|\)))|[-*+])([^\n]*)$/gm, (listItem: string, $1: string = '', _$2: string, $3: string, _$4: string, _$5: string, $6: string) => {
-      let listItemIndicatorNumber = (orderedListStyle === OrderListItemStyles.Preserve || preserveStart) ? Number(_$4) : 1;
+      // _$4 is the indicator with its terminator attached (`1.` or `1)`), so it has to be
+      // parsed rather than coerced: Number('1.') is 1, but Number('1)') is NaN.
+      let listItemIndicatorNumber = (orderedListStyle === OrderListItemStyles.Preserve || preserveStart) ? parseInt(_$4, 10) : 1;
       const listItemIndicatorLevel = getListItemLevel($1);
       // when dealing with a value that is not an int reset all values greater than or equal to the current list level
       if (!/^\d/.test($3)) {


### PR DESCRIPTION
### Bug

`1) a` becomes `NaN. a`.

`updateOrderedListItemIndicators` reads the item number from group 4 of

```
/^(( |\t|> )*)((\d+(\.|\)))|[-*+])([^\n]*)$/gm
```

which is `\d+(\.|\))` — the digits *with* their terminator — and coerces it. `Number('1.')` is `1` (JS accepts a trailing decimal point); `Number('1)')` is `NaN`, which then propagates down the rest of the list through `NaN + 1` under `ascending`.

Reachable via two documented settings: `preserve-start` enabled, or `number-style: preserve`. The loss is silent and unrecoverable — the source numbers no longer exist in the file. In one vault this destroyed 197 indicators across 7 notes before it was traced.

### Fix

`parseInt(_$4, 10)`; parsing stops at the terminator. Regex, group numbering and all other paths unchanged.

### Tests

One case per trigger in `__tests__/ordered-list-style.test.ts`. Both fail on master with `NaN. Item 1`, pass here. Full suite green (1199 tests / 59 suites); eslint clean.
